### PR TITLE
Small issues: #499, #498, #489, #488

### DIFF
--- a/src/sorcha/readers/CSVReader.py
+++ b/src/sorcha/readers/CSVReader.py
@@ -74,10 +74,10 @@ class CSVDataReader(ObjectDataReader):
 
         pplogger = logging.getLogger(__name__)
         pplogger.error(
-            "ERROR: OIFCSVReader: column headings not found. Ensure column headings exist in OIF output and first column is ObjID."
+            "ERROR: CSVReader: column headings not found. Ensure column headings exist in input files and first column is ObjID."
         )
         sys.exit(
-            "ERROR: OIFCSVReader: column headings not found. Ensure column headings exist in OIF output and first column is ObjID."
+            "ERROR: CSVReader: column headings not found. Ensure column headings exist in input files and first column is ObjID."
         )
         return 0
 

--- a/src/sorcha/readers/OrbitAuxReader.py
+++ b/src/sorcha/readers/OrbitAuxReader.py
@@ -68,16 +68,4 @@ class OrbitAuxReader(CSVDataReader):
             ["INDEX", "N_PAR", "MOID", "COMPCODE", "FORMAT"], axis=1, errors="ignore"
         )
 
-        # Check if there is q in the resulting dataframe.
-        if "q" not in input_table.columns:
-            if "a" not in input_table.columns or "e" not in input_table.columns:
-                pplogger.error(
-                    "ERROR: OrbitAuxReader: unable to join ephemeris simulation and orbital parameters: no a or e in input."
-                )
-                sys.exit(
-                    "ERROR: OrbitAuxReader: unable to join ephemeris simulation and orbital parameters: no a or e in input."
-                )
-            else:
-                input_table["q"] = input_table["a"] * (1.0 - input_table["e"])
-
         return input_table

--- a/tests/readers/test_OrbitAuxReader.py
+++ b/tests/readers/test_OrbitAuxReader.py
@@ -55,19 +55,3 @@ def test_OrbitAuxReader():
         reader = OrbitAuxReader(get_test_filepath("testorb.csv"), "whitespace")
         _ = reader.read_rows(0, 14)
     assert e2.type == SystemExit
-
-
-def test_OrbitAuxReader_no_q():
-    reader = OrbitAuxReader(get_test_filepath("testorb_no_q.csv"), "csv")
-    orbit_df = reader.read_rows()
-    assert_equal(len(orbit_df), 5)
-    assert reader.get_reader_info() == "OrbitAuxReader:" + get_test_filepath("testorb_no_q.csv")
-
-    # Check that we modify the columns (i -> incl, etc.) and include a q column.
-    expected_columns = np.array(
-        ["ObjID", "a", "e", "incl", "node", "argperi", "t_p", "t_0", "q"], dtype=object
-    )
-    assert_equal(expected_columns, orbit_df.columns.values)
-
-    # Check that the first q value is approximately what we expect.
-    assert pytest.approx(0.952105479028) == orbit_df.iloc[0]["q"]


### PR DESCRIPTION
Fixes #499.
Changed the error message in CSVReader that triggers if ObjID doesn't exist in one of the input files to make it clear that the error could be in any of the input files, not just the OIF output/ephemeris.

Fixes #498.
Removed the calculation of q in OrbitAuxReader as it turns out we _don't_ actually require it. I also removed the unit test that tested this.

Fixes #489.
Changed PPAddUncertainties line 159 to use astropy.units to convert from mas to degrees. This brings it in line with recent changes to PPCalculateApparentMagnitudeInFilter.

Fixes #488.
PPAddUncertainties now uses the np functions np.log10, np.sqrt and np.power explicitly, instead of setting them as variables.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
