### PR TITLE
Passing pointings dataframe to A&R so that we only read the file once.

### DIFF
--- a/demo/test_bench.py
+++ b/demo/test_bench.py
@@ -1,6 +1,13 @@
+import cProfile
+import pstats
+
+from pstats import SortKey
 from sorcha.sorcha import runLSSTSimulation  # noqa: F401
 from sorcha.modules.PPConfigParser import PPConfigFileParser
 import argparse
+
+# Run this from the command line using:
+# python .../demo/test_bench.py
 
 if __name__ == "__main__":  # pragma: no cover
     # Parse the command line arguments.
@@ -25,4 +32,11 @@ if __name__ == "__main__":  # pragma: no cover
 
     configs = PPConfigFileParser("./demo/test_bench_config.ini", "LSST")
 
-    runLSSTSimulation(cmd_args_dict, configs)
+    debug = False
+    if debug:
+        runLSSTSimulation(cmd_args_dict, configs)
+    else: # benchmark
+        cProfile.run("runLSSTSimulation(cmd_args_dict, configs)", "./data/out/restats")
+
+        p = pstats.Stats("./data/out/restats")
+        p.strip_dirs().sort_stats(SortKey.CUMULATIVE).print_stats(100)

--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -17,7 +17,7 @@ from sorcha.modules.PPReadPointingDatabase import PPReadPointingDatabase
 out_csv_path = get_data_out_filepath("ephemeris_output.csv")
 
 
-def create_ephemeris(orbits_df, args, configs):
+def create_ephemeris(orbits_df, pointings_df, args, configs):
     ang_fov = configs["ar_ang_fov"]
     buffer = configs["ar_fov_buffer"]
     picket_interval = configs["ar_picket"]
@@ -67,9 +67,6 @@ def create_ephemeris(orbits_df, args, configs):
     column_types = defaultdict(ObjID=str, FieldID=str).setdefault(float)
     in_memory_csv.writerow(column_names)
 
-    pointings_df = PPReadPointingDatabase(
-        args.pointing_database, configs["observing_filters"], configs["pointing_sql_query"]
-    )
     for _, pointing in pointings_df.iterrows():
         mjd_tai = float(pointing["observationStartMJD"])
         ra, dec = float(pointing["fieldRA"]), float(pointing["fieldDec"])

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -165,7 +165,7 @@ def runLSSTSimulation(args, configs, pplogger=None):
             observations = reader.read_block(block_size=configs["size_serial_chunk"])
         else:
             orbits_df = reader.read_aux_block(block_size=configs["size_serial_chunk"])
-            observations = create_ephemeris(orbits_df, args, configs)
+            observations = create_ephemeris(orbits_df, filterpointing, args, configs)
 
         observations = PPMatchPointingToObservations(observations, filterpointing)
 


### PR DESCRIPTION
Fixes #623 

The pointings database is read in initially in `runLSSTSimulation` as a dataframe. We now pass that dataframe to A&R to avoid a second read in. 

Benchmark testing with a small dataset and 1 year point database (and a batch size that only calls A&R once) shows, no surprise, half the baseline time spent reading the pointing database. 

Baseline time: 0.74s
This change: 0.36s

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
