### PR TITLE
Remove unused `lightcurve` config

### DIFF
--- a/demo/OIFconfig_benchmark.ini
+++ b/demo/OIFconfig_benchmark.ini
@@ -155,6 +155,5 @@ magnitude_decimals = 3
 # SQL query for extracting data from the pointing database.
 pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId
 
-
-lightcurve = False
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method of the subclasses of AbstractLightCurve
 lc_model = none

--- a/demo/OIFconfig_lca.ini
+++ b/demo/OIFconfig_lca.ini
@@ -155,6 +155,5 @@ magnitude_decimals = 3
 # SQL query for extracting data from the pointing database.
 pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId
 
-
-lightcurve = True
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method of the subclasses of AbstractLightCurve
 lc_model = sinusoidal

--- a/src/sorcha/modules/PPCalculateApparentMagnitude.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitude.py
@@ -11,8 +11,7 @@ def PPCalculateApparentMagnitude(
     othercolours,
     observing_filters,
     object_type,
-    lightcurve=False,
-    lightcurve_choice="None",
+    lightcurve_choice=None,
     verbose=False,
 ):
     """This function applies the correct colour offset to H for the relevant filter, checks to make sure
@@ -33,9 +32,7 @@ def PPCalculateApparentMagnitude(
 
     object_type (string): type of object for cometary activity. Either 'comet' or 'none'.
 
-    lightcurve (boolean): whether lightcurves are applied or not
-
-    lc_choice (string): choice of lightcurve model
+    lc_choice (string): choice of lightcurve model. Default None
 
     verbose (boolean): True/False trigger for verbosity.
 

--- a/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
@@ -8,7 +8,7 @@ from sorcha.lightcurves.lightcurve_registration import LC_METHODS
 
 
 def PPCalculateApparentMagnitudeInFilter(
-    padain, function, colname="TrailedSourceMag", lightcurve_choice="None"
+    padain, function, colname="TrailedSourceMag", lightcurve_choice=None
 ):
     """
     This task calculates the apparent brightness of an object at a given pointing
