### PR TITLE
Prefactor of lightcurve code

### DIFF
--- a/demo/OIFconfig_benchmark.ini
+++ b/demo/OIFconfig_benchmark.ini
@@ -122,6 +122,9 @@ SSP_number_tracklets = 3
 # constitute a complete track/detection.
 SSP_track_window = 15
 
+# Maximum time separation (in days) between subsequent observations in a tracklet. Default is 0.0625 days (90mins).
+SSP_maximum_time = 0.0625
+
 
 [OUTPUT]
 
@@ -154,4 +157,4 @@ pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFw
 
 
 lightcurve = False
-lc_model = Sinusoidal
+lc_model = none

--- a/demo/OIFconfig_lca.ini
+++ b/demo/OIFconfig_lca.ini
@@ -122,6 +122,9 @@ SSP_number_tracklets = 3
 # constitute a complete track/detection.
 SSP_track_window = 15
 
+# Maximum time separation (in days) between subsequent observations in a tracklet. Default is 0.0625 days (90mins).
+SSP_maximum_time = 0.0625
+
 
 [OUTPUT]
 
@@ -154,4 +157,4 @@ pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFw
 
 
 lightcurve = True
-lc_model = Sinusoidal
+lc_model = sinusoidal

--- a/src/sorcha/lightcurves/__init__.py
+++ b/src/sorcha/lightcurves/__init__.py
@@ -1,0 +1,4 @@
+from .base_lightcurve import AbstractLightCurve
+from .identity_lightcurve import IdentityLightCurve
+
+from .lightcurve_registration import register_lc_subclasses, update_lc_subclasses, LC_METHODS

--- a/src/sorcha/lightcurves/base_lightcurve.py
+++ b/src/sorcha/lightcurves/base_lightcurve.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import List
 import numpy as np
 import pandas as pd
 
@@ -6,7 +7,7 @@ import pandas as pd
 class AbstractLightCurve(ABC):
     """Abstract base class for lightcurve models"""
 
-    def __init__(self, required_column_names: list[str] = []) -> None:
+    def __init__(self, required_column_names: List[str] = []) -> None:
         """Abstract base class accepts a list of column names that are required
         to be present in the Pandas dataframe passed to the ``compute`` method.
 
@@ -59,7 +60,7 @@ class SinusoidalLightCurve(AbstractLightCurve):
     Note: assuming sinusoidal in magnitude instead of flux. Maybe not call LCA?
     """
 
-    def __init__(self, required_column_names: list[str] = [TIME_COLUMN, "LCA", "Period", "Time0"]) -> None:
+    def __init__(self, required_column_names: List[str] = [TIME_COLUMN, "LCA", "Period", "Time0"]) -> None:
         super().__init__(required_column_names)
 
     def compute(self, df: pd.DataFrame) -> np.array:

--- a/src/sorcha/lightcurves/base_lightcurve.py
+++ b/src/sorcha/lightcurves/base_lightcurve.py
@@ -52,15 +52,12 @@ class AbstractLightCurve(ABC):
 
 
 # ! The code below will be moved to the `sorcha_community_utils` repository soon
-TIME_COLUMN = "FieldMJD"
-
-
 class SinusoidalLightCurve(AbstractLightCurve):
     """
     Note: assuming sinusoidal in magnitude instead of flux. Maybe not call LCA?
     """
 
-    def __init__(self, required_column_names: List[str] = [TIME_COLUMN, "LCA", "Period", "Time0"]) -> None:
+    def __init__(self, required_column_names: List[str] = ["FieldMJD", "LCA", "Period", "Time0"]) -> None:
         super().__init__(required_column_names)
 
     def compute(self, df: pd.DataFrame) -> np.array:
@@ -70,7 +67,7 @@ class SinusoidalLightCurve(AbstractLightCurve):
 
         self._validate_column_names(df)
 
-        modtime = np.mod(df[TIME_COLUMN] / df["Period"] + df["Time0"], 2 * np.pi)
+        modtime = np.mod(df["FieldMJD"] / df["Period"] + df["Time0"], 2 * np.pi)
         return df["LCA"] * np.sin(modtime)
 
     @staticmethod

--- a/src/sorcha/lightcurves/identity_lightcurve.py
+++ b/src/sorcha/lightcurves/identity_lightcurve.py
@@ -1,4 +1,5 @@
 from sorcha.lightcurves.base_lightcurve import AbstractLightCurve
