### PR TITLE
set difi config by_object to false

### DIFF
--- a/src/sorcha/modules/PPLinkingFilter.py
+++ b/src/sorcha/modules/PPLinkingFilter.py
@@ -86,10 +86,10 @@ def PPLinkingFilter(
         difi_dataframe,
         detection_window=tracklet_interval,  # number of nights in a rolling detection window
         min_window_nights=min_tracklets,  # minimum size of a window as the rolling window is moved
-        by_object=True,  # split observations by object instead of by window [set to True if you want ignore_after_discovery=True]
+        by_object=False,  # split observations by object instead of by window [set to True if you want ignore_after_discovery=True]
         discovery_probability=detection_efficiency,  # probability of discovery for any discovery chance
         num_jobs=1,  # number of parallel jobs
-        ignore_after_discovery=True,  # ignore observations of an object after it has been discovered
+        ignore_after_discovery=False,  # ignore observations of an object after it has been discovered
     )
 
     linked_object_observations = observations[observations["ObjID"].isin(findable["object_id"])]


### PR DESCRIPTION
Speed up for PPLinkingFilter/difi. sets `by_object` to false, which gives a speedup of ~3x on the 400k row/10 yr baseline benchmark.

side note: I'm taking a look into whether or not it's possible to speed up the `by_object` option in difi. if it's possible, we can turn it back on but for now I think it's smart to leave it off for the speedup.

Describe your changes.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
