### PR TITLE
Allow rng seed setting via SORCHA_SEED envvar

### DIFF
--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -421,6 +421,11 @@ def main():
 
     # Extract and validate the remaining arguments.
     cmd_args = PPCommandLineParser(args)
+
+    if "SORCHA_SEED" in os.environ:
+        cmd_args["seed"] = int(os.environ["SORCHA_SEED"])
+        pplogger.info(f"Random seed overridden via environmental variable, SORCHA_SEED={cmd_args['seed']}")
+
     if cmd_args["surveyname"] in ["LSST", "lsst"]:
         runLSSTPostProcessing(cmd_args, pplogger)
     else:

--- a/src/sorcha/utilities/sorchaArguments.py
+++ b/src/sorcha/utilities/sorchaArguments.py
@@ -37,13 +37,7 @@ class sorchaArguments:
     complex_parameters: str = ""
     """optional, extra complex physical parameter input files"""
 
-    _rng = np.random.default_rng(int(time.time()))
-    """
-    DO NOT CHANGE THIS UNLESS YOU ARE A MEMBER OF THE DEVELOPMENT TEAM
-    FOR TESTING PURPOSES ONLY
-    CHANGING THE RNG SEED COULD INVALIDATE ANY SCIENCE RESULTS GAINED FROM SORCHA
-    THIS IS NOT A PLACE OF HONOR
-    """
+    _rng = None
 
     def __init__(self, cmd_args_dict=None):
         if cmd_args_dict is not None:
@@ -69,6 +63,12 @@ class sorchaArguments:
 
         if "complex_physical_parameters" in args.keys():
             self.complex_parameters = args["complex_physical_parameters"]
+
+        # WARNING: Take care if manually setting the seed. Re-using seeds between
+        # simulations may result in hard-to-detect correlations in simulation
+        # outputs.
+        seed = args.get("seed", int(time.time()))
+        self._rng = np.random.default_rng(seed)
 
     def validate_arguments(self):
         if not path.isfile(self.paramsinput):


### PR DESCRIPTION
Adding the (currently intentionally undocumented) ability for the seed to be specified via the SORCHA_SEED environmental variable. This allows for sorcha to be fully reproducibly run with something like:

```
SORCHA_SEED=42 sorcha -c ./demo/PPConfig_test.ini -p ./demo/sspp_testset_colours.txt -ob ./demo/sspp_testset_orbits.des -e ./demo/example_oif_output.txt -pd ./demo/baseline_v2.0_1yr.db -o ./data/out/ -t testrun_e2e.csv
```

which comes in handy when developing.

I haven't written any unit tests for this yet... I'm not 100% sure how I'd test it (w/o some rather inelegant grepping of the log files)?

closes #573
## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
