### PR TITLE
Issue #509: light curve models use complex parameters input file.

### DIFF
--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -132,7 +132,7 @@ def runLSSTPostProcessing(cmd_args, pplogger=None):
 
     reader.add_aux_data_reader(OrbitAuxReader(args.orbinfile, configs["aux_format"]))
     reader.add_aux_data_reader(CSVDataReader(args.paramsinput, configs["aux_format"]))
-    if configs["comet_activity"] is not None:
+    if configs["comet_activity"] is not None or configs["lc_model"] is not None:
         reader.add_aux_data_reader(CSVDataReader(args.complex_parameters, configs["aux_format"]))
 
     # In case of a large input file, the data is read in chunks. The


### PR DESCRIPTION
Fixes #509.

Comet activity and light curve models now use the same file for input parameters: the complex parameters input file. Facilitating this required one very small change to sorcha.py: now when lc_model is not None, the code looks for the complex parameters input file and merges it onto the dataframe.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
