### PR TITLE
Forcing "ObjID" column types to match prior to joining dataframes.

### DIFF
--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -199,9 +199,9 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
 
     # join the ephemeris and input orbits dataframe, take special care to make
     # sure the 'ObjID' column types match.
-    observations = ephemeris_df.astype({"ObjID": orbits_df.dtypes["ObjID"]}).join(
-        orbits_df.set_index("ObjID"), on="ObjID"
-    )
+    ephemeris_df["ObjID"] = ephemeris_df["ObjID"].astype("string")
+    orbits_df["ObjID"] = orbits_df["ObjID"].astype("string")
+    observations = ephemeris_df.join(orbits_df.set_index("ObjID"), on="ObjID")
 
     spice.kclear()
 


### PR DESCRIPTION
Fixes #631 .

In `simulation_driver.py`, when the "join on" column types of the `ephemeris_df` and `orbits_df` dataframes were of dissimilar types, the join would fail silently, resulting in an output dataframe with the correct columns, but the right side of the join would be all `NaN`. 

Initially an unsuccessful attempt was made to force the column types to match, but type change was transient, and reverted prior to performing the join. Additionally, it swallowed any exceptions that might have been raised. 

This PR forces the column types for both dataframes to be Python `string`, which seems to be the most natural data type available for object id.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
