### PR TITLE
Removing default value for CLI orbit file argument.

### DIFF
--- a/demo/OIFconfig_benchmark.ini
+++ b/demo/OIFconfig_benchmark.ini
@@ -26,7 +26,7 @@ camera = instrument_circle.dat
 [INPUT]
 eph_format = csv
 aux_format = csv
-ephemerides_type = oif
+ephemerides_type = external
 size_serial_chunk = 100
 
 [ACTIVITY]

--- a/demo/bench_LCA.py
+++ b/demo/bench_LCA.py
@@ -5,6 +5,7 @@ import pstats
 
 from pstats import SortKey
 from sorcha.sorcha import runLSSTSimulation  # noqa: F401
+from sorcha.modules.PPConfigParser import PPConfigFileParser
 import argparse
 
 if __name__ == "__main__":  # pragma: no cover
@@ -28,7 +29,9 @@ if __name__ == "__main__":  # pragma: no cover
         "verbose": False,
     }
 
-    cProfile.run("runLSSTSimulation(cmd_args_dict)", "../data/out/restats")
+    configs = PPConfigFileParser("./OIFconfig_benchmark.ini", "LSST")
+
+    cProfile.run("runLSSTSimulation(cmd_args_dict, configs)", "../data/out/restats")
 
     p = pstats.Stats("../data/out/restats")
     p.strip_dirs().sort_stats(SortKey.CUMULATIVE).print_stats()

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -302,10 +302,10 @@ def main():
     Required arguments:
       -c C, --config C      Input configuration file name (default: None)
       -o O, --outfile O     Path to store output and logs. (default: None)
-      -ob OB, --orbit OB    Orbit file name (default: ./data/orbit.des)
+      -ob OB, --orbit OB    Orbit file name (default: None)
       -p P, --params P      Physical parameters file name (default: None)
       -pd PD, --pointing_database PD
-                        Survey pointing information (default: None)
+                            Survey pointing information (default: None)
 
     Optional arguments:
       -er E, --ephem_read E Existing ephemeris simulation output file name (default: None)
@@ -346,7 +346,6 @@ def main():
         help="Orbit file name",
         type=str,
         dest="ob",
-        default="./data/orbit.des",
         required=True,
     )
     required.add_argument(


### PR DESCRIPTION
Fixes #561 

Removes the default values from the CLI argument definition. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
