### PR TITLE
Move the logging earlier

### DIFF
--- a/src/sorcha/modules/PPCommandLineParser.py
+++ b/src/sorcha/modules/PPCommandLineParser.py
@@ -110,4 +110,9 @@ def PPCommandLineParser(args):
             )
         )
 
+    # If verbose logging is on, log all the command line settings to INFO.
+    if args.v:
+        for flag, value in cmd_args_dict.items():
+            pplogger.info(f"Using commandline setting {flag} = {value}")
+
     return cmd_args_dict

--- a/src/sorcha/modules/PPCommandLineParser.py
+++ b/src/sorcha/modules/PPCommandLineParser.py
@@ -110,9 +110,8 @@ def PPCommandLineParser(args):
             )
         )
 
-    # If verbose logging is on, log all the command line settings to INFO.
-    if args.v:
-        for flag, value in cmd_args_dict.items():
-            pplogger.info(f"Using commandline setting {flag} = {value}")
+    # Log all the command line settings to INFO.
+    for flag, value in cmd_args_dict.items():
+        pplogger.info(f"Using commandline setting {flag} = {value}")
 
     return cmd_args_dict

--- a/tests/sorcha/test_PPGetLogger.py
+++ b/tests/sorcha/test_PPGetLogger.py
@@ -1,16 +1,42 @@
 import glob
 import os
+import pytest
+import tempfile
 
 
-def test_PPGetLogger(tmp_path):
+def test_PPGetLogger():
     from sorcha.modules.PPGetLogger import PPGetLogger
 
-    PPGetLogger(tmp_path)
+    with tempfile.TemporaryDirectory() as dir_name:
+        pplogger = PPGetLogger(dir_name)
 
-    errlog = glob.glob(os.path.join(tmp_path, "*-sorcha.err"))
-    datalog = glob.glob(os.path.join(tmp_path, "*-sorcha.log"))
+        # Check that the files get created.
+        errlog = glob.glob(os.path.join(dir_name, "*-sorcha.err"))
+        datalog = glob.glob(os.path.join(dir_name, "*-sorcha.log"))
 
-    assert os.path.exists(errlog[0])
-    assert os.path.exists(datalog[0])
+        assert os.path.exists(errlog[0])
+        assert os.path.exists(datalog[0])
 
-    return
+        # Log some information.
+        pplogger.info("Test1")
+        pplogger.info("Test2")
+        pplogger.error("Error1")
+        pplogger.info("Test3")
+
+        # Check that all five lines exist in the INFO file.
+        with open(datalog[0], "r") as f_info:
+            log_data = f_info.read()
+            print(log_data)
+            assert "Test1" in log_data
+            assert "Test2" in log_data
+            assert "Error1" in log_data
+            assert "Test3" in log_data
+
+        # Check that only error and critical lines exist in the ERROR file.
+        with open(errlog[0], "r") as f_err:
+            log_data = f_err.read()
+            print(log_data)
+            assert "Test1" not in log_data
+            assert "Test2" not in log_data
+            assert "Error1" in log_data
+            assert "Test3" not in log_data

--- a/tests/sorcha/test_PPGetLogger.py
+++ b/tests/sorcha/test_PPGetLogger.py
@@ -26,7 +26,6 @@ def test_PPGetLogger():
         # Check that all five lines exist in the INFO file.
         with open(datalog[0], "r") as f_info:
             log_data = f_info.read()
-            print(log_data)
             assert "Test1" in log_data
             assert "Test2" in log_data
             assert "Error1" in log_data
@@ -35,7 +34,6 @@ def test_PPGetLogger():
         # Check that only error and critical lines exist in the ERROR file.
         with open(errlog[0], "r") as f_err:
             log_data = f_err.read()
-            print(log_data)
             assert "Test1" not in log_data
             assert "Test2" not in log_data
             assert "Error1" in log_data


### PR DESCRIPTION
Fixes #544 

Moves the logging earlier in the code flow to allow it to pick up info and errors during command line parsing. Also adds more comprehensive testing of the logging.

- [ ] Does pip install still work?
- [X] Have you written a unit test for any new functions?
- [X] Do all the units tests run successfully?
- [X] Does Sorcha run successfully on a test set of input files/databases?
- [X] Have you used black on the files you have updated to confirm python programming style guide enforcement?
