### PR TITLE
make required arguments and error message fix

### DIFF
--- a/surveySimPP/modules/PPRunUtilities.py
+++ b/surveySimPP/modules/PPRunUtilities.py
@@ -256,7 +256,7 @@ def PPCMDLineParser(parser):
 
 	cmd_args_dict = {}
 	
-	cmd_args_dict['colourinput'] = PPFindFileOrExit(args.l, '-c --colour')
+	cmd_args_dict['colourinput'] = PPFindFileOrExit(args.l, '-l --colour')
 	cmd_args_dict['orbinfile'] = PPFindFileOrExit(args.o, '-o --orbit')
 	cmd_args_dict['oifoutput'] = PPFindFileOrExit(args.p, '-p, --pointing')
 	cmd_args_dict['configfile'] = PPFindFileOrExit(args.c, '-c, --config')

--- a/surveySimPP/surveySimPP.py
+++ b/surveySimPP/surveySimPP.py
@@ -231,12 +231,12 @@ def main():
     """
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-c", "--config", help="Input configuration file name", type=str, dest='c', default='./PPConfig.ini')
+    parser.add_argument("-c", "--config", help="Input configuration file name", type=str, dest='c', default='./PPConfig.ini', required=True)
     parser.add_argument("-d", help="Make intermediate pointing database", dest='d', action='store_true')
     parser.add_argument("-m", "--comet", help="Comet parameter file name", type=str, dest='m')
-    parser.add_argument("-l", "--colour", "--color", help="Colour file name", type=str, dest='l', default='./data/colour')
-    parser.add_argument("-o", "--orbit", help="Orbit file name", type=str, dest='o', default='./data/orbit.des')
-    parser.add_argument("-p", "--pointing", help="Pointing simulation output file name", type=str, dest='p', default='./data/oiftestoutput')
+    parser.add_argument("-l", "--colour", "--color", help="Colour file name", type=str, dest='l', default='./data/colour', required=True)
+    parser.add_argument("-o", "--orbit", help="Orbit file name", type=str, dest='o', default='./data/orbit.des', required=True)
+    parser.add_argument("-p", "--pointing", help="Pointing simulation output file name", type=str, dest='p', default='./data/oiftestoutput', required=True)
 
     runPostProcessing(parser)
 


### PR DESCRIPTION
make command line variables actually needed for running the code required.

fix the color file error message to use -l

Fixes #146 and #120 .

make command line variables actually needed for running the code required.

## Review Checklist for Source Code Changes

- [X] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [X] Does SurveySimPP run successfully on a test set of input files/databases?
