### PR TITLE
Comet corrections, #485, #491

### DIFF
--- a/docs/notebooks/demo_ApparentMagnitudeValidation.ipynb
+++ b/docs/notebooks/demo_ApparentMagnitudeValidation.ipynb
@@ -103,9 +103,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "observations_df = PPCalculateApparentMagnitudeInFilter(observations_df.copy(), 'HG', 'HG_mag')\n",
-    "observations_df = PPCalculateApparentMagnitudeInFilter(observations_df.copy(), 'HG12', 'HG12_mag')\n",
-    "observations_df = PPCalculateApparentMagnitudeInFilter(observations_df.copy(), 'HG1G2', 'HG1G2_mag')"
+    "observations_df = PPCalculateApparentMagnitudeInFilter(observations_df.copy(), 'HG', 'r', 'r', 'HG_mag')\n",
+    "observations_df = PPCalculateApparentMagnitudeInFilter(observations_df.copy(), 'HG12', 'r,', 'r', 'HG12_mag')\n",
+    "observations_df = PPCalculateApparentMagnitudeInFilter(observations_df.copy(), 'HG1G2', 'r', 'r', 'HG1G2_mag')"
    ]
   },
   {
@@ -205,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "observations_df = PPCalculateApparentMagnitudeInFilter(observations_df.copy(), 'linear', 'linear_mag')"
+    "observations_df = PPCalculateApparentMagnitudeInFilter(observations_df.copy(), 'linear', 'r', 'r', 'linear_mag')"
    ]
   },
   {
@@ -241,7 +241,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/docs/notebooks/demo_CalculateSimpleCometaryMagnitude.ipynb
+++ b/docs/notebooks/demo_CalculateSimpleCometaryMagnitude.ipynb
@@ -30,7 +30,7 @@
    "id": "e069ed2c",
    "metadata": {},
    "source": [
-    "The lsstcomet code used by sorcha validates its results by comparing them to the cometary magnitude calculated by sbpy. We will do the same.\n",
+    "The lsstcomet code used by sorcha validates its results by comparing them to the coma magnitude calculated by sbpy. We will do the same.\n",
     "\n",
     "First, calculating using sbpy:"
    ]
@@ -51,9 +51,7 @@
     "m0 = afrho.to_fluxd(r, rap, g, unit=u.ABmag).value\n",
     "\n",
     "comet = Comet(R=1, afrho1=100, k=-2)\n",
-    "m = comet.mag(g, 'r', rap=rap.value, nucleus=False)\n",
-    "\n",
-    "m_sbpy = -2.5 * np.log10(10 ** (-0.4 * m) + 10 ** (-0.4 * 7.3))"
+    "m_sbpy = comet.mag(g, 'r', rap=rap.value, nucleus=False)"
    ]
   },
   {
@@ -61,7 +59,7 @@
    "id": "49a0f00a",
    "metadata": {},
    "source": [
-    "Now a test dataset must be created using the same values."
+    "Now a test dataset must be created using the same values. TrailedSourceMag here is a placeholder value: the function calculates the total apparent magnitude of coma and nucleus, and thus needs the \"nucleus\" apparent magnitude."
    ]
   },
   {
@@ -72,16 +70,18 @@
    "outputs": [],
    "source": [
     "test_dict = {'MJD': [2459215.5],\n",
-    "              'H_r': [7.3],\n",
-    "              'AstRange(km)': [1. * 1.495978707e8],\n",
-    "              'Ast-Sun(km)': [2. * 1.495978707e8],\n",
-    "              'Sun-Ast-Obs(deg)': [0],\n",
+    "              'H_original': [7.3],\n",
     "              'afrho1': [100],\n",
-    "              'q':[1. * 1.495978707e8],\n",
     "              'k':[-2],\n",
-    "              'optFilter':'r'}\n",
+    "              'optFilter':'r',\n",
+    "              'seeingFwhmGeom': [1],\n",
+    "              'TrailedSourceMag': 18}\n",
     "\n",
-    "test_data = pd.DataFrame(test_dict)"
+    "test_data = pd.DataFrame(test_dict)\n",
+    "\n",
+    "rho = 2.\n",
+    "delta = 1.\n",
+    "alpha = 0"
    ]
   },
   {
@@ -89,7 +89,7 @@
    "id": "f8f2771c",
    "metadata": {},
    "source": [
-    "Calculating cometary apparent magnitude using the SSPP function and comparing:"
+    "Calculating coma apparent magnitude using the SSPP function and comparing:"
    ]
   },
   {
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_data = PPCalculateSimpleCometaryMagnitude(test_data.copy(), 'r', '')"
+    "test_data = PPCalculateSimpleCometaryMagnitude(test_data.copy(), 'r', rho, delta, alpha)"
    ]
   },
   {
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m_sspp = test_data['H_r']"
+    "m_sspp = test_data['coma_magnitude']"
    ]
   },
   {

--- a/docs/notebooks/demo_CalculateSimpleCometaryMagnitude.ipynb
+++ b/docs/notebooks/demo_CalculateSimpleCometaryMagnitude.ipynb
@@ -70,11 +70,11 @@
    "outputs": [],
    "source": [
     "test_dict = {'MJD': [2459215.5],\n",
-    "              'H_original': [7.3],\n",
+    "              'H_r': [7.3],\n",
     "              'afrho1': [100],\n",
     "              'k':[-2],\n",
     "              'optFilter':'r',\n",
-    "              'seeingFwhmGeom': [1],\n",
+    "              'seeingFwhmEff': [1],\n",
     "              'TrailedSourceMag': 18}\n",
     "\n",
     "test_data = pd.DataFrame(test_dict)\n",

--- a/src/sorcha/modules/PPApplyColourOffsets.py
+++ b/src/sorcha/modules/PPApplyColourOffsets.py
@@ -139,7 +139,7 @@ def PPApplyColourOffsets(observations, function, othercolours, observing_filters
     obsolete_colours = fnmatch.filter(ks, str("?-" + mainfilter))
     observations.drop(obsolete_colours, axis=1, inplace=True)
 
-    # rename H
-    observations.rename(columns={H_col: "H_filter"}, inplace=True)
+    # rename H columns to H_filter (for H in filter) and H_mainfilter (for original H)
+    observations.rename(columns={H_col: "H_filter", "H_original": H_col}, inplace=True)
 
     return observations

--- a/src/sorcha/modules/PPApplyColourOffsets.py
+++ b/src/sorcha/modules/PPApplyColourOffsets.py
@@ -33,6 +33,9 @@ def PPApplyColourOffsets(observations, function, othercolours, observing_filters
 
     H_col = "H_" + mainfilter
 
+    # save original H column: useful for other functions.
+    observations["H_original"] = observations[H_col].copy()
+
     # create a zero-offset column for mainfilter-mainfilter
     observations[mainfilter + "-" + mainfilter] = np.zeros(len(observations))
 

--- a/src/sorcha/modules/PPCalculateApparentMagnitude.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitude.py
@@ -44,12 +44,6 @@ def PPCalculateApparentMagnitude(
     pplogger = logging.getLogger(__name__)
     verboselog = pplogger.info if verbose else lambda *a, **k: None
 
-    if object_type == "comet":
-        verboselog("Calculating cometary magnitude using a simple model and applying colour offset...")
-
-        # calculate coma/tail contribution to the apparent magnitude
-        observations = PPCalculateSimpleCometaryMagnitude(observations, mainfilter, othercolours)
-
     # apply correct colour offset to get H magnitude in observation filter
     # if user is only interested in one filter, we have no colour offsets to apply: assume H is in that filter
     if len(observing_filters) > 1:
@@ -64,7 +58,12 @@ def PPCalculateApparentMagnitude(
     # calculate main body apparent magnitude in observation filter
     verboselog("Calculating apparent magnitude in filter...")
     observations = PPCalculateApparentMagnitudeInFilter(
-        observations, phasefunction, lightcurve_choice=lightcurve_choice
+        observations,
+        phasefunction,
+        mainfilter,
+        observing_filters,
+        lightcurve_choice=lightcurve_choice,
+        object_type=object_type,
     )
 
     return observations

--- a/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
@@ -55,18 +55,22 @@ def PPCalculateApparentMagnitudeInFilter(
 
     # first, get H, rho, delta and alpha as ndarrays
     # delta, rho and alpha are converted to au from kilometres
-    delta = padain["AstRange(km)"].values / 1.495978707e8
+    delta = (padain["AstRange(km)"].values * u.km).to(u.au).value
 
     try:
-        rho = padain["Ast-Sun(km)"] / 1.495978707e8
+        rho = (padain["Ast-Sun(km)"].values * u.km).to(u.au).value
     except KeyError:
         rho = (
-            np.sqrt(
-                padain["Ast-Sun(J2000x)(km)"].values ** 2
-                + padain["Ast-Sun(J2000y)(km)"].values ** 2
-                + padain["Ast-Sun(J2000z)(km)"].values ** 2
+            (
+                np.sqrt(
+                    padain["Ast-Sun(J2000x)(km)"].values ** 2
+                    + padain["Ast-Sun(J2000y)(km)"].values ** 2
+                    + padain["Ast-Sun(J2000z)(km)"].values ** 2
+                )
+                * u.km
             )
-            / 1.495978707e8
+            .to(u.au)
+            .value
         )
 
     alpha = padain["Sun-Ast-Obs(deg)"].values

--- a/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
@@ -5,10 +5,17 @@ from sbpy.photometry import HG, HG1G2, HG12_Pen16, LinearPhaseFunc
 import logging
 
 from sorcha.lightcurves.lightcurve_registration import LC_METHODS
+from .PPCalculateSimpleCometaryMagnitude import PPCalculateSimpleCometaryMagnitude
 
 
 def PPCalculateApparentMagnitudeInFilter(
-    padain, function, colname="TrailedSourceMag", lightcurve_choice=None
+    padain,
+    function,
+    mainfilter,
+    observing_filters,
+    colname="TrailedSourceMag",
+    lightcurve_choice=None,
+    object_type="None",
 ):
     """
     This task calculates the apparent brightness of an object at a given pointing
@@ -46,14 +53,14 @@ def PPCalculateApparentMagnitudeInFilter(
 
     H_col = "H_filter"
 
-    # first, get H, r, delta and alpha as ndarrays
-    # r, delta and alpha are converted to au from kilometres
-    r = padain["AstRange(km)"].values / 1.495978707e8
+    # first, get H, rho, delta and alpha as ndarrays
+    # delta, rho and alpha are converted to au from kilometres
+    delta = padain["AstRange(km)"].values / 1.495978707e8
 
     try:
-        delta = padain["Ast-Sun(km)"] / 1.495978707e8
+        rho = padain["Ast-Sun(km)"] / 1.495978707e8
     except KeyError:
-        delta = (
+        rho = (
             np.sqrt(
                 padain["Ast-Sun(J2000x)(km)"].values ** 2
                 + padain["Ast-Sun(J2000y)(km)"].values ** 2
@@ -66,7 +73,7 @@ def PPCalculateApparentMagnitudeInFilter(
     H = padain[H_col].values
 
     # calculating light curve offset
-    if lightcurve_choice and LC_METHODS.get(lightcurve_choice, False):
+    if LC_METHODS.get(lightcurve_choice, False):
         lc_model = LC_METHODS[lightcurve_choice]()
         lc_shift = lc_model.compute(padain)
         padain["Delta_m"] = lc_shift
@@ -109,7 +116,13 @@ def PPCalculateApparentMagnitudeInFilter(
         )
 
     # apparent magnitude equation: see equation 1 in Schwamb et al. 2023
-    padain[colname] = 5.0 * np.log10(delta) + 5.0 * np.log10(r) + reduced_mag
+    padain[colname] = 5.0 * np.log10(delta) + 5.0 * np.log10(rho) + reduced_mag
+
+    # if comet activity is turned on in configs, this calculates the apparent
+    # magnitude of the coma and combines it with the "nucleus" apparent magnitude
+    # as calculated above
+    if object_type == "comet":
+        padain = PPCalculateSimpleCometaryMagnitude(padain, observing_filters, rho, delta, alpha)
 
     padain = padain.reset_index(drop=True)
 

--- a/src/sorcha/modules/PPCalculateSimpleCometaryMagnitude.py
+++ b/src/sorcha/modules/PPCalculateSimpleCometaryMagnitude.py
@@ -40,7 +40,7 @@ def PPCalculateSimpleCometaryMagnitude(
     # this calculates the coma magnitude in each filter
     for filt in observing_filters:
         padain.loc[padain["optFilter"] == filt, "coma_magnitude"] = com.mag(
-            g, filt, rap=padain["seeingFwhmGeom"], nucleus=False
+            g, filt, rap=padain["seeingFwhmEff"], nucleus=False
         )
 
     padain[colname] = -2.5 * np.log10(

--- a/src/sorcha/modules/PPCalculateSimpleCometaryMagnitude.py
+++ b/src/sorcha/modules/PPCalculateSimpleCometaryMagnitude.py
@@ -6,7 +6,7 @@ import numpy as np
 
 
 def PPCalculateSimpleCometaryMagnitude(
-    padain, observing_filters, rho, delta, alpha, H_col="H_original", colname="TrailedSourceMag"
+    padain, observing_filters, rho, delta, alpha, H_col="H_r", colname="TrailedSourceMag"
 ):
     """
     This task calculates the brightness of the comet at a given pointing

--- a/tests/sorcha/test_PPCalculateApparentMagnitude.py
+++ b/tests/sorcha/test_PPCalculateApparentMagnitude.py
@@ -108,7 +108,7 @@ def test_PPCalculateSimpleCometaryMagnitude():
             "H_r": [15.35, 15.35],
             "afrho1": [1552, 1552],
             "k": [-3.35, -3.35],
-            "seeingFwhmGeom": [8.064748, 3.206723],
+            "seeingFwhmEff": [8.064748, 3.206723],
         }
     )
 
@@ -196,7 +196,7 @@ def test_PPCalculateApparentMagnitude():
             "afrho1": [1552],
             "k": [-3.35],
             "i-r": [-0.12],
-            "seeingFwhmGeom": [1],
+            "seeingFwhmEff": [1.0],
         }
     )
 

--- a/tests/sorcha/test_PPCalculateApparentMagnitude.py
+++ b/tests/sorcha/test_PPCalculateApparentMagnitude.py
@@ -21,7 +21,9 @@ def test_PPCalculateApparentMagnitudeInFilter_default():
         }
     )
 
-    test_observations = PPCalculateApparentMagnitudeInFilter(test_observations.copy(), "none", "output")
+    test_observations = PPCalculateApparentMagnitudeInFilter(
+        test_observations.copy(), "none", "r", "r", colname="output"
+    )
 
     assert_almost_equal(test_observations["output"][0], 12.998891, decimal=5)
 
@@ -48,7 +50,7 @@ def test_PPCalculateApparentMagnitudeInFilterWithIdentityLightcurve():
     )
 
     test_observations = PPCalculateApparentMagnitudeInFilter(
-        test_observations.copy(), "none", "output", "identity"
+        test_observations.copy(), "none", "r", "r", colname="output", lightcurve_choice="identity"
     )
 
     assert_almost_equal(test_observations["output"][0], 12.998891, decimal=5)
@@ -72,10 +74,18 @@ def test_PPCalculateApparentMagnitudeInFilter():
         }
     )
 
