### PR TITLE
Update error logging, use `comet_activity` config value, register all cometary activity subclasses in Sorcha 

### DIFF
--- a/demo/OIFconfig_benchmark.ini
+++ b/demo/OIFconfig_benchmark.ini
@@ -33,7 +33,8 @@ size_serial_chunk = 100
 [ACTIVITY]
 
 # Flag for cometary activity. If not none, a cometary parameters file ust be specified at the command line.
-# Options: none, comet
+# Value is expected to be the unique name of the activity model to use.
+# The unique name is defined in the ``name_id`` method of the subclasses of AbstractCometaryActivity
 comet_activity = none
 
 

--- a/demo/OIFconfig_lca.ini
+++ b/demo/OIFconfig_lca.ini
@@ -33,7 +33,8 @@ size_serial_chunk = 100
 [ACTIVITY]
 
 # Flag for cometary activity. If not none, a cometary parameters file ust be specified at the command line.
-# Options: none, comet
+# Value is expected to be the unique name of the activity model to use.
+# The unique name is defined in the ``name_id`` method of the subclasses of AbstractCometaryActivity
 comet_activity = none
 
 

--- a/demo/PPConfig_test.ini
+++ b/demo/PPConfig_test.ini
@@ -34,7 +34,8 @@ pointing_database = ./demo/baseline_v2.0_1yr.db
 [ACTIVITY]
 
 # Flag for cometary activity. If not none, a cometary parameters file ust be specified at the command line.
-# Options: none, comet
+# Value is expected to be the unique name of the activity model to use.
+# The unique name is defined in the ``name_id`` method of the subclasses of AbstractCometaryActivity
 comet_activity = none
 
 

--- a/src/sorcha/activity/base_activity.py
+++ b/src/sorcha/activity/base_activity.py
@@ -1,7 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import List
+import logging
 import pandas as pd
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 class AbstractCometaryActivity(ABC):
@@ -42,7 +45,29 @@ class AbstractCometaryActivity(ABC):
         """
         for colname in self.required_column_names:
             if colname not in df.columns:
-                raise (ValueError, f"Input dataframe is missing column %{colname}")
+                err_msg = f"Input dataframe is missing column %{colname}"
+                self._log_error_message(error_msg=err_msg)
+                raise (ValueError, err_msg)
+
+    def _log_exception(self, exception: Exception) -> None:
+        """Log an error message from an exception to the error log file
+
+        Parameters
+        ----------
+        exception : Exception
+            The exception with a value string to appended to the error log
+        """
+        self._log_error_message(str(exception.value))
+
+    def _log_error_message(self, error_msg: str) -> None:
+        """Log a specific error string to the error log file
+
+        Parameters
+        ----------
+        error_msg : str
+            The string to be appended to the error log
+        """
+        logger.error(error_msg)
 
     @staticmethod
     @abstractmethod

--- a/src/sorcha/lightcurves/base_lightcurve.py
+++ b/src/sorcha/lightcurves/base_lightcurve.py
@@ -1,7 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import List
+import logging
 import numpy as np
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 
 class AbstractLightCurve(ABC):
@@ -42,7 +45,29 @@ class AbstractLightCurve(ABC):
         """
         for colname in self.required_column_names:
             if colname not in df.columns:
-                raise (ValueError, f"Input dataframe is missing column %{colname}")
+                err_msg = f"Input dataframe is missing column %{colname}"
+                self._log_error_message(error_msg=err_msg)
+                raise (ValueError, err_msg)
+
+    def _log_exception(self, exception: Exception) -> None:
+        """Log an error message from an exception to the error log file
+
+        Parameters
+        ----------
+        exception : Exception
+            The exception with a string to appended to the error log
+        """
+        self._log_error_message(str(exception))
+
+    def _log_error_message(self, error_msg: str) -> None:
+        """Log a specific error string to the error log file
+
+        Parameters
+        ----------
+        error_msg : str
+            The string to be appended to the error log
+        """
+        logger.error(error_msg)
 
     @staticmethod
     @abstractmethod

