### PR TITLE
make test logs for PPPrintConfigsToLogs actually go to the tmp directory

### DIFF
--- a/tests/sorcha/test_PPConfigParser.py
+++ b/tests/sorcha/test_PPConfigParser.py
@@ -233,7 +233,7 @@ def test_PPPrintConfigsToLog(tmp_path):
 
     test_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
 
-    PPGetLogger(tmp_path, log_format="%(name)-12s %(levelname)-8s %(message)s ")
+    pplogger = PPGetLogger(tmp_path, log_format="%(name)-12s %(levelname)-8s %(message)s ")
 
     cmd_args = {
         "paramsinput": "testcolour.txt",
@@ -251,7 +251,7 @@ def test_PPPrintConfigsToLog(tmp_path):
         "seed": 24601,
     }
 
-    args = sorchaArguments(cmd_args)
+    args = sorchaArguments(cmd_args, pplogger=pplogger)
 
     configs = {
         "eph_format": "csv",


### PR DESCRIPTION
`sorchaArguments` has some pplogger functionality now, but the test logger wasn't being passed to it, so it was spewing the logs into the root directory (the `outpath` set as part of test.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