@@ -33,9 +33,7 @@ def PPCalculateApparentMagnitudeInFilter(
 
     colname (string): column name in which to store calculated magnitude.
 
-    lightcurve (boolean): whether lightcurves are applied or not
-
-    lightcurve_choice (string): choice of lightcurve model
+    lightcurve_choice (string): choice of lightcurve model. Default None
 
 
     Returns:
@@ -66,7 +64,7 @@ def PPCalculateApparentMagnitudeInFilter(
     alpha = padain["Sun-Ast-Obs(deg)"].values
     H = padain[H_col].values
 
-    if LC_METHODS.get(lightcurve_choice, False):
+    if lightcurve_choice and LC_METHODS.get(lightcurve_choice, False):
         lc_model = LC_METHODS[lightcurve_choice]()
         lc_shift = lc_model.compute(padain)
         padain["Delta_m"] = lc_shift

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -645,20 +645,8 @@ def PPConfigFileParser(configfile, survey_name):
     else:
         config_dict["rng_seed"] = None
 
-    try:
-        config_dict["lightcurve"] = config.getboolean("EXPERT", "lightcurve", fallback=False)
-    except ValueError:
-        pplogger.error(
-            "ERROR: could not parse value for lightcurve as a boolean. Check formatting and try again."
-        )
-        sys.exit("ERROR: could not parse value for lightcurve as a boolean. Check formatting and try again.")
-
     config_dict["lc_model"] = config.get("EXPERT", "lc_model", fallback=None)
     config_dict["lc_model"] = None if config_dict["lc_model"] == "None" else config_dict["lc_model"]
-
-    if config_dict["lightcurve"] and not config_dict["lc_model"]:
-        pplogger.error("ERROR: lightcurve set to True but lc_model not supplied or set to None.")
-        sys.exit("ERROR: lightcurve set to True but lc_model not supplied or set to None.")
 
     return config_dict
 
@@ -807,7 +795,7 @@ def PPPrintConfigsToLog(configs, cmd_args):
     else:
         pplogger.info("Solar System Processing linking filter is turned OFF.")
 
-    if configs["lightcurve"] == True:
+    if configs["lc_model"]:
         pplogger.info("A lightcurve model is being applied.")
         pplogger.info("The lightcurve model is: " + configs["lc_model"])
     else:

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -158,7 +158,6 @@ def runLSSTPostProcessing(cmd_args):
             configs["othercolours"],
             configs["observing_filters"],
             configs["comet_activity"],
-            lightcurve=configs["lightcurve"],
             lightcurve_choice=configs["lc_model"],
             verbose=args.verbose,
         )

--- a/src/sorcha/utilities/makeConfigPP.py
+++ b/src/sorcha/utilities/makeConfigPP.py
@@ -9,7 +9,7 @@ import sys
 
 def makeConfigFile(args):
     """
-    Makes an SSPP config file from the variables defined at the command line.
+    Makes an sorcha config file from the variables defined at the command line.
 
     Parameters:
     -----------
@@ -52,7 +52,6 @@ def makeConfigFile(args):
         "mag_limit": str(args.maglimit),
         "trailing_losses_on": str(args.trailinglosseson),
         "pointing_sql_query": str(args.sqlquery),
-        "lightcurve": str(args.lightcurve),
         "lc_model": str(args.lcmodel),
     }
 
@@ -375,13 +374,6 @@ def main():
         help="Switch on trailing losses. Relevant for close-approaching NEOs. Default True.",
         type=bool,
         default=True,
-    )
-    parser.add_argument(
-        "--lightcurve",
-        "-lc",
-        help="Include lightcurve model. Default False.",
-        type=bool,
-        default=False,
     )
     parser.add_argument(
         "--lcmodel",

--- a/survey_setups/Rubin_circular_approximation.ini
+++ b/survey_setups/Rubin_circular_approximation.ini
@@ -151,8 +151,8 @@ magnitude_decimals = 3
 # WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
 # They may have unexpected results or break the code entirely.
 
-# Lightcurve model. Options: none
-lightcurve_model = none
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method of the subclasses of AbstractLightCurve
+lc_model = none
 
 # SQL query for extracting data from the pointing database.
 pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId

--- a/survey_setups/Rubin_full_footprint.ini
+++ b/survey_setups/Rubin_full_footprint.ini
@@ -145,8 +145,8 @@ magnitude_decimals = 3
 # WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
 # They may have unexpected results or break the code entirely.
 
-# Lightcurve model. Options: none
-lightcurve_model = none
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method of the subclasses of AbstractLightCurve
+lc_model = none
 
 # SQL query for extracting data from the pointing database.
 pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId

--- a/tests/data/makeConfigPP_config.ini
+++ b/tests/data/makeConfigPP_config.ini
@@ -43,4 +43,4 @@ magnitude_decimals = 3
 [EXPERT]
 trailing_losses_on = True
 pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId
-lightcurve = False
+lc_model = identity

--- a/tests/data/test_PPConfig.ini
+++ b/tests/data/test_PPConfig.ini
@@ -164,6 +164,5 @@ pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFw
 # Cannot be used at the same time as the SNR limit. Must be a float.
 #magnitude_limit = 22.0
 
-#Lightcurve: whether a lightcurve is applied or not, and its parameters
-lightcurve = False
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method of the subclasses of AbstractLightCurve
 lc_model = None

--- a/tests/sorcha/test_PPConfigParser.py
+++ b/tests/sorcha/test_PPConfigParser.py
@@ -68,7 +68,6 @@ def test_PPConfigFileParser(setup_and_teardown_for_PPConfigFileParser):
         "magnitude_decimals": 3,
         "size_serial_chunk": 10,
         "rng_seed": None,
-        "lightcurve": False,
         "lc_model": None,
     }
 
@@ -285,7 +284,6 @@ def test_PPPrintConfigsToLog(tmp_path):
         "rng_seed": None,
         "mainfilter": "r",
         "othercolours": ["g-r", "i-r", "z-r"],
-        "lightcurve": False,
         "lc_model": None,
     }
 

--- a/tests/sorcha/test_makeConfigPP.py
+++ b/tests/sorcha/test_makeConfigPP.py
@@ -38,8 +38,7 @@ class args:
         self.maglimit = None
         self.sqlquery = "SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId"
         self.trailinglosseson = True
-        self.lightcurve = False
-        self.lcmodel = "None"
+        self.lcmodel = "identity"
 
 
 def test_makeConfigPP(tmp_path):


### PR DESCRIPTION
Fixes #482 .

This PR removes the unused `lightcurve` config parameter and the various references to it throughout the code and tests. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
