### PR TITLE
Change log file name

### DIFF
--- a/src/sorcha/modules/PPGetLogger.py
+++ b/src/sorcha/modules/PPGetLogger.py
@@ -7,8 +7,8 @@ def PPGetLogger(
     log_location,
     log_format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s ",
     log_name="",
-    log_file_info="postprocessing.log",
-    log_file_error="postprocessing.err",
+    log_file_info="sorcha.log",
+    log_file_error="sorcha.err",
 ):
     """
     Initialises log and error files.

--- a/tests/sorcha/test_PPConfigParser.py
+++ b/tests/sorcha/test_PPConfigParser.py
@@ -289,7 +289,7 @@ def test_PPPrintConfigsToLog(tmp_path):
 
     PPPrintConfigsToLog(configs, args)
 
-    datalog = glob.glob(os.path.join(tmp_path, "*-postprocessing.log"))
+    datalog = glob.glob(os.path.join(tmp_path, "*-sorcha.log"))
 
     testfile = open(os.path.join(test_path, "test_PPPrintConfigsToLog.txt"), mode="r")
     newfile = open(datalog[0], mode="r")

--- a/tests/sorcha/test_PPGetLogger.py
+++ b/tests/sorcha/test_PPGetLogger.py
@@ -7,8 +7,8 @@ def test_PPGetLogger(tmp_path):
 
     PPGetLogger(tmp_path)
 
-    errlog = glob.glob(os.path.join(tmp_path, "*-postprocessing.err"))
-    datalog = glob.glob(os.path.join(tmp_path, "*-postprocessing.log"))
+    errlog = glob.glob(os.path.join(tmp_path, "*-sorcha.err"))
+    datalog = glob.glob(os.path.join(tmp_path, "*-sorcha.log"))
 
     assert os.path.exists(errlog[0])
     assert os.path.exists(datalog[0])


### PR DESCRIPTION
Fixes #539

Changes the log file names from postprocessing to sorcha

- [ ] Does pip install still work?
- [X] Have you written a unit test for any new functions?
- [X] Do all the units tests run successfully?
- [X] Does Sorcha run successfully on a test set of input files/databases?
- [X] Have you used black on the files you have updated to confirm python programming style guide enforcement?
