### PR TITLE
Dropping unnecessary colour columns that remain unused after read-in

### DIFF
--- a/src/sorcha/modules/PPApplyColourOffsets.py
+++ b/src/sorcha/modules/PPApplyColourOffsets.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import numpy as np
+import fnmatch
 
 
 def PPApplyColourOffsets(observations, function, othercolours, observing_filters, mainfilter):
@@ -133,6 +134,11 @@ def PPApplyColourOffsets(observations, function, othercolours, observing_filters
     # drop a few more unneeded columns to reduce size of dataframe :)
     observations.drop(mainfilter + "-" + mainfilter, axis=1, inplace=True)
     observations.drop(othercolours, axis=1, inplace=True)
+    
+    # drop colours that remain after read-in from the parameter file and are not used      
+    ks=observations.keys().tolist()
+    obsolete_colours=fnmatch.filter(ks, str('?-' + mainfilter))         
+    observations.drop(obsolete_colours, axis=1, inplace=True)
 
     # rename H
     observations.rename(columns={H_col: "H_filter"}, inplace=True)


### PR DESCRIPTION

Fixes #428 

Dropping unnecessary colour columns that remain unused after read-in

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