+from typing import List
 import numpy as np
 import pandas as pd
 
@@ -19,7 +20,7 @@ class IdentityLightCurve(AbstractLightCurve):
     created for testing purposes.
     """
 
-    def __init__(self, required_column_names: list = [TIME_COLUMN]) -> None:
+    def __init__(self, required_column_names: List[str] = [TIME_COLUMN]) -> None:
         super().__init__(required_column_names)
 
     def compute(self, df: pd.DataFrame) -> np.array:

--- a/src/sorcha/lightcurves/identity_lightcurve.py
+++ b/src/sorcha/lightcurves/identity_lightcurve.py
@@ -9,8 +9,6 @@ FOR TESTING ONLY
 !!!!!!!!!!!!!!!!
 """
 
-TIME_COLUMN = "FieldMJD"
-
 
 class IdentityLightCurve(AbstractLightCurve):
     """
@@ -20,7 +18,7 @@ class IdentityLightCurve(AbstractLightCurve):
     created for testing purposes.
     """
 
-    def __init__(self, required_column_names: List[str] = [TIME_COLUMN]) -> None:
+    def __init__(self, required_column_names: List[str] = ["FieldMJD"]) -> None:
         super().__init__(required_column_names)
 
     def compute(self, df: pd.DataFrame) -> np.array:
@@ -40,7 +38,7 @@ class IdentityLightCurve(AbstractLightCurve):
 
         self._validate_column_names(df)
 
-        return np.zeros_like(df[TIME_COLUMN])
+        return np.zeros_like(df["FieldMJD"])
 
     @staticmethod
     def name_id() -> str:

--- a/src/sorcha/lightcurves/identity_lightcurve.py
+++ b/src/sorcha/lightcurves/identity_lightcurve.py
@@ -1,0 +1,57 @@
+from sorcha.lightcurves.base_lightcurve import AbstractLightCurve
+import numpy as np
+import pandas as pd
+
+"""
+!!!!!!!!!!!!!!!!
+FOR TESTING ONLY
+!!!!!!!!!!!!!!!!
+"""
+
+TIME_COLUMN = "FieldMJD"
+
+
+class IdentityLightCurve(AbstractLightCurve):
+    """
+    !!! THIS SHOULD NEVER BE USED - FOR TESTING ONLY !!!
+
+    Rudimentary lightcurve model that returns no shift. This class is explicitly
+    created for testing purposes.
+    """
+
+    def __init__(self, required_column_names: list = [TIME_COLUMN]) -> None:
+        super().__init__(required_column_names)
+
+    def compute(self, df: pd.DataFrame) -> np.array:
+        """Returns numpy array of 0's with shape equal to the input dataframe
+        time column.
+
+        Parameters
+        ----------
+        df : Pandas dataframe
+            The ``observations`` dataframe provided by ``Sorcha``.
+
+        Returns
+        -------
+        np.array
+            Numpy array of 0's with shape equal to the input dataframe time column.
+        """
+
+        self._validate_column_names(df)
+
+        return np.zeros_like(df[TIME_COLUMN])
+
+    @staticmethod
+    def name_id() -> str:
+        """Returns the string identifier for this light curve method. It must be
+        unique within all the subclasses of ``AbstractLightCurve``.
+
+        We have chosen the name "identity" here because the input brightness will
+        equal the output brightness if this model is applied.
+
+        Returns
+        -------
+        str
+            Unique identifier for this light curve calculator
+        """
+        return "identity"

--- a/src/sorcha/lightcurves/lightcurve_registration.py
+++ b/src/sorcha/lightcurves/lightcurve_registration.py
@@ -1,23 +1,24 @@
-from .base_lightcurve import AbstractLightCurve
+from sorcha.lightcurves.base_lightcurve import AbstractLightCurve
+from typing import Callable
 
 
-def register_lc_subclasses():
-    """This method will identify all of the subclasses of `AbstractLightCurve`
-    and build a dictionary that maps `name : subclass`.
+def register_lc_subclasses() -> dict[str, Callable]:
+    """This method will identify all of the subclasses of ``AbstractLightCurve``
+    and build a dictionary that maps ``name : subclass``.
 
     Returns
     -------
     dict
-        A dictionary of all of subclasses of `AbstractLightCurve`. Where
-        the str returned from `subclass.name_id()` is the key, and the class is
-        the value.
+        A dictionary of all of subclasses of ``AbstractLightCurve``. Where
+        the string returned from ``subclass.name_id()`` is the key, and the
+        subclass is the value.
 
     Raises
     ------
     ValueError