-    test_observations = PPCalculateApparentMagnitudeInFilter(test_observations.copy(), "HG", "HG_mag")
-    test_observations = PPCalculateApparentMagnitudeInFilter(test_observations.copy(), "HG12", "HG12_mag")
-    test_observations = PPCalculateApparentMagnitudeInFilter(test_observations.copy(), "HG1G2", "HG1G2_mag")
-    test_observations = PPCalculateApparentMagnitudeInFilter(test_observations.copy(), "linear", "linear_mag")
+    test_observations = PPCalculateApparentMagnitudeInFilter(
+        test_observations.copy(), "HG", "r", "r", colname="HG_mag"
+    )
+    test_observations = PPCalculateApparentMagnitudeInFilter(
+        test_observations.copy(), "HG12", "r", "r", colname="HG12_mag"
+    )
+    test_observations = PPCalculateApparentMagnitudeInFilter(
+        test_observations.copy(), "HG1G2", "r", "r", colname="HG1G2_mag"
+    )
+    test_observations = PPCalculateApparentMagnitudeInFilter(
+        test_observations.copy(), "linear", "r", "r", "linear_mag"
+    )
 
     assert_almost_equal(test_observations["HG_mag"][0], 13.391578, decimal=5)
     assert_almost_equal(test_observations["HG12_mag"][0], 13.387267, decimal=5)
