### PR TITLE
Investigating bench_lca

### DIFF
--- a/demo/bench_LCA.py
+++ b/demo/bench_LCA.py
@@ -5,19 +5,20 @@ import pstats
 
 from pstats import SortKey
 from sorcha.sorcha import runLSSTPostProcessing  # noqa: F401
+from sorcha_community_utils.lightcurve.sinusoidal.sinusoidal_lightcurve import SinusoidalLightCurve
 import argparse
 
 if __name__ == "__main__":  # pragma: no cover
     # Parse the command line arguments.
     parser = argparse.ArgumentParser()
-    parser.add_argument("--object_type", default="mba", help="The type of objects to test (mba or tno).")
+    parser.add_argument("--object_type", default="tno", help="The type of objects to test (mba or tno).")
     args = parser.parse_args()
 
     cmd_args_dict = {
         "paramsinput": f"./{args.object_type}_sample_1000_physical_lca.csv",
         "orbinfile": f"./{args.object_type}_sample_1000_orbit.csv",
         "oifoutput": f"./{args.object_type}_sample_1000_eph.csv",
-        "configfile": "./OIFconfig_benchmark.ini",
+        "configfile": "./OIFconfig_lca.ini",
         "outpath": "../data/out",
         "makeTemporaryEphemerisDatabase": False,
         "readTemporaryEphemerisDatabase": False,


### PR DESCRIPTION
I made a couple of changes to the bench_lca module so that I could experiment with importing lightcurve models from sorcha_community_utils. 

NOTE: In my virtual environment I also needed to `pip install sorcha-community-utils` as well. 

When I run `bench_lca.py` locally with these changes, I get the following error: 

```
(sorcha) drew@allosaurus:~/code/sorcha/demo$ /home/drew/miniconda3/envs/sorcha/bin/python /home/drew/code/sorcha/demo/bench_LCA.py
Traceback (most recent call last):
  File "/home/drew/code/sorcha/demo/bench_LCA.py", line 31, in <module>
    cProfile.run("runLSSTPostProcessing(cmd_args_dict)", "../data/out/restats")
  File "/home/drew/miniconda3/envs/sorcha/lib/python3.10/cProfile.py", line 17, in run
    return _pyprofile._Utils(Profile).run(statement, filename, sort)
  File "/home/drew/miniconda3/envs/sorcha/lib/python3.10/profile.py", line 54, in run
    prof.run(statement)
  File "/home/drew/miniconda3/envs/sorcha/lib/python3.10/cProfile.py", line 96, in run
    return self.runctx(cmd, dict, dict)
  File "/home/drew/miniconda3/envs/sorcha/lib/python3.10/cProfile.py", line 101, in runctx
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "/home/drew/code/sorcha/src/sorcha/sorcha.py", line 154, in runLSSTPostProcessing
    observations = PPCalculateApparentMagnitude(
  File "/home/drew/code/sorcha/src/sorcha/modules/PPCalculateApparentMagnitude.py", line 60, in PPCalculateApparentMagnitude
    observations = PPCalculateApparentMagnitudeInFilter(
  File "/home/drew/code/sorcha/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py", line 99, in PPCalculateApparentMagnitudeInFilter
    reduced_mag = HGm(alpha * u.deg).value
AttributeError: 'numpy.ndarray' object has no attribute 'value'
```

Which stems from `PPCalculateApparentMagnitudeInFilter` and I'm not sure why. 

When I run unit tests, even modifying them to make use of the sinusoidal lightcurve model, the tests pass as expected. I'm not sure if this is a product of the mistake that you mentioned earlier today (Aug 2) @bernardinelli, maybe? 

It's not clear to me why `HGm` in this case would be a numpy array. 