### PR TITLE
Adding a RTD page with the example configuration files.

### DIFF
--- a/docs/exampleconfig.rst
+++ b/docs/exampleconfig.rst
@@ -1,0 +1,28 @@
+Example Configuration Files
+===========================
+
+The following sections show reasonable configuration files for various settings.
+
+Rubin Full Footprint
+--------------------
+
+This configuration file is appropriate for running ``sorcha`` using the Rubin
+full detector footprint.
+
+The source code is available `here <https://github.com/dirac-institute/sorcha/blob/main/survey_setups/Rubin_full_footprint.ini>`_.
+
+.. literalinclude:: ../survey_setups/Rubin_full_footprint.ini
+   :language: txt
+   :linenos:
+
+Rubin Circular Approximation
+----------------------------
+
+This configuration file is appropriate for running ``sorcha`` using a circular 
+approximation of the Rubin detector.
+
+The source code is available `here <https://github.com/dirac-institute/sorcha/blob/main/survey_setups/Rubin_circular_approximation.ini>`_.
+
+.. literalinclude:: ../survey_setups/Rubin_circular_approximation.ini
+    :language: txt
+    :linenos:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ if it is observable with LSST, and specific guides for near earth objects, Jupit
    inputs
    filters
    configfiles
+   exampleconfig
    outputs
    gettingstarted
    whatsspdoesnotdo


### PR DESCRIPTION
Fixes #470 .

Added a new RTD page that renders the "Full Footprint" and "Circular Approximation" configuration files found in `.../survey_setups`. Each section includes a link to the config file in the GitHub repo. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