@@ -88,26 +98,27 @@ def test_PPCalculateApparentMagnitudeInFilter():
 def test_PPCalculateSimpleCometaryMagnitude():
     from sorcha.modules.PPCalculateSimpleCometaryMagnitude import PPCalculateSimpleCometaryMagnitude
 
+    # data is for 67P, taken by Colin Snodgrass, and validated against same
+    # abnormally large seeing is to account for Colin's use of an aperture measured at comet distance
+
     cometary_obs = pd.DataFrame(
         {
-            "AstRange(km)": [7.35908481e08],
-            "Ast-Sun(J2000x)(km)": [-5.61871308e08],
-            "Ast-Sun(J2000y)(km)": [-5.47551402e08],
-            "Ast-Sun(J2000z)(km)": [-2.48566276e08],
-            "Sun-Ast-Obs(deg)": [8.899486],
-            "optFilter": ["i"],
-            "H_r": [15.9],
-            "afrho1": [1552],
-            "q": [1.21050916],
-            "k": [-3.35],
-            "i-r": [-0.12],
+            "optFilter": ["r", "r"],
+            "TrailedSourceMag": [19.676259, 22.748274],
+            "H_original": [15.35, 15.35],
+            "afrho1": [1552, 1552],
+            "k": [-3.35, -3.35],
+            "seeingFwhmGeom": [8.064748, 3.206723],
         }
     )
 
