### PR TITLE
A series of improvements to the argument parsing

### DIFF
--- a/src/sorcha/modules/PPCommandLineParser.py
+++ b/src/sorcha/modules/PPCommandLineParser.py
@@ -26,10 +26,11 @@ def PPCommandLineParser(args):
     cmd_args_dict = {}
 
     cmd_args_dict["paramsinput"] = PPFindFileOrExit(args.p, "-p, --params")
-    cmd_args_dict["orbinfile"] = PPFindFileOrExit(args.o, "-o, --orbit")
+    cmd_args_dict["orbinfile"] = PPFindFileOrExit(args.ob, "-ob, --orbit")
     cmd_args_dict["oifoutput"] = PPFindFileOrExit(args.e, "-e, --ephem")
     cmd_args_dict["configfile"] = PPFindFileOrExit(args.c, "-c, --config")
-    cmd_args_dict["outpath"] = PPFindFileOrExit(args.u, "-u, --outfile")
+    cmd_args_dict["outpath"] = PPFindFileOrExit(args.o, "-o, --outfile")
+    cmd_args_dict["pointing_database"] = PPFindFileOrExit(args.pd, "-pd, --pointing_database")
 
     if args.cp:
         cmd_args_dict["complex_physical_parameters"] = PPFindFileOrExit(

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -371,12 +371,10 @@ def main():
         dest="cp",
     )
     optional.add_argument(
-        "-dw",
-        help="Make temporary ephemeris database. If no filepath/name supplied, default name and ephemeris input location used.",
-        dest="dw",
-        nargs="?",
-        const="default",
-        type=str,
+        "-dl",
+        help="Delete the temporary ephemeris database after code has completed.",
+        action="store_true",
+        default=False,
     )
     optional.add_argument(
         "-dr",
@@ -385,10 +383,12 @@ def main():
         type=str,
     )
     optional.add_argument(
-        "-dl",
-        help="Delete the temporary ephemeris database after code has completed.",
-        action="store_true",
-        default=False,
+        "-dw",
+        help="Make temporary ephemeris database. If no filepath/name supplied, default name and ephemeris input location used.",
+        dest="dw",
+        nargs="?",
+        const="default",
+        type=str,
     )
     optional.add_argument(
         "-f",

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -302,8 +302,9 @@ def main():
           -f, --force        Force deletion/overwrite of existing output file(s). Default False.
     """
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    required = parser.add_argument_group("Required arguments")
+    required.add_argument(
         "-c",
         "--config",
         help="Input configuration file name",
@@ -311,42 +312,23 @@ def main():
         dest="c",
         required=True,
     )
-    parser.add_argument(
-        "-dw",
-        help="Make temporary ephemeris database. If no filepath/name supplied, default name and ephemeris input location used.",
-        dest="dw",
-        nargs="?",
-        const="default",
+    required.add_argument(
+        "-e",
+        "--ephem",
+        help="Ephemeris simulation output file name",
         type=str,
-    )
-    parser.add_argument(
-        "-dr",
-        help="Location of existing/previous temporary ephemeris database to read from if wanted.",
-        dest="dr",
-        type=str,
-    )
-    parser.add_argument(
-        "-dl",
-        help="Delete the temporary ephemeris database after code has completed.",
-        action="store_true",
-        default=False,
-    )
-    parser.add_argument(
-        "-cp",
-        "--complex_physical_parameters",
-        help="Complex physical parameters file name",
-        type=str,
-        dest="cp",
-    )
-    parser.add_argument(
-        "-p",
-        "--params",
-        help="Physical parameters file name",
-        type=str,
-        dest="p",
+        dest="e",
         required=True,
     )
-    parser.add_argument(
+    required.add_argument(
+        "-o",
+        "--outfile",
+        help="Path to store output and logs.",
+        type=str,
+        dest="o",
+        required=True,
+    )
+    required.add_argument(
         "-ob",
         "--orbit",
         help="Orbit file name",
@@ -355,15 +337,15 @@ def main():
         default="./data/orbit.des",
         required=True,
     )
-    parser.add_argument(
-        "-e",
-        "--ephem",
-        help="Ephemeris simulation output file name",
+    required.add_argument(
+        "-p",
+        "--params",
+        help="Physical parameters file name",
         type=str,
-        dest="e",
+        dest="p",
         required=True,
     )
-    parser.add_argument(
+    required.add_argument(
         "-pd",
         "--pointing_database",
         help="Survey pointing information",
@@ -372,27 +354,35 @@ def main():
         required=True,
     )
 
-    parser.add_argument("-s", "--survey", help="Survey to simulate", type=str, dest="s", default="LSST")
-    parser.add_argument(
-        "-o",
-        "--outfile",
-        help="Path to store output and logs.",
+    optional = parser.add_argument_group("Optional arguments")
+    optional.add_argument(
+        "-cp",
+        "--complex_physical_parameters",
+        help="Complex physical parameters file name",
         type=str,
-        dest="o",
-        required=True,
+        dest="cp",
     )
-    parser.add_argument(
-        "-t", "--stem", help="Output file name stem.", type=str, dest="t", default="SSPPOutput"
+    optional.add_argument(
+        "-dw",
+        help="Make temporary ephemeris database. If no filepath/name supplied, default name and ephemeris input location used.",
+        dest="dw",
+        nargs="?",
+        const="default",
+        type=str,
     )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        help="Verbosity. Default currently true; include to turn off verbosity.",
-        dest="v",
-        default=True,
-        action="store_false",
+    optional.add_argument(
+        "-dr",
+        help="Location of existing/previous temporary ephemeris database to read from if wanted.",
+        dest="dr",
+        type=str,
     )
-    parser.add_argument(
+    optional.add_argument(
+        "-dl",
+        help="Delete the temporary ephemeris database after code has completed.",
+        action="store_true",
+        default=False,
+    )
+    optional.add_argument(
         "-f",
         "--force",
         help="Force deletion/overwrite of existing output file(s). Default False.",
@@ -400,10 +390,23 @@ def main():
         action="store_true",
         default=False,
     )
+    optional.add_argument("-s", "--survey", help="Survey to simulate", type=str, dest="s", default="LSST")
+    optional.add_argument(
+        "-t", "--stem", help="Output file name stem.", type=str, dest="t", default="SSPPOutput"
+    )
+    optional.add_argument(
+        "-v",
+        "--verbose",
+        help="Verbosity. Default currently true; include to turn off verbosity.",
+        dest="v",
+        default=True,
+        action="store_false",
+    )
+
     args = parser.parse_args()
 
     # Extract the output file path now in order to set up logging.
-    outpath = PPFindFileOrExit(args.u, "-u, --outfile")
+    outpath = PPFindFileOrExit(args.o, "-o, --outfile")
     pplogger = PPGetLogger(outpath)
     pplogger.info("Sorcha Start (Main)")
     pplogger.info(f"Command line: {' '.join(sys.argv)}")

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -284,22 +284,30 @@ def main():
     model Solar System small body population to what the specified wide-field
     survey would observe.
 
-    usage: sorcha [-h] -c C [-dw [DW]] [-dr DR] [-dl] [-m M] -p P -o O -e E [-s S] -u U [-t T] [-v] [-f]
-        arguments:
-          -h, --help         show this help message and exit
-          -c C, --config C   Input configuration file name
-          -dw [DW]           Make temporary ephemeris database. If no filepath/name supplied, default name and ephemeris input location used.
-          -dr DR             Location of existing/previous temporary ephemeris database to read from if wanted.
-          -dl                Delete the temporary ephemeris database after code has completed.
-          -m M, --comet M    Comet parameter file name
-          -p P, --params P   Physical parameters file name
-          -o O, --orbit O    Orbit file name
-          -e E, --ephem E    Ephemeris simulation output file name
-          -s S, --survey S   Survey to simulate
-          -u U, --outfile U  Path to store output and logs.
-          -t T, --stem T     Output file name stem.
-          -v, --verbose      Verbosity. Default currently true; include to turn off verbosity.
-          -f, --force        Force deletion/overwrite of existing output file(s). Default False.
+    usage: sorcha [-h] -c C -e E -o O -ob OB -p P -pd PD [-cp CP] [-dw [DW]] [-dr DR] [-dl] [-f] [-s S] [-t T] [-v]
+
+    options:
+      -h, --help            show this help message and exit
+
+    Required arguments:
+      -c C, --config C      Input configuration file name (default: None)
+      -e E, --ephem E       Ephemeris simulation output file name (default: None)
+      -o O, --outfile O     Path to store output and logs. (default: None)
+      -ob OB, --orbit OB    Orbit file name (default: ./data/orbit.des)
+      -p P, --params P      Physical parameters file name (default: None)
+      -pd PD, --pointing_database PD
+                        Survey pointing information (default: None)
+
+    Optional arguments:
+      -cp CP, --complex_physical_parameters CP
+                            Complex physical parameters file name (default: None)
+      -dw [DW]              Make temporary ephemeris database. If no filepath/name supplied, default name and ephemeris input location used. (default: None)
+      -dr DR                Location of existing/previous temporary ephemeris database to read from if wanted. (default: None)
+      -dl                   Delete the temporary ephemeris database after code has completed. (default: False)
+      -f, --force           Force deletion/overwrite of existing output file(s). Default False. (default: False)
+      -s S, --survey S      Survey to simulate (default: LSST)
+      -t T, --stem T        Output file name stem. (default: SSPPOutput)
+      -v, --verbose         Verbosity. Default currently true; include to turn off verbosity. (default: True)
     """
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/tests/sorcha/test_PPCommandLineParser.py
+++ b/tests/sorcha/test_PPCommandLineParser.py
@@ -7,10 +7,11 @@ from sorcha.utilities.dataUtilitiesForTests import get_test_filepath
 class args:
     def __init__(self, cp, dw, dr, dl, t="testout", u="./", f=False):
         self.p = get_test_filepath("testcolour.txt")
-        self.o = get_test_filepath("testorb.des")
+        self.ob = get_test_filepath("testorb.des")
         self.e = get_test_filepath("oiftestoutput.txt")
         self.c = get_test_filepath("test_PPConfig.ini")
-        self.u = u
+        self.pd = get_test_filepath("baseline_10klines_2.0.db")
+        self.o = u
         self.cp = cp
         self.s = "lsst"
         self.t = t
@@ -32,6 +33,7 @@ def test_PPCommandLineParser():
         "orbinfile": get_test_filepath("testorb.des"),
         "oifoutput": get_test_filepath("oiftestoutput.txt"),
         "configfile": get_test_filepath("test_PPConfig.ini"),
+        "pointing_database": get_test_filepath("baseline_10klines_2.0.db"),
         "outpath": "./",
         "makeTemporaryEphemerisDatabase": False,
         "readTemporaryEphemerisDatabase": None,
@@ -49,6 +51,7 @@ def test_PPCommandLineParser():
         "orbinfile": get_test_filepath("testorb.des"),
         "oifoutput": get_test_filepath("oiftestoutput.txt"),
         "configfile": get_test_filepath("test_PPConfig.ini"),
+        "pointing_database": get_test_filepath("baseline_10klines_2.0.db"),
         "outpath": "./",
         "makeTemporaryEphemerisDatabase": False,
         "complex_physical_parameters": get_test_filepath("testcomet.txt"),
@@ -65,6 +68,7 @@ def test_PPCommandLineParser():
         "orbinfile": get_test_filepath("testorb.des"),
         "oifoutput": get_test_filepath("oiftestoutput.txt"),
         "configfile": get_test_filepath("test_PPConfig.ini"),
+        "pointing_database": get_test_filepath("baseline_10klines_2.0.db"),
         "outpath": "./",
         "makeTemporaryEphemerisDatabase": os.path.join(tmp_path, "test.db"),
         "readTemporaryEphemerisDatabase": None,
@@ -80,6 +84,7 @@ def test_PPCommandLineParser():
         "orbinfile": get_test_filepath("testorb.des"),
         "oifoutput": get_test_filepath("oiftestoutput.txt"),
         "configfile": get_test_filepath("test_PPConfig.ini"),
+        "pointing_database": get_test_filepath("baseline_10klines_2.0.db"),
         "outpath": "./",
         "makeTemporaryEphemerisDatabase": os.path.join(tmp_path, "temp_oiftestoutput.db"),
         "readTemporaryEphemerisDatabase": None,

--- a/tests/sorcha/test_PPCommandLineParser.py
+++ b/tests/sorcha/test_PPCommandLineParser.py
@@ -5,13 +5,13 @@ from sorcha.utilities.dataUtilitiesForTests import get_test_filepath
 
 
 class args:
-    def __init__(self, cp, dw, dr, dl, t="testout", u="./", f=False):
+    def __init__(self, cp, dw, dr, dl, t="testout", o="./", f=False):
         self.p = get_test_filepath("testcolour.txt")
         self.ob = get_test_filepath("testorb.des")
         self.e = get_test_filepath("oiftestoutput.txt")
         self.c = get_test_filepath("test_PPConfig.ini")
         self.pd = get_test_filepath("baseline_10klines_2.0.db")
-        self.o = u
+        self.o = o
         self.cp = cp
         self.s = "lsst"
         self.t = t
@@ -98,9 +98,9 @@ def test_PPCommandLineParser():
         pass
 
     with pytest.raises(SystemExit) as e:
-        _ = PPCommandLineParser(args(False, False, None, False, u=tmp_path, t="dummy_file"))
+        _ = PPCommandLineParser(args(False, False, None, False, o=tmp_path, t="dummy_file"))
 
-    _ = PPCommandLineParser(args(False, False, None, False, u=tmp_path, t="dummy_file", f=True))
+    _ = PPCommandLineParser(args(False, False, None, False, o=tmp_path, t="dummy_file", f=True))
 
     assert cmd_dict_1 == expected_1
     assert cmd_dict_2 == expected_2


### PR DESCRIPTION
Fixes #557
Fixes #558

A series of small improvements and fixes to the command line argument parsing.
1) Fixes conflicting merges between #555 and some other PR (such as #553). In particular #555 changed the name of some of the command line arguments (`o` -> `ob` and `u` -> `o`). This updates them in the additions from the other PRs.
2) Print out the default values for --help (fixes #557)
3) Separate out the required vs. optional parameters for --help (fixes #558)
4) Add pointing database argument to `PPCommandLineParser`
5) List arguments in alphabetical order within optional/required sections.

Describe your changes.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
