### PR TITLE
Fixing comet magnitudes, adding comments.

### DIFF
--- a/docs/notebooks/demo_CalculateSimpleCometaryMagnitude.ipynb
+++ b/docs/notebooks/demo_CalculateSimpleCometaryMagnitude.ipynb
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m_sspp = test_data['TrailedSourceMag']"
+    "m_sspp = test_data['H_r']"
    ]
   },
   {
@@ -139,7 +139,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/src/sorcha/modules/PPApplyColourOffsets.py
+++ b/src/sorcha/modules/PPApplyColourOffsets.py
@@ -36,7 +36,7 @@ def PPApplyColourOffsets(observations, function, othercolours, observing_filters
     # create a zero-offset column for mainfilter-mainfilter
     observations[mainfilter + "-" + mainfilter] = np.zeros(len(observations))
 
-    # first apply the H offset for every observation
+    # first apply the correct colour offset to H for every observation
     try:
         unique_opt_filters = observations["optFilter"].unique()
         for filter in unique_opt_filters:
@@ -48,9 +48,9 @@ def PPApplyColourOffsets(observations, function, othercolours, observing_filters
         pplogger.error("ERROR: PPApplyColourOffsets: H column missing!")
         sys.exit("ERROR: PPApplyColourOffsets: H column missing!")
 
-    # then check the function
-    # for each function, see if the basic columns exist: if so, leave them
-    # if colour-specific terms exist, make columns with the appropriate values
+    # then check the columns for the phase function variables
+    # if colour-specific terms exist, pick the columns with the appropriate colour
+    # if only one value specified, assume same value for all filters
 
     if function == "HG1G2":
         G1list = ["G1" + filt for filt in observing_filters]
@@ -131,7 +131,7 @@ def PPApplyColourOffsets(observations, function, othercolours, observing_filters
         )
         sys.exit("ERROR: PPApplyColourOffsets: unknown phase function. Should be HG1G2, HG, HG12 or linear.")
 
-    # drop columns for colours that remain after read-in from the parameter file and are not used
+    # drop colour offset columns
     ks = observations.keys().tolist()
     obsolete_colours = fnmatch.filter(ks, str("?-" + mainfilter))
     observations.drop(obsolete_colours, axis=1, inplace=True)

--- a/src/sorcha/modules/PPCalculateApparentMagnitude.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitude.py
@@ -49,20 +49,25 @@ def PPCalculateApparentMagnitude(
 
     if object_type == "comet":
         verboselog("Calculating cometary magnitude using a simple model and applying colour offset...")
-        observations = PPCalculateSimpleCometaryMagnitude(observations, mainfilter, othercolours)
-    else:
-        # if user is only interested in one filter, we have no colour offsets to apply: assume H is in that filter
-        if len(observing_filters) > 1:
-            verboselog("Selecting and applying correct colour offset...")
-            observations = PPApplyColourOffsets(
-                observations, phasefunction, othercolours, observing_filters, mainfilter
-            )
-        else:
-            observations.rename(columns={"H_" + mainfilter: "H_filter"}, inplace=True)
 
-        verboselog("Calculating apparent magnitude in filter...")
-        observations = PPCalculateApparentMagnitudeInFilter(
-            observations, phasefunction, lightcurve_choice=lightcurve_choice
+        # calculate coma/tail contribution to the apparent magnitude
+        observations = PPCalculateSimpleCometaryMagnitude(observations, mainfilter, othercolours)
+
+    # apply correct colour offset to get H magnitude in observation filter
+    # if user is only interested in one filter, we have no colour offsets to apply: assume H is in that filter
+    if len(observing_filters) > 1:
+        verboselog("Selecting and applying correct colour offset...")
+
+        observations = PPApplyColourOffsets(
+            observations, phasefunction, othercolours, observing_filters, mainfilter
         )
+    else:
+        observations.rename(columns={"H_" + mainfilter: "H_filter"}, inplace=True)
+
+    # calculate main body apparent magnitude in observation filter
+    verboselog("Calculating apparent magnitude in filter...")
+    observations = PPCalculateApparentMagnitudeInFilter(
+        observations, phasefunction, lightcurve_choice=lightcurve_choice
+    )
 
     return observations

--- a/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
@@ -82,25 +82,25 @@ def PPCalculateApparentMagnitudeInFilter(
         G1 = padain["G1"].values
         G2 = padain["G2"].values
         HGm = HG1G2(H=Heff * u.mag, G1=G1, G2=G2)
-        phase_function = HGm(alpha * u.deg).value
+        reduced_mag = HGm(alpha * u.deg).value
 
     elif function == "HG":
         G = padain["GS"].values
         HGm = HG(H=Heff * u.mag, G=G)
-        phase_function = HGm(alpha * u.deg).value
+        reduced_mag = HGm(alpha * u.deg).value
 
     elif function == "HG12":
         G12 = padain["G12"].values
         HGm = HG12_Pen16(H=Heff * u.mag, G12=G12)
-        phase_function = HGm(alpha * u.deg).value
+        reduced_mag = HGm(alpha * u.deg).value
 
     elif function == "linear":
         S = padain["S"].values
         HGm = LinearPhaseFunc(H=Heff * u.mag, S=S * u.mag / u.deg)
-        phase_function = HGm(alpha * u.deg).value
+        reduced_mag = HGm(alpha * u.deg).value
 
     elif function == "none":
-        phase_function = Heff.copy()
+        reduced_mag = Heff.copy()
 
     else:
         pplogger.error(
@@ -111,7 +111,7 @@ def PPCalculateApparentMagnitudeInFilter(
         )
 
     # apparent magnitude equation: see equation 1 in Schwamb et al. 2023
-    padain[colname] = 5.0 * np.log10(delta) + 5.0 * np.log10(r) + phase_function
+    padain[colname] = 5.0 * np.log10(delta) + 5.0 * np.log10(r) + reduced_mag
 
     padain = padain.reset_index(drop=True)
 

--- a/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
@@ -49,6 +49,7 @@ def PPCalculateApparentMagnitudeInFilter(
     H_col = "H_filter"
 
     # first, get H, r, delta and alpha as ndarrays
+    # r, delta and alpha are converted to au from kilometres
     r = padain["AstRange(km)"].values / 1.495978707e8
 
     try:
@@ -66,6 +67,7 @@ def PPCalculateApparentMagnitudeInFilter(
     alpha = padain["Sun-Ast-Obs(deg)"].values
     H = padain[H_col].values
 
+    # calculating light curve offset
     if LC_METHODS.get(lightcurve_choice, False):
         lc_model = LC_METHODS[lightcurve_choice]()
         lc_shift = lc_model.compute(padain)
@@ -74,6 +76,8 @@ def PPCalculateApparentMagnitudeInFilter(
     else:
         Heff = H
 
+    # calculate reduced magnitude and contribution from phase function
+    # reduced magnitude = H + 2.5log10(f(phi))
     if function == "HG1G2":
         G1 = padain["G1"].values
         G2 = padain["G2"].values
@@ -106,7 +110,7 @@ def PPCalculateApparentMagnitudeInFilter(
             "ERROR: PPCalculateApparentMagnitudeInFilter: unknown phase function. Should be HG1G2, HG, HG12 or linear."
         )
 
-    # in sbpy, phase_function = H(alpha) + Phi(alpha)
+    # apparent magnitude equation: see equation 1 in Schwamb et al. 2023
     padain[colname] = 5.0 * np.log10(delta) + 5.0 * np.log10(r) + phase_function
 
     padain = padain.reset_index(drop=True)

--- a/src/sorcha/modules/PPCalculateSimpleCometaryMagnitude.py
+++ b/src/sorcha/modules/PPCalculateSimpleCometaryMagnitude.py
@@ -5,7 +5,7 @@ import numpy as np
 # (C)  LSST Solar System Scientific Collaboration 2019
 
 
-def PPCalculateSimpleCometaryMagnitude(padain, mainfilter, othercolours, colname="TrailedSourceMag"):
+def PPCalculateSimpleCometaryMagnitude(padain, mainfilter, othercolours):
     """
     This task calculates the brightness of the comet at a given pointing
     according to a simple model by A'Hearn et al. (1984).
@@ -53,16 +53,16 @@ def PPCalculateSimpleCometaryMagnitude(padain, mainfilter, othercolours, colname
     padain["coma"] = com.mag(g, mainfilter, rap=1, nucleus=False)
 
     # The contribution of the nucleus is taken from the absolute brightness
-    padain[colname] = -2.5 * np.log10(10 ** (-0.4 * padain["coma"]) + 10 ** (-0.4 * padain[H_col]))
+    padain[H_col] = -2.5 * np.log10(10 ** (-0.4 * padain["coma"]) + 10 ** (-0.4 * padain[H_col]))
 
-    # We then calculate the colour offset.
-    padain[mainfilter + "-" + mainfilter] = np.zeros(len(padain))
-    padain[colname] = padain.apply(
-        lambda row: row[colname] + row[row["optFilter"] + "-" + mainfilter], axis=1
-    )
-    padain.drop(mainfilter + "-" + mainfilter, axis=1, inplace=True)
-
-    if othercolours != "":
-        padain.drop(othercolours, axis=1, inplace=True)
+    #     # We then calculate the colour offset.
+    #     padain[mainfilter + "-" + mainfilter] = np.zeros(len(padain))
+    #     padain[colname] = padain.apply(
+    #         lambda row: row[colname] + row[row["optFilter"] + "-" + mainfilter], axis=1
+    #     )
+    #     padain.drop(mainfilter + "-" + mainfilter, axis=1, inplace=True)
+    #
+    #     if othercolours != "":
+    #         padain.drop(othercolours, axis=1, inplace=True)
 
     return padain

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -702,7 +702,7 @@ def PPPrintConfigsToLog(configs, cmd_args):
         pplogger.info("Temporary ephemeris database will be deleted upon code conclusion.")
 
     if configs["comet_activity"] == "comet":
-        pplogger.info("Cometary activity set to: " + str(configs["cometary activity"]))
+        pplogger.info("Cometary activity set to: " + str(configs["comet_activity"]))
     elif configs["comet_activity"] == "none":
         pplogger.info("No cometary activity selected.")
 

--- a/tests/sorcha/test_PPCalculateApparentMagnitude.py
+++ b/tests/sorcha/test_PPCalculateApparentMagnitude.py
@@ -107,7 +107,7 @@ def test_PPCalculateSimpleCometaryMagnitude():
     df_comet = PPCalculateSimpleCometaryMagnitude(cometary_obs, "r", ["i-r"])
 
     assert_almost_equal(df_comet["coma"].values[0], 24.82220145)
-    assert_almost_equal(df_comet["TrailedSourceMag"].values[0], 15.77970706)
+    assert_almost_equal(df_comet["H_r"].values[0], 15.89970705)
 
     return
 
@@ -181,6 +181,7 @@ def test_PPCalculateApparentMagnitude():
             "Sun-Ast-Obs(deg)": [8.899486],
             "optFilter": ["i"],
             "H_r": [15.9],
+            "GS": [0.19],
             "afrho1": [1552],
             "q": [1.21050916],
             "k": [-3.35],
@@ -226,7 +227,7 @@ def test_PPCalculateApparentMagnitude():
     asteroid_single = PPCalculateApparentMagnitude(asteroid_obs_single, "HG", "r", ["r-r"], ["r"], "none")
 
     assert_almost_equal(comet_out["coma"].values[0], 24.822201, decimal=6)
-    assert_almost_equal(comet_out["TrailedSourceMag"].values[0], 15.779707, decimal=6)
+    assert_almost_equal(comet_out["TrailedSourceMag"].values[0], 23.527587, decimal=6)
 
     assert_almost_equal(asteroid_out["TrailedSourceMag"].values[0], 13.281578, decimal=6)
     assert_almost_equal(asteroid_out["H_filter"].values[0], 7.19, decimal=6)


### PR DESCRIPTION
Fixes #477.
The distance offset and phase function calculation is now applied when the cometary case is switched on. The unit tests have been updated appropriately, as has the demo notebook. This bug fix was not done elegantly, but I also plan to perform a small overhaul to how cometary contribution to magnitude is applied in the next couple of days, which will simplify and streamline the process. Issue #491 explains it.

I also changed a rogue incorrect variable name in PPPrintConfigsToLog. I thought I'd done this already, sorry.

Fixes #480.
Added helpful comments throughout the magnitude calculation and colour offset application functions, with Meg's help. The variable "phase_function" in PPCalculateMagnitudeInFilter has been renamed to "reduced_mag" to properly reflect what it actually is.


## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
