### PR TITLE
Refactored `Footprint` object creation

### DIFF
--- a/src/sorcha/modules/PPApplyFOVFilter.py
+++ b/src/sorcha/modules/PPApplyFOVFilter.py
@@ -1,10 +1,9 @@
-from . import PPFootprintFilter
 import logging
 import numpy as np
 from astropy.coordinates import SkyCoord
 
 
-def PPApplyFOVFilter(observations, configs, rng, verbose=False):
+def PPApplyFOVFilter(observations, configs, rng, footprint=None, verbose=False):
     """
     Wrapper function for PPFootprintFilter and PPFilterDetectionEfficiency. Checks to see
     whether a camera footprint filter should be applied or if a simple fraction of the
@@ -18,6 +17,9 @@ def PPApplyFOVFilter(observations, configs, rng, verbose=False):
 
     rng (numpy Generator): numpy random number generator object.
 
+    footprint (Footprint): A Footprint object that represents the boundaries of
+    the detector(s). Default `None`.
+
     verbose (boolean): Verbose mode on or off.
 
     Returns:
@@ -30,8 +32,7 @@ def PPApplyFOVFilter(observations, configs, rng, verbose=False):
 
     if configs["camera_model"] == "footprint":
         verboselog("Applying sensor footprint filter...")
-        footprintf = PPFootprintFilter.Footprint(configs["footprint_path"])
-        onSensor, detectorIDs = footprintf.applyFootprint(observations)
+        onSensor, detectorIDs = footprint.applyFootprint(observations)
 
         observations = observations.iloc[onSensor].copy()
         observations["detectorID"] = detectorIDs

--- a/src/sorcha/modules/PPFootprintFilter.py
+++ b/src/sorcha/modules/PPFootprintFilter.py
@@ -333,17 +333,23 @@ class Footprint:
         # the center of the camera should be the origin
         allcornersdf = pd.read_csv(path)
 
+        # build dictionary of detectorName:[list_of_inds]
+        det_to_inds = {}
+        for det in allcornersdf.detector.unique():
+            det_to_inds[det] = allcornersdf.index[allcornersdf.detector == det].tolist()
+
+        # create a list of `Detector` objects using the list_of_inds for each detector
         self.detectors = [
             Detector(
                 np.array(
                     (
-                        allcornersdf.loc[allcornersdf[detectorName] == i, "x"],
-                        allcornersdf.loc[allcornersdf[detectorName] == i, "y"],
+                        allcornersdf.iloc[inds].x,
+                        allcornersdf.iloc[inds].y,
                     )
                 ),
-                i,
+                det,
             )
-            for i in range(len(allcornersdf[detectorName].unique()))
+            for det, inds in det_to_inds.items()
         ]
 
         self.N = len(self.detectors)

--- a/src/sorcha/modules/PPLinkingFilter.py
+++ b/src/sorcha/modules/PPLinkingFilter.py
@@ -88,7 +88,7 @@ def PPLinkingFilter(
         min_window_nights=min_tracklets,  # minimum size of a window as the rolling window is moved
         by_object=True,  # split observations by object instead of by window [set to True if you want ignore_after_discovery=True]
         discovery_probability=detection_efficiency,  # probability of discovery for any discovery chance
-        num_jobs=30,  # number of parallel jobs
+        num_jobs=1,  # number of parallel jobs
         ignore_after_discovery=True,  # ignore observations of an object after it has been discovered
     )
 

--- a/tests/sorcha/test_PPApplyFOVFilter.py
+++ b/tests/sorcha/test_PPApplyFOVFilter.py
@@ -48,6 +48,7 @@ def test_PPGetSeparation():
 
 def test_PPApplyFOVFilters():
     from sorcha.modules.PPApplyFOVFilter import PPApplyFOVFilter
+    from sorcha.modules.PPFootprintFilter import Footprint
 
     observations = pd.read_csv(get_test_filepath("test_input_fullobs.csv"), nrows=20)
 
@@ -68,8 +69,8 @@ def test_PPApplyFOVFilters():
     assert_equal(new_obs["FieldID"].values, expected)
 
     configs = {"camera_model": "footprint", "footprint_path": get_test_filepath("detectors_corners.csv")}
-
-    new_obs = PPApplyFOVFilter(observations, configs, rng)
+    footprint = Footprint(configs["footprint_path"])
+    new_obs = PPApplyFOVFilter(observations, configs, rng, footprint=footprint)
     expected = [
         894816,
         894838,


### PR DESCRIPTION
Moved `Footprint` instantiation out of `PPApplyFOVFilter`. Set difi `num_jobs=1`.

Fixes #464  .

Please see the ticket for a description of the what the code was originally organized. This PR represents the work to move the creation of the `Footprint` object (that describes the detector geometry) out of `PPApplyFOVFilter` (which is called twice per chunk) into the main sorcha function `runLSSTPostProcessing` such that it only needs to be calculated once. 

Additionally, I modified the list comprehension step. When a `Footprint` object is being instantiated it reads in a CSV file containing a list of (detector id, x, y) tuples. A nested loop was being used to generate a list of `Detector` objects. I removed the nested loop in favor of direct indexing. 

I used the `.../demo/bench_cProfile.py` script to benchmark the changes.  I've summarized the changes below: 

| Change | Calls | PPFootprintFilter time | Benchmark run time |
| ---- | ---- | ---- | ---- | 
| Baseline | 20 | 2.464s | 11.878s |
| Direct indexing during instantiation | 20 | 2.184s | 11.499s | 
| Instantiate only 1 time | 1 | 0.111s | 9.438s |

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
