### PR TITLE
Updating difi version in pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "matplotlib",
     "sbpy",
     "tables",
-    "difi == 1.2rc2",
+    "difi == 1.2rc3",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Fixes #476.

I've updated the difi requirement in pyproject.toml to the latest version, v1.2rc3. 

This is specifically because I found quite suddenly that any calls to difi resulted in a `FileExistsError: [Errno 17] File exists: '/DIFI_ARRAY'` error which persisted even in a fresh environment. Installing v.2rc3 stopped this as now shared memory arrays have an instance-specific name including the PID.

I'm not sure why this suddenly started happening on my machine (explanations and speculations welcome) but I figured to be safe it's best to update the version requirement.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
