### PR TITLE
Initial scaffolding commit for plugable cometary activity models.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,6 @@ write_to = "src/sorcha/_version.py"
 [tool.pytest.ini_options]
 testpaths = [
     "tests",
-    "src/sorcha",
 ]
 
 [tool.black]

--- a/src/sorcha/activity/__init__.py
+++ b/src/sorcha/activity/__init__.py
@@ -1,0 +1,4 @@
+from .base_activity import AbstractCometaryActivity
+from .identity_activity import IdentityCometaryActivity
+
+from .activity_registration import register_activity_subclasses, update_activity_subclasses, CA_METHODS

--- a/src/sorcha/activity/activity_registration.py
+++ b/src/sorcha/activity/activity_registration.py
@@ -1,0 +1,46 @@
+from sorcha.activity.base_activity import AbstractCometaryActivity
+from typing import Callable, Dict
+
+
+def register_activity_subclasses() -> Dict[str, Callable]:
+    """This method will identify all of the subclasses of ``AbstractCometaryActivity``
+    and build a dictionary that maps ``name : subclass``.
+
+    Returns
+    -------
+    dict
+        A dictionary of all of subclasses of ``AbstractCometaryActivity``. Where
+        the string returned from ``subclass.name_id()`` is the key, and the
+        subclass is the value.
+
+    Raises
+    ------
+    ValueError
+        If a duplicate key is found, a ``ValueError`` is raised. This would
+        likely occur if a user copy/pasted an existing subclass but failed to
+        update the string returned from ``name_id()``.
+    """
+    subclass_dict = {}
+    for subcls in AbstractCometaryActivity.__subclasses__():
+        if subcls.name_id() in subclass_dict:
+            raise ValueError(
+                "Attempted to add duplicate cometary activity calculator name to CA_METHODS: "
+                + str(subcls.name_id())
+            )
+
+        subclass_dict[subcls.name_id()] = subcls
+
+    return subclass_dict
+
+
+def update_activity_subclasses() -> None:
+    """This function is used to register newly created subclasses of the
+    `AbstractCometaryActivity`.
+    """
+    for subcls in AbstractCometaryActivity.__subclasses__():
+        if subcls.name_id() not in CA_METHODS.keys():
+            CA_METHODS[subcls.name_id()] = subcls
+
+
+# The dictionary of all available subclasses of the AbstractCometaryActivity.
+CA_METHODS = register_activity_subclasses()

--- a/src/sorcha/activity/base_activity.py
+++ b/src/sorcha/activity/base_activity.py
@@ -1,23 +1,16 @@
 from abc import ABC, abstractmethod
-from typing import List
-import numpy as np
 import pandas as pd
+import numpy as np
 
 
-class AbstractLightCurve(ABC):
-    """Abstract base class for lightcurve models"""
+class AbstractCometaryActivity(ABC):
+    """Abstract base class for cometary activity models"""
 
-    def __init__(self, required_column_names: List[str] = []) -> None:
+    def __init__(self) -> None:
         """Abstract base class accepts a list of column names that are required
         to be present in the Pandas dataframe passed to the ``compute`` method.
-
-        Parameters
-        ----------
-        required_column_names : list, optional
-            The list of columns in ``observations`` dataframe that are required
-            for the model calculation, by default []
         """
-        self.required_column_names = required_column_names
+        self.required_column_names = []
 
     @abstractmethod
     def compute(self, df: pd.DataFrame) -> np.array:

--- a/src/sorcha/activity/identity_activity.py
+++ b/src/sorcha/activity/identity_activity.py
@@ -1,0 +1,55 @@
+from sorcha.activity.base_activity import AbstractCometaryActivity
+import pandas as pd
+
+"""
+!!!!!!!!!!!!!!!!
+FOR TESTING ONLY
+!!!!!!!!!!!!!!!!
+"""
+
+
+class IdentityCometaryActivity(AbstractCometaryActivity):
+    """
+    !!! THIS SHOULD NEVER BE USED - FOR TESTING ONLY !!!
+
+    Rudimentary cometary activity model that returns no change to the input ``observation``
+    dataframe.
+    This class is explicitly created for testing purposes.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    def compute(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Returns numpy array of 0's with shape equal to the input dataframe
+        time column.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            The ``observations`` dataframe provided by ``Sorcha``.
+
+        Returns
+        -------
+        pd.DataFrame
+            The original ``observations`` dataframe, unchanged.
+        """
+
+        self._validate_column_names(df)
+
+        return df
+
+    @staticmethod
+    def name_id() -> str:
+        """Returns the string identifier for this cometary activity method. It
+        must be unique within all the subclasses of ``AbstractCometaryActivity``.
+
+        We have chosen the name "identity" here because the input dataframe is
+        returned unchanged.
+
+        Returns
+        -------
+        str
+            Unique identifier for this cometary activity model
+        """
+        return "identity"

--- a/tests/activity/test_activity_registration.py
+++ b/tests/activity/test_activity_registration.py
@@ -1,0 +1,42 @@
+import pytest
+from sorcha.activity.activity_registration import (
+    register_activity_subclasses,
+    update_activity_subclasses,
+    CA_METHODS,
+)
+from sorcha.activity.base_activity import AbstractCometaryActivity
+
+
+def test_register_subclasses():
+    output = register_activity_subclasses()
+
+    assert output == CA_METHODS
+
+
+def test_register_subclasses_with_duplicate():
+    class dup_identity(AbstractCometaryActivity):
+        def compute(self):
+            return 1
+
+        @staticmethod
+        def name_id():
+            return "identity"
+
+    with pytest.raises(ValueError) as excinfo:
+        _ = register_activity_subclasses()
+
+    assert "duplicate cometary activity calculator name to CA_METHODS: identity" in str(excinfo.value)
+
+
+def test_update_subclasses():
+    class test_activity(AbstractCometaryActivity):
+        def compute(self):
+            return 1
+
+        @staticmethod
+        def name_id():
+            return "test_ca"
+
+    update_activity_subclasses()
+
+    assert CA_METHODS["test_ca"] == test_activity


### PR DESCRIPTION
Foundational work to address #457  .

This PR introduces nearly identical scaffolding to support user provided, pluggable, cometary activity models. Here we have an abstract base class as well as a "identity" class for testing that returns the input dataframe unchanged. Additionally, the registration utility has been implemented as have tests for that. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
