### PR TITLE
Pre-computing all of the pointing database-related calculations for A&R.

### DIFF
--- a/src/sorcha/ephemeris/__init__.py
+++ b/src/sorcha/ephemeris/__init__.py
@@ -13,7 +13,12 @@ from .simulation_data_files import (
     DE440S,
     make_retriever,
 )
-from .simulation_geometry import ecliptic_to_equatorial, integrate_light_time, ra_dec2vec
+from .simulation_geometry import (
+    barycentricObservatoryRates,
+    ecliptic_to_equatorial,
+    integrate_light_time,
+    ra_dec2vec,
+)
 from .simulation_parsing import (
     mjd_tai_to_epoch,
     Observatory,
@@ -22,6 +27,7 @@ from .simulation_parsing import (
 from .simulation_setup import (
     create_assist_ephemeris,
     furnish_spiceypy,
+    precompute_pointing_information,
 )
 
 from .simulation_driver import create_ephemeris

--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -7,7 +7,11 @@ import numpy as np
 import pandas as pd
 import spiceypy as spice
 
-from sorcha.ephemeris.simulation_setup import *
+from sorcha.ephemeris.simulation_setup import (
+    create_assist_ephemeris,
+    furnish_spiceypy,
+    generate_simulations,
+)
 from sorcha.ephemeris.simulation_constants import *
 from sorcha.ephemeris.simulation_geometry import *
 from sorcha.ephemeris.simulation_parsing import *
@@ -70,98 +74,59 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
     for _, pointing in pointings_df.iterrows():
         mjd_tai = float(pointing["observationStartMJD"])
         ra, dec = float(pointing["fieldRA"]), float(pointing["fieldDec"])
-        visit_vec = ra_dec2vec(ra, dec)
-        pixels = get_hp_neighbors(ra, dec, ang_fov + buffer, nside=nside, nested=True)
-        jd_tdb = mjd_tai_to_epoch(mjd_tai)
-        et = (jd_tdb - spice.j2000()) * 24 * 60 * 60
-        utc_str = spice.et2utc(et, "J", 7)
-
-        if False:
-            r_obs = observatories.barycentricObservatory(et, obsCode) / AU_KM
-        else:
-            r_obs, v_obs = barycentricObservatoryRates(
-                et, obsCode, observatories=observatories
-            )  # <--- Need this routine
-            r_obs /= AU_KM  # convert to au
-            v_obs *= (24 * 60 * 60) / AU_KM  # convert to au/day
-            sun = ephem.get_particle("Sun", jd_tdb - ephem.jd_ref)  # This can be pre-calculated
-            r_sun = np.array((sun.x, sun.y, sun.z))
-            v_sun = np.array((sun.vx, sun.vy, sun.vz))
 
         # If the observation time is too far from the
         # time of the last set of ballpark sky position,
         # compute a new set
         while (
-            abs(jd_tdb - t_picket) > 0.5 * picket_interval or first == 1
+            abs(pointing["jd_tdb"] - t_picket) > 0.5 * picket_interval or first == 1
         ):  # right now this assumes time ordering
             t_picket, pixel_dict, _ = update_pixel_dict(
-                jd_tdb, t_picket, picket_interval, sim_dict, ephem, obsCode, observatories, nside
+                pointing["jd_tdb"], t_picket, picket_interval, sim_dict, ephem, obsCode, observatories, nside
             )
             first = 0
 
         # This should be a separate function
         desigs = set()
-        for pix in pixels:
+        for pix in pointing["pixels"]:
             desigs.update(pixel_dict[pix])
 
         for obj_id in sorted(desigs):
             v = sim_dict[obj_id]
             sim, ex, rho_hat_rough = v["sim"], v["ex"], v["rho_hat"]
-            ang = np.arccos(np.dot(rho_hat_rough, visit_vec)) * 180 / np.pi
+            ang = np.arccos(np.dot(rho_hat_rough, pointing["visit_vector"])) * 180 / np.pi
             if ang < ang_fov + buffer:
                 rho, rho_mag, lt, r_ast, v_ast = integrate_light_time(
-                    sim, ex, jd_tdb - ephem.jd_ref, r_obs, lt0=0.01
+                    sim, ex, pointing["jd_tdb"] - ephem.jd_ref, pointing["r_obs"], lt0=0.01
                 )
                 rho_hat = rho / rho_mag
 
-                ang_from_center = 180 / np.pi * np.arccos(np.dot(rho_hat, visit_vec))
+                ang_from_center = 180 / np.pi * np.arccos(np.dot(rho_hat, pointing["visit_vector"]))
                 if ang_from_center < ang_fov:
                     # Only do rates and geometry if the object is within the FOV
                     ra0, dec0 = vec2ra_dec(rho_hat)
-                    drhodt = v_ast - v_obs
+                    drhodt = v_ast - pointing["v_obs"]
                     drho_magdt = (1 / rho_mag) * np.dot(rho, drhodt)
                     ddeltatdt = drho_magdt / (SPEED_OF_LIGHT)
-                    drhodt = v_ast * (1 - ddeltatdt) - v_obs
+                    drhodt = v_ast * (1 - ddeltatdt) - pointing["v_obs"]
                     A, D = get_residual_vectors(rho_hat)
                     drho_hatdt = drhodt / rho_mag - drho_magdt * rho_hat / rho_mag
                     dradt = np.dot(A, drho_hatdt)
                     ddecdt = np.dot(D, drho_hatdt)
-                    r_ast_sun = r_ast - r_sun
-                    v_ast_sun = v_ast - v_sun
-                    r_ast_obs = r_ast - r_obs
+                    r_ast_sun = r_ast - pointing["r_sun"]
+                    v_ast_sun = v_ast - pointing["v_sun"]
+                    r_ast_obs = r_ast - pointing["r_obs"]
                     phase_angle = np.arccos(
                         np.dot(r_ast_sun, r_ast_obs) / (np.linalg.norm(r_ast_sun) * np.linalg.norm(r_ast_obs))
                     )
-                    obs_sun = r_obs - r_sun
-                    dobs_sundt = v_obs - v_sun
-
-                    outstring = "%s,%s," % (obj_id, pointing["FieldID"])
-                    outstring += "%lf,%lf," % (mjd_tai, jd_tdb)
-                    outstring += "%lf,%lf," % (rho_mag * AU_KM, drho_magdt * AU_KM / (24 * 60 * 60))
-                    outstring += "%lf,%lf,%lf,%lf," % (ra0, dradt * 180 / np.pi, dec0, ddecdt * 180 / np.pi)
-                    outstring += "%lf,%lf,%lf," % (
-                        r_ast_sun[0] * AU_KM,
-                        r_ast_sun[1] * AU_KM,
-                        r_ast_sun[2] * AU_KM,
-                    )
-                    outstring += "%lf,%lf,%lf," % (
-                        v_ast_sun[0] * AU_KM / (24 * 60 * 60),
-                        v_ast_sun[1] * AU_KM / (24 * 60 * 60),
-                        v_ast_sun[2] * AU_KM / (24 * 60 * 60),
-                    )
-                    outstring += "%lf,%lf,%lf," % (obs_sun[0] * AU_KM, obs_sun[1] * AU_KM, obs_sun[2] * AU_KM)
-                    outstring += "%lf,%lf,%lf," % (
-                        dobs_sundt[0] * AU_KM / (24 * 60 * 60),
-                        dobs_sundt[1] * AU_KM / (24 * 60 * 60),
-                        dobs_sundt[2] * AU_KM / (24 * 60 * 60),
-                    )
-                    outstring += "%lf\n" % (phase_angle * 180 / np.pi)
+                    obs_sun = np.asarray(pointing["r_obs"]) - np.asarray(pointing["r_sun"])
+                    dobs_sundt = np.asarray(pointing["v_obs"]) - np.asarray(pointing["v_sun"])
 
                     out_tuple = (
                         obj_id,
                         pointing["FieldID"],
                         mjd_tai,
-                        jd_tdb,
+                        pointing["jd_tdb"],
                         rho_mag * AU_KM,
                         drho_magdt * AU_KM / (24 * 60 * 60),
                         ra0,
@@ -234,26 +199,3 @@ def update_pixel_dict(jd_tdb, t_picket, picket_interval, sim_dict, ephem, obsCod
         this_pix = hp.vec2pix(nside, rho_hat[0], rho_hat[1], rho_hat[2], nest=True)
         pixel_dict[this_pix].append(k)
     return t_picket, pixel_dict, r_obs
-
-
-def barycentricObservatoryRates(
-    et, obsCode, observatories, Rearth=RADIUS_EARTH_KM, delta_et=10
-):  # This JPL's quoted Earth radius (km)
-    # et is JPL's internal time
-    # Get the barycentric position of Earth
-    posvel, _ = spice.spkezr("EARTH", et, "J2000", "NONE", "SSB")
-    pos = posvel[0:3]
-    vel = posvel[3:6]
-    # Get the matrix that rotates from the Earth's equatorial body fixed frame to the J2000 equatorial frame.
-    m = spice.pxform("ITRF93", "J2000", et)
-    mp = spice.pxform("ITRF93", "J2000", et + delta_et)
-    mm = spice.pxform("ITRF93", "J2000", et - delta_et)
-    # Get the MPC's unit vector from the geocenter to
-    # the observatory
-    obsVec = observatories.ObservatoryXYZ[obsCode]
-    obsVec = np.array(obsVec)
-    # Carry out the rotation and scale
-    mVec = np.dot(m, obsVec) * Rearth
-    mVecp = np.dot(mp, obsVec) * Rearth
-    mVecm = np.dot(mm, obsVec) * Rearth
-    return pos + mVec, vel + (mVecp - mVecm) / (2 * delta_et)

--- a/src/sorcha/ephemeris/simulation_setup.py
+++ b/src/sorcha/ephemeris/simulation_setup.py
@@ -1,3 +1,4 @@
+from functools import partial
 import spiceypy as spice
 from assist import Ephem
 from . import simulation_parsing as sp
@@ -7,6 +8,7 @@ import assist
 import logging
 import sys
 
+from sorcha.ephemeris.simulation_constants import *
 from sorcha.ephemeris.simulation_data_files import (
     make_retriever,
     JPL_PLANETS,
@@ -15,13 +17,23 @@ from sorcha.ephemeris.simulation_data_files import (
     ORDERED_KERNEL_FILES,
 )
 
+from sorcha.ephemeris.simulation_geometry import (
+    barycentricObservatoryRates,
+    get_hp_neighbors,
+    ra_dec2vec,
+)
+from sorcha.ephemeris.simulation_parsing import (
+    Observatory,
+    mjd_tai_to_epoch,
+)
 
-def create_assist_ephemeris(args) -> Ephem:
+
+def create_assist_ephemeris(args) -> tuple:
     """Build the ASSIST ephemeris object
 
     Returns
     -------
-    Ephem
+    Ephem, gm_sun
         The ASSIST ephemeris object
     """
     pplogger = logging.getLogger(__name__)
@@ -104,3 +116,80 @@ def generate_simulations(ephem, gm_sun, orbits_df):
         sim_dict[row["ObjID"]]["ex"] = ex
 
     return sim_dict
+
+
+def precompute_pointing_information(pointings_df, args, configs):
+    """This function is meant to be run once to prime the pointings dataframe
+    with additional information that Assist & Rebound needs for it's work.
+
+    Parameters
+    ----------
+    pointings_df : pd.dataframe
+        Contains the telescope pointing database.
+    args : dict
+        Command line arguments needed for initialization.
+    configs : dict
+        Configuration settings.
+
+    Returns
+    -------
+    pointings_df : pd.dataframe
+        The original dataframe with several additional columns of precomputed values.
+    """
+    ephem, _ = create_assist_ephemeris(args)
+
+    furnish_spiceypy(args)
+    obsCode = configs["ar_obs_code"]
+    observatories = Observatory(args)
+
+    # vectorize the calculation to get x,y,z vector from ra/dec
+    vectors = ra_dec2vec(pointings_df["fieldRA"].astype("float"), pointings_df["fieldDec"].astype("float"))
+    pointings_df["visit_vector"] = vectors.tolist()
+
+    # use pandas `apply` (even though it's slow) instead of looping over the df in a for loop
+    pointings_df["jd_tdb"] = pointings_df.apply(
+        lambda row: mjd_tai_to_epoch(row["observationStartMJD"]), axis=1
+    )
+    et = (pointings_df["jd_tdb"] - spice.j2000()) * 24 * 60 * 60
+
+    # create a partial function since most params don't change, and it makes the lambda easier to read
+    partial_get_hp_neighbors = partial(
+        get_hp_neighbors,
+        search_radius=configs["ar_ang_fov"] + configs["ar_fov_buffer"],
+        nside=2 ** configs["ar_healpix_order"],
+        nested=True,
+    )
+
+    # use pandas `apply` again because healpy.query_disc is not easily vectorizable
+    pointings_df["pixels"] = pointings_df.apply(
+        lambda row: partial_get_hp_neighbors(ra_c=float(row["fieldRA"]), dec_c=float(row["fieldDec"])),
+        axis=1,
+    )
+
+    # create empty arrays for observatory position and velocity to be filled in
+    r_obs = np.empty((len(pointings_df), 3))
+    v_obs = np.empty((len(pointings_df), 3))
+
+    for idx, et_i in enumerate(et):
+        r_obs[idx], v_obs[idx] = barycentricObservatoryRates(et_i, obsCode, observatories=observatories)
+
+    r_obs /= AU_KM  # convert to au
+    v_obs *= (24 * 60 * 60) / AU_KM  # convert to au/day
+
+    pointings_df["r_obs"] = r_obs.tolist()
+    pointings_df["v_obs"] = v_obs.tolist()
+
+    # create empty arrays for sun position and velocity to be filled in
+    r_sun = np.empty((len(pointings_df), 3))
+    v_sun = np.empty((len(pointings_df), 3))
+    time_offsets = pointings_df["jd_tdb"] - ephem.jd_ref
+    for idx, time_offset_i in enumerate(time_offsets):
+        sun = ephem.get_particle("Sun", time_offset_i)
+        r_sun[idx] = np.array((sun.x, sun.y, sun.z))
+        v_sun[idx] = np.array((sun.vx, sun.vy, sun.vz))
+
+    pointings_df["r_sun"] = r_sun.tolist()
+    pointings_df["v_sun"] = v_sun.tolist()
+
+    spice.kclear()
+    return pointings_df

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -7,6 +7,7 @@ import argparse
 import os
 
 from sorcha.ephemeris.simulation_driver import create_ephemeris
+from sorcha.ephemeris.simulation_setup import precompute_pointing_information
 
 from sorcha.modules.PPReadPointingDatabase import PPReadPointingDatabase
 from sorcha.modules.PPLinkingFilter import PPLinkingFilter
@@ -165,6 +166,10 @@ def runLSSTSimulation(args, configs, pplogger=None):
             observations = reader.read_block(block_size=configs["size_serial_chunk"])
         else:
             orbits_df = reader.read_aux_block(block_size=configs["size_serial_chunk"])
+            # determine if the pointing dataframe has been primed for creating ephemeris
+            if "visit_vector" not in filterpointing:
+                filterpointing = precompute_pointing_information(filterpointing, args, configs)
+
             observations = create_ephemeris(orbits_df, filterpointing, args, configs)
 
         observations = PPMatchPointingToObservations(observations, filterpointing)

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -117,6 +117,11 @@ def runLSSTSimulation(args, configs, pplogger=None):
         args.pointing_database, configs["observing_filters"], configs["pointing_sql_query"]
     )
 
+    # if we are going to compute the ephemerides, then we should pre-compute all
+    # of the needed values derived from the pointing information.
+    if configs["ephemerides_type"].casefold() != "external":
+        filterpointing = precompute_pointing_information(filterpointing, args, configs)
+
     # Set up the data readers.
     ephem_type = configs["ephemerides_type"]
     ephem_primary = False
@@ -166,10 +171,6 @@ def runLSSTSimulation(args, configs, pplogger=None):
             observations = reader.read_block(block_size=configs["size_serial_chunk"])
         else:
             orbits_df = reader.read_aux_block(block_size=configs["size_serial_chunk"])
-            # determine if the pointing dataframe has been primed for creating ephemeris
-            if "visit_vector" not in filterpointing:
-                filterpointing = precompute_pointing_information(filterpointing, args, configs)
-
             observations = create_ephemeris(orbits_df, filterpointing, args, configs)
 
         observations = PPMatchPointingToObservations(observations, filterpointing)


### PR DESCRIPTION
Fixes #622 .

Pulled most of the per-pointing calculations out of the main for loop in A&R into a pre-compute function that is run once. The pre-calculated values are stored on the pointing dataframe, and passed to A&R for each chunk of data to be processed.

If the chunk size is large (and data size is small) such that only one chunking of data is required, there will be no performance improvement. As a benchmark though, using the example 1 year pointing database on my local machine, the pre-computation time was 12-13 seconds. I think this can be extrapolated to ~120-130 seconds for a 10 year database. Meaning that we would save approximate 2 minutes per chunk of data processed (for chunk number >1).

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