-    df_comet = PPCalculateSimpleCometaryMagnitude(cometary_obs, "r", ["i-r"])
+    rho = [1.260000, 4.889116]
+    delta = [1.709000, 4.298050]
+    alpha = [35.100000, 10.339021]
 
-    assert_almost_equal(df_comet["coma"].values[0], 24.82220145)
-    assert_almost_equal(df_comet["H_r"].values[0], 15.89970705)
+    df_comet = PPCalculateSimpleCometaryMagnitude(cometary_obs, ["r"], rho, delta, alpha)
+
+    assert_almost_equal(df_comet["TrailedSourceMag"], [13.516, 22.010], decimal=3)
 
     return
 
@@ -183,9 +194,9 @@ def test_PPCalculateApparentMagnitude():
             "H_r": [15.9],
             "GS": [0.19],
             "afrho1": [1552],
-            "q": [1.21050916],
             "k": [-3.35],
             "i-r": [-0.12],
+            "seeingFwhmGeom": [1],
         }
     )
 
@@ -226,8 +237,8 @@ def test_PPCalculateApparentMagnitude():
     asteroid_out = PPCalculateApparentMagnitude(asteroid_obs, "HG", "r", ["i-r"], ["r", "i"], "none")
     asteroid_single = PPCalculateApparentMagnitude(asteroid_obs_single, "HG", "r", ["r-r"], ["r"], "none")
 