-        If a duplicate key is found, a ValueError will be raised. This would
+        If a duplicate key is found, a ``ValueError`` is raised. This would
         likely occur if a user copy/pasted an existing subclass but failed to
-        update the unique name_id string.
+        update the string returned from ``name_id()``.
     """
     subclass_dict = {}
     for subcls in AbstractLightCurve.__subclasses__():
@@ -32,7 +33,7 @@ def register_lc_subclasses():
     return subclass_dict
 
 
-def update_lc_subclasses():
+def update_lc_subclasses() -> dict[str, Callable]:
     """This function is used to register newly created subclasses of the
     `AbstractLightCurve`.
     """

--- a/src/sorcha/lightcurves/lightcurve_registration.py
+++ b/src/sorcha/lightcurves/lightcurve_registration.py
@@ -1,8 +1,8 @@
 from sorcha.lightcurves.base_lightcurve import AbstractLightCurve
-from typing import Callable
+from typing import Callable, Dict
 
 
-def register_lc_subclasses() -> dict[str, Callable]:
+def register_lc_subclasses() -> Dict[str, Callable]:
     """This method will identify all of the subclasses of ``AbstractLightCurve``
     and build a dictionary that maps ``name : subclass``.
 
@@ -33,7 +33,7 @@ def register_lc_subclasses() -> dict[str, Callable]:
     return subclass_dict
 
 
-def update_lc_subclasses() -> dict[str, Callable]:
+def update_lc_subclasses() -> None:
     """This function is used to register newly created subclasses of the
     `AbstractLightCurve`.
     """