--- a/src/sorcha/modules/PPCalculateApparentMagnitude.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitude.py
@@ -10,7 +10,7 @@ def PPCalculateApparentMagnitude(
     mainfilter,
     othercolours,
     observing_filters,
-    object_type,
+    cometary_activity_choice=None,
     lightcurve_choice=None,
     verbose=False,
 ):
@@ -30,7 +30,7 @@ def PPCalculateApparentMagnitude(
 
     observing_filters (list of strings): list of observation filters of interest.
 
-    object_type (string): type of object for cometary activity. Either 'comet' or 'none'.
+    cometary_activity_choice (string): type of object for cometary activity. Either 'comet' or 'none'.
 
     lc_choice (string): choice of lightcurve model. Default None
 
@@ -62,7 +62,7 @@ def PPCalculateApparentMagnitude(
         phasefunction,
         observing_filters,
         lightcurve_choice=lightcurve_choice,
-        object_type=object_type,
+        cometary_activity_choice=cometary_activity_choice,
     )
 
     return observations

--- a/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
@@ -14,7 +14,7 @@ def PPCalculateApparentMagnitudeInFilter(
     observing_filters,
     colname="TrailedSourceMag",
     lightcurve_choice=None,
-    object_type="None",
+    cometary_activity_choice=None,
 ):
     """
     This task calculates the apparent brightness of an object at a given pointing
@@ -123,8 +123,10 @@ def PPCalculateApparentMagnitudeInFilter(
     # if comet activity is turned on in configs, this calculates the apparent
     # magnitude of the coma and combines it with the "nucleus" apparent magnitude
     # as calculated above
-    if object_type == "comet":
-        padain = PPCalculateSimpleCometaryMagnitude(padain, observing_filters, rho, delta, alpha)
+    if cometary_activity_choice:
+        padain = PPCalculateSimpleCometaryMagnitude(
+            padain, observing_filters, rho, delta, alpha, activity_choice=cometary_activity_choice
+        )
 
     padain = padain.reset_index(drop=True)
 

--- a/src/sorcha/modules/PPCalculateSimpleCometaryMagnitude.py
+++ b/src/sorcha/modules/PPCalculateSimpleCometaryMagnitude.py
@@ -25,11 +25,11 @@ def PPCalculateSimpleCometaryMagnitude(
         The photometric filters the observation is taken in (the filter
         requested that the coma magnitude be calculated for)
     rho : List[float]
-        Heliocentric distance
+        Heliocentric distance [units au]
     delta : List[float]
-        Distance to Earth
+        Distance to Earth [units au]
     alpha : List[float]
-
+        Phase angle [units degrees]
     activity_choice : str, optional
         The activity model to use, by default None
 

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -32,6 +32,7 @@ from sorcha.readers.CSVReader import CSVDataReader
 from sorcha.readers.OIFReader import OIFDataReader
 from sorcha.readers.OrbitAuxReader import OrbitAuxReader
 
+from sorcha.activity.activity_registration import update_activity_subclasses
 from sorcha.lightcurves.lightcurve_registration import update_lc_subclasses
 
 from sorcha.utilities.sorchaArguments import sorchaArguments
@@ -56,6 +57,7 @@ def runLSSTPostProcessing(cmd_args):
     """
 
     update_lc_subclasses()
+    update_activity_subclasses()
 
     # Initialise argument parser and assign command line arguments
 

--- a/survey_setups/Rubin_circular_approximation.ini
+++ b/survey_setups/Rubin_circular_approximation.ini
@@ -34,7 +34,8 @@ pointing_database = ./baseline_v3.0_10yrs.db
 [ACTIVITY]
 
 # Flag for cometary activity. If not none, a cometary parameters file must be specified at the command line.
-# Options: none, comet
+# Value is expected to be the unique name of the activity model to use.
+# The unique name is defined in the ``name_id`` method of the subclasses of AbstractCometaryActivity
 comet_activity = none
 
 

--- a/survey_setups/Rubin_full_footprint.ini
+++ b/survey_setups/Rubin_full_footprint.ini
@@ -34,7 +34,8 @@ pointing_database = ./baseline_v3.0_10yrs.db
 [ACTIVITY]
 
 # Flag for cometary activity. If not none, a cometary parameters file must be specified at the command line.
-# Options: none, comet
+# Value is expected to be the unique name of the activity model to use.
+# The unique name is defined in the ``name_id`` method of the subclasses of AbstractCometaryActivity
 comet_activity = none
 
 

--- a/tests/activity/test_base_activity.py
+++ b/tests/activity/test_base_activity.py
@@ -1,0 +1,11 @@
+from sorcha.activity.activity_registration import CA_METHODS
+
+
+def test_send_error_message():
+    identity_activity = CA_METHODS["identity"]()
+    identity_activity._log_error_message("Test error")
+
+
+def test_sent_exception():
+    identity_activity = CA_METHODS["identity"]()
+    identity_activity._log_error_message(KeyError("Test key error"))

--- a/tests/data/test_PPConfig.ini
+++ b/tests/data/test_PPConfig.ini
@@ -34,7 +34,8 @@ pointing_database = ./baseline_10klines_2.0.db
 [ACTIVITY]
 
 # Flag for cometary activity. If not none, a cometary parameters file must be specified at the command line.
-# Options: none, comet
+# Value is expected to be the unique name of the activity model to use.
+# The unique name is defined in the ``name_id`` method of the subclasses of AbstractCometaryActivity
 comet_activity = none
 
 
@@ -165,4 +166,4 @@ pointing_sql_query = SELECT observationId, observationStartMJD, filter, seeingFw
 #magnitude_limit = 22.0
 
 # The unique name of the lightcurve model to use. Defined in the ``name_id`` method of the subclasses of AbstractLightCurve
-lc_model = None
+lc_model = none

--- a/tests/lightcurves/test_base_lightcurve.py
+++ b/tests/lightcurves/test_base_lightcurve.py
@@ -1,0 +1,11 @@
+from sorcha.lightcurves.lightcurve_registration import LC_METHODS
+
+
+def test_send_error_message():
+    identity_activity = LC_METHODS["identity"]()
+    identity_activity._log_error_message("Test error")
+
+
+def test_sent_exception():
+    identity_activity = LC_METHODS["identity"]()
+    identity_activity._log_error_message(KeyError("Test key error"))

--- a/tests/sorcha/test_PPConfigParser.py
+++ b/tests/sorcha/test_PPConfigParser.py
@@ -39,7 +39,7 @@ def test_PPConfigFileParser(setup_and_teardown_for_PPConfigFileParser):
         "ephemerides_type": "oif",
         "pointing_database": "./baseline_10klines_2.0.db",
         "pointing_sql_query": "SELECT observationId, observationStartMJD, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId",
-        "comet_activity": "none",
+        "comet_activity": None,
         "observing_filters": ["r", "g", "i", "z"],
         "phase_function": "HG",
         "trailing_losses_on": True,


### PR DESCRIPTION
Fixes #486 #507 #511 #512 

This PR addresses several small, related issues. 

#486 - We will now warn the user, and terminate the program with messages emitted to the error log file as well as terminal when the user has requested a lightcurve or comet activity model that has not been registered. The error message in the logs and on the command line will look something like this: 
```
2023-08-09 13:39:36,731 root         ERROR    The requested comet activity model, 'stinky', is not registered. Available comet activity models are: ['identity', 'lsst_comet']
```

#507 - I've reused the existing `comet_activity` config parameter such that it can be used to select one of the available cometary activity models. The name has not changed, but the parsing logic in PPConfigParser has been updated to support more than the original two options ('comet' and 'none')

#511 - In the same way that we have to update the dictionary of available lightcurve models, we need to do the same thing for the cometary activity models. This is accomplished by calling `update_activity_subclasses()` as one of the first commands in the `runLSSTPostProcessing` function. 

#512 - If the user has not provided the necessary columns for either a lightcurve model or a cometary activity model, we will log that in the error log file using the new methods (`_log_exception`, `_log_error_message`) in the  `AbstractLightCurve` and `AbstractCometaryActivity` classes.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