-    assert_almost_equal(comet_out["coma"].values[0], 24.822201, decimal=6)
-    assert_almost_equal(comet_out["TrailedSourceMag"].values[0], 23.527587, decimal=6)
+    assert_almost_equal(comet_out["H_filter"].values[0], 15.78, decimal=6)
+    assert_almost_equal(comet_out["TrailedSourceMag"].values[0], 23.210883, decimal=6)
 
     assert_almost_equal(asteroid_out["TrailedSourceMag"].values[0], 13.281578, decimal=6)
     assert_almost_equal(asteroid_out["H_filter"].values[0], 7.19, decimal=6)

--- a/tests/sorcha/test_PPCalculateApparentMagnitude.py
+++ b/tests/sorcha/test_PPCalculateApparentMagnitude.py
@@ -105,7 +105,7 @@ def test_PPCalculateSimpleCometaryMagnitude():
         {
             "optFilter": ["r", "r"],
             "TrailedSourceMag": [19.676259, 22.748274],
-            "H_original": [15.35, 15.35],
+            "H_r": [15.35, 15.35],
             "afrho1": [1552, 1552],
             "k": [-3.35, -3.35],
             "seeingFwhmGeom": [8.064748, 3.206723],


### PR DESCRIPTION
Fixes #491.
Fixes #485.

- PPCalculateSimpleCometaryMagnitude is now called within PPCalculateApparentMagnitudeInFilter, at the end.
- It now correctly combines the coma apparent magnitude with the "nucleus" apparent magnitude, rather than the absolute magnitude.
- The aperture used to calculate the coma magnitude is now the seeing (seeingFwhmEff).
- H_mainfilter is now preserved in the dataframe instead of overwritten in PPApplyColourOffsets.
- I renamed rho and delta in PPCalculateApparentMagnitudeInFilter to be consistent with usual usage.
- Unit tests updated. test_PPCalculateSimpleCometaryMagnitude now checks _two_ distances for a known comet (67P).
- Demo notebooks updated.
- PPCalculateApparentMagnitudeInFilter now uses astropy units to perform conversion from km to au, instead of hardcoded numbers.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
