### PR TITLE
Adding configuration files to simulate full survey runs

### DIFF
--- a/survey_setups/README
+++ b/survey_setups/README
@@ -1,0 +1,17 @@
+README file for survey_setups folder
+
+This directory contains configuration files that simulate Solar System surveys.
+
+The user are encouraged to familiarise themselves with the documentation for 
+a deeper understanding of different parameters. 
+
+Currently, the directory contains the following files:
+
+
+Rubin_full_footprint.ini -- The configuration file for the Vera C. Rubin Observatory's
+Legacy Survey of Space and Time (LSST) using the full camera footprint.
+
+Rubin_circular_approximation.ini -- The configuration file for the Vera C. Rubin Observatory's
+Legacy Survey of Space and Time (LSST) using the circular footprint approximation
+where the circular footprint matches 90% of the detector surface area.
+

--- a/survey_setups/Rubin_circular_approximation.ini
+++ b/survey_setups/Rubin_circular_approximation.ini
@@ -1,0 +1,158 @@
+# Configuration file for Solar System Post Processing package.
+
+
+[INPUT]
+
+# Paths of input files (orbits, physical parameters, cometary, ephemeris
+# simulation output) are given at the command line with the following flags:
+# -c or --config                Configuration file name (this file)
+# -m or --comet                 Comet parameter file name (optional)
+# -p or --params                Physical parameters file name
+# -o or --orbit                 Orbit file name
+# -e or --ephem                 Ephemeris simulation output file name (i.e. OIF output)
+ 
+# The simulation used for the ephemeris input.
+# Options: currently only oif (objectsInField)
+ephemerides_type = oif
+
+# Format for ephemeris simulation output file. If reading from an existing temporary ephemeris
+# database, this will be ignored.
+# Options: csv, whitespace, hdf5
+eph_format = csv
+
+# SSPP chunks processing by object: how many objects should be processed at once?
+size_serial_chunk = 5000
+
+# Format for orbit/colour/brightness/cometary data files.
+# Options: csv or whitespace
+aux_format = whitespace
+
+# Location of pointing database.
+pointing_database = ./baseline_v3.0_10yrs.db
+
+
+[ACTIVITY]
+
+# Flag for cometary activity. If not none, a cometary parameters file must be specified at the command line.
+# Options: none, comet
+comet_activity = none
+
+
+[FILTERS]
+
+# Filters of the observations you are interested in, comma-separated.
+# Your physical parameters file must have H calculated in one of these filters
+# and colour offset columns defined relative to that filter.
+observing_filters = u,g,r,i,z,y
+
+
+[SATURATION]
+
+# Upper magnitude limit on sources that will overfill the detector pixels/have
+# counts above the non-linearity regime of the pixels where one can’t do 
+# photometry. Objects brighter than this limit (in magnitude) will be cut. 
+# Comment out for no saturation limit.
+# Two formats are accepted:
+# Single float: applies same saturation limit to observations in all filters.
+# Comma-separated list of floats: applies saturation limit per filter, in order as
+# given in observing_filters keyword.
+bright_limit = 16.0
+
+
+[PHASECURVES]
+
+# The phase function used to calculate apparent magnitude. The physical parameters input
+# file must contain the columns needed to calculate the phase function.
+# Options: HG, HG1G2, HG12, linear, none.
+phase_function = HG12
+
+[FOV]
+
+# Choose between circular or actual camera footprint, including chip gaps.
+# Options: circle, footprint.
+camera_model = circle
+
+
+# Fraction of detector surface area which contains CCD -- simulates chip gaps
+# for OIF output. Comment out if using camera footprint.
+fill_factor = 0.9
+
+# Radius of the circle for a circular footprint (in degrees). Float.
+# Comment out or do not include if using footprint camera model.
+circle_radius = 1.75
+
+[FADINGFUNCTION]
+
+# Detection efficiency fading function on or off. Uses the fading function as outlined in
+# Chelsey and Vereš (2017) to remove observations.
+fading_function_on = True
+
+# Width parameter for fading function. Should be greater than zero and less than 0.5.
+# Suggested value is 0.1 after Chelsey and Vereš (2017).
+fading_function_width = 0.1
+
+# Peak efficiency for the fading function, called the 'fill factor' in Chelsey and Veres (2017).
+# Suggested value is 1. Do not change this unless you are sure of what you are doing.
+fading_function_peak_efficiency = 1.
+
+
+[LINKINGFILTER]
+# Remove this section if you do not wish to run the SSP linking filter.
+
+# SSP detection efficiency. Which fraction of the objects will
+# the automated Rubin Solar System Processing (SSP) pipeline successfully link? Float.
+SSP_detection_efficiency = 0.95
+
+# Length of tracklets. How many observations of an object during one night are
+# required to produce a valid tracklet?
+SSP_number_observations = 2
+
+# Minimum separation (in arcsec) between two observations of an object required 
+#for the linking software to distinguish them as separate and therefore as a valid tracklet.
+SSP_separation_threshold = 0.5
+
+# Maximum time separation (in days) between subsequent observations in a tracklet. 
+#Default is 0.0625 days (90mins).
+SSP_maximum_time = 0.0625
+
+
+# Number of tracklets for detection. How many tracklets are required to classify
+# an object as detected? Must be an int.
+SSP_number_tracklets = 3
+
+# The number of tracklets defined above must occur in <= this number of days to 
+# constitute a complete track/detection.
+SSP_track_window = 15
+
+
+[OUTPUT]
+
+# Path for output file and filename stem is given at the command line with the following flags:
+# -u or --outfile               Output file path.
+# -t or --stem                  Output file stem.
+
+# Output format. The 'separatelycsv' option saves output into separate CSVs for each object.
+# Options: csv, separatelycsv, sqlite3, hdf5
+output_format = sqlite3
+
+# Size of output. Controls which columns are in the output files.
+# Options are "basic" and "all", which returns all columns.
+output_size = basic
+
+# Decimal places to which RA and Dec should be rounded to in output.
+position_decimals = 7
+
+# Decimal places to which all magnitudes should be rounded to in output.
+magnitude_decimals = 3
+
+
+[EXPERT]
+
+# WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
+# They may have unexpected results or break the code entirely.
+
+# Lightcurve model. Options: none
+lightcurve_model = none
+
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId

--- a/survey_setups/Rubin_full_footprint.ini
+++ b/survey_setups/Rubin_full_footprint.ini
@@ -1,0 +1,152 @@
+# Configuration file for Solar System Post Processing package.
+
+
+[INPUT]
+
+# Paths of input files (orbits, physical parameters, cometary, ephemeris
+# simulation output) are given at the command line with the following flags:
+# -c or --config                Configuration file name (this file)
+# -m or --comet                 Comet parameter file name (optional)
+# -p or --params                Physical parameters file name
+# -o or --orbit                 Orbit file name
+# -e or --ephem                 Ephemeris simulation output file name (i.e. OIF output)
+ 
+# The simulation used for the ephemeris input.
+# Options: currently only oif (objectsInField)
+ephemerides_type = oif
+
+# Format for ephemeris simulation output file. If reading from an existing temporary ephemeris
+# database, this will be ignored.
+# Options: csv, whitespace, hdf5
+eph_format = csv
+
+# SSPP chunks processing by object: how many objects should be processed at once?
+size_serial_chunk = 5000
+
+# Format for orbit/colour/brightness/cometary data files.
+# Options: csv or whitespace
+aux_format = whitespace
+
+# Location of pointing database.
+pointing_database = ./baseline_v3.0_10yrs.db
+
+
+[ACTIVITY]
+
+# Flag for cometary activity. If not none, a cometary parameters file must be specified at the command line.
+# Options: none, comet
+comet_activity = none
+
+
+[FILTERS]
+
+# Filters of the observations you are interested in, comma-separated.
+# Your physical parameters file must have H calculated in one of these filters
+# and colour offset columns defined relative to that filter.
+observing_filters = u,g,r,i,z,y
+
+
+[SATURATION]
+
+# Upper magnitude limit on sources that will overfill the detector pixels/have
+# counts above the non-linearity regime of the pixels where one can’t do 
+# photometry. Objects brighter than this limit (in magnitude) will be cut. 
+# Comment out for no saturation limit.
+# Two formats are accepted:
+# Single float: applies same saturation limit to observations in all filters.
+# Comma-separated list of floats: applies saturation limit per filter, in order as
+# given in observing_filters keyword.
+bright_limit = 16.0
+
+
+[PHASECURVES]
+
+# The phase function used to calculate apparent magnitude. The physical parameters input
+# file must contain the columns needed to calculate the phase function.
+# Options: HG, HG1G2, HG12, linear, none.
+phase_function = HG12
+
+[FOV]
+
+# Choose between circular or actual camera footprint, including chip gaps.
+# Options: circle, footprint.
+camera_model = footprint
+
+# Path to camera footprint file. Comment out if using circle footprint.
+footprint_path= ./data/detectors_corners.csv
+
+[FADINGFUNCTION]
+
+# Detection efficiency fading function on or off. Uses the fading function as outlined in
+# Chelsey and Vereš (2017) to remove observations.
+fading_function_on = True
+
+# Width parameter for fading function. Should be greater than zero and less than 0.5.
+# Suggested value is 0.1 after Chelsey and Vereš (2017).
+fading_function_width = 0.1
+
+# Peak efficiency for the fading function, called the 'fill factor' in Chelsey and Veres (2017).
+# Suggested value is 1. Do not change this unless you are sure of what you are doing.
+fading_function_peak_efficiency = 1.
+
+
+[LINKINGFILTER]
+# Remove this section if you do not wish to run the SSP linking filter.
+
+# SSP detection efficiency. Which fraction of the objects will
+# the automated Rubin Solar System Processing (SSP) pipeline successfully link? Float.
+SSP_detection_efficiency = 0.95
+
+# Length of tracklets. How many observations of an object during one night are
+# required to produce a valid tracklet?
+SSP_number_observations = 2
+
+# Minimum separation (in arcsec) between two observations of an object required 
+#for the linking software to distinguish them as separate and therefore as a valid tracklet.
+SSP_separation_threshold = 0.5
+
+# Maximum time separation (in days) between subsequent observations in a tracklet. 
+#Default is 0.0625 days (90mins).
+SSP_maximum_time = 0.0625
+
+
+# Number of tracklets for detection. How many tracklets are required to classify
+# an object as detected? Must be an int.
+SSP_number_tracklets = 3
+
+# The number of tracklets defined above must occur in <= this number of days to 
+# constitute a complete track/detection.
+SSP_track_window = 15
+
+
+[OUTPUT]
+
+# Path for output file and filename stem is given at the command line with the following flags:
+# -u or --outfile               Output file path.
+# -t or --stem                  Output file stem.
+
+# Output format. The 'separatelycsv' option saves output into separate CSVs for each object.
+# Options: csv, separatelycsv, sqlite3, hdf5
+output_format = sqlite3
+
+# Size of output. Controls which columns are in the output files.
+# Options are "basic" and "all", which returns all columns.
+output_size = basic
+
+# Decimal places to which RA and Dec should be rounded to in output.
+position_decimals = 7
+
+# Decimal places to which all magnitudes should be rounded to in output.
+magnitude_decimals = 3
+
+
+[EXPERT]
+
+# WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
+# They may have unexpected results or break the code entirely.
+
+# Lightcurve model. Options: none
+lightcurve_model = none
+
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId


### PR DESCRIPTION

Fixes #389 

Created survey_setups folder to store configuration files simulating the surveys.

Two configuration files (Rubin_full_footprint.ini and Rubin_circular_approximation.ini) represent the two different use cases (respectively, the full footprint and circular approximation).

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