--- a/src/sorcha/modules/PPCalculateApparentMagnitude.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitude.py
@@ -62,7 +62,7 @@ def PPCalculateApparentMagnitude(
 
         verboselog("Calculating apparent magnitude in filter...")
         observations = PPCalculateApparentMagnitudeInFilter(
-            observations, phasefunction, lightcurve=lightcurve, lightcurve_choice=lightcurve_choice
+            observations, phasefunction, lightcurve_choice=lightcurve_choice
         )
 
     return observations

--- a/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
@@ -4,11 +4,11 @@ import astropy.units as u
 from sbpy.photometry import HG, HG1G2, HG12_Pen16, LinearPhaseFunc
 import logging
 
-from sorcha.lightcurves.LightcurveImporter import LC_METHODS
+from sorcha.lightcurves.lightcurve_registration import LC_METHODS
 
 
 def PPCalculateApparentMagnitudeInFilter(
-    padain, function, colname="TrailedSourceMag", lightcurve=False, lightcurve_choice="None"
+    padain, function, colname="TrailedSourceMag", lightcurve_choice="None"
 ):
     """
     This task calculates the apparent brightness of an object at a given pointing
@@ -65,8 +65,10 @@ def PPCalculateApparentMagnitudeInFilter(
 
     alpha = padain["Sun-Ast-Obs(deg)"].values
     H = padain[H_col].values
-    if lightcurve:
-        lc_shift = LC_METHODS[lightcurve_choice]()(padain)
+
+    if LC_METHODS.get(lightcurve_choice, False):
+        lc_model = LC_METHODS[lightcurve_choice]()
+        lc_shift = lc_model.compute(padain)
         padain["Delta_m"] = lc_shift
         Heff = H + lc_shift
     else:

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -32,6 +32,8 @@ from sorcha.readers.CSVReader import CSVDataReader
 from sorcha.readers.OIFReader import OIFDataReader
 from sorcha.readers.OrbitAuxReader import OrbitAuxReader
 
+from sorcha.lightcurves.lightcurve_registration import update_lc_subclasses
+
 from sorcha.utilities.sorchaArguments import sorchaArguments
 
 # Author: Samuel Cornwall, Siegfried Eggl, Grigori Fedorets, Steph Merritt, Meg Schwamb
@@ -52,6 +54,8 @@ def runLSSTPostProcessing(cmd_args):
     None.
 
     """
+
+    update_lc_subclasses()
 
     # Initialise argument parser and assign command line arguments
 

--- a/tests/lightcurves/test_lightcurve_registration.py
+++ b/tests/lightcurves/test_lightcurve_registration.py
@@ -1,0 +1,42 @@
+import pytest
+from sorcha.lightcurves.lightcurve_registration import (
+    register_lc_subclasses,
+    update_lc_subclasses,
+    LC_METHODS,
+)
+from sorcha.lightcurves.base_lightcurve import AbstractLightCurve
+
+
+def test_register_subclasses():
+    output = register_lc_subclasses()
+
+    assert output == LC_METHODS
+
+
+def test_register_subclasses_with_duplicate():
+    class dup_identity(AbstractLightCurve):
+        def compute(self):
+            return 1
+
+        @staticmethod
+        def name_id():
+            return "identity"
+
+    with pytest.raises(ValueError) as excinfo:
+        _ = register_lc_subclasses()
+
+    assert "duplicate Lightcurve calculator name to LC_METHODS: identity" in str(excinfo.value)
+
+
+def test_update_subclasses():
+    class test_lc(AbstractLightCurve):
+        def compute(self):
+            return 1
+
+        @staticmethod
+        def name_id():
+            return "test_lc"
+
+    update_lc_subclasses()
+
+    assert LC_METHODS["test_lc"] == test_lc

--- a/tests/sorcha/test_PPCalculateApparentMagnitude.py
+++ b/tests/sorcha/test_PPCalculateApparentMagnitude.py
@@ -1,14 +1,65 @@
 import pandas as pd
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
+from sorcha.modules.PPCalculateApparentMagnitudeInFilter import PPCalculateApparentMagnitudeInFilter
+
+
+def test_PPCalculateApparentMagnitudeInFilter_default():
+    """Baseline test, no phase function"""
+    test_observations = pd.DataFrame(
+        {
+            "FieldMJD": [2459215.5],
+            "H_filter": [7.3],
+            "GS": [0.19],
+            "G1": [0.62],
+            "G2": [0.14],
+            "G12": [0.68],
+            "S": [0.04],
+            "AstRange(km)": [4.899690e08],
+            "Ast-Sun(km)": [6.301740e08],
+            "Sun-Ast-Obs(deg)": [4.5918],
+        }
+    )
+
+    test_observations = PPCalculateApparentMagnitudeInFilter(test_observations.copy(), "none", "output")
+
+    assert_almost_equal(test_observations["output"][0], 12.998891, decimal=5)
+
+    return
+
+
+def test_PPCalculateApparentMagnitudeInFilterWithIdentityLightcurve():
+    """Baseline test, no phase function, but includes the "identity" (for testing only!)
+    light curve model
+    """
+    test_observations = pd.DataFrame(
+        {
+            "FieldMJD": [2459215.5],
+            "H_filter": [7.3],
+            "GS": [0.19],
+            "G1": [0.62],
+            "G2": [0.14],
+            "G12": [0.68],
+            "S": [0.04],
+            "AstRange(km)": [4.899690e08],
+            "Ast-Sun(km)": [6.301740e08],
+            "Sun-Ast-Obs(deg)": [4.5918],
+        }
+    )
+
+    test_observations = PPCalculateApparentMagnitudeInFilter(
+        test_observations.copy(), "none", "output", "identity"
+    )
+
+    assert_almost_equal(test_observations["output"][0], 12.998891, decimal=5)
+
+    return
 
 
 def test_PPCalculateApparentMagnitudeInFilter():
-    from sorcha.modules.PPCalculateApparentMagnitudeInFilter import PPCalculateApparentMagnitudeInFilter
-
     test_observations = pd.DataFrame(
         {
-            "MJD": [2459215.5],
+            "FieldMJD": [2459215.5],
             "H_filter": [7.3],
             "GS": [0.19],
             "G1": [0.62],


### PR DESCRIPTION
Initial commit to refactor lightcurve code in prep for separating it out to `sorcha_community_util` repo.

Fixes # 484.

This PR represents the work to:

1. Separate the abstract base class for the lightcurve models from any implementations
2. Introduces a test LC model "identity"
3. Updates docstrings for the base and identity classes
4. Removes the use of the `lightcurve` boolean config value (but does not remove it from the config machinery yet (there's a separate issue for that #482 )
5. Adds tests for the lightcurve registration mechanism
6. Expands the `.../lightcurves/init.py` file so that the classes are registered automatically.
7. Update `src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py` where we make use of LC_METHODS so that if the requested light curve model isn't in the dictionary, the program won't crash (extra work needed here to report something reasonable to the user when this happens #486)

Bonus: 
Add the extra config parameter needed in the `demo/OIFconfig_*` files so that `bench_cProfile` runs correctly. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
