### PR TITLE
Removed requirement to define an ephemeris output file.

### DIFF
--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -456,10 +456,6 @@ def main():
         pplogger.error("ERROR: A+R simulation not enabled and no ephemerides file provided")
         sys.exit("ERROR: A+R simulation not enabled and no ephemerides file provided")
 
-    if configs["ephemerides_type"] == "ar" and cmd_args["output_ephemeris_file"] is None:
-        pplogger.error("ERROR: A+R simulation is enabled and no output file name for ephemerides provided")
-        sys.exit("ERROR: A+R simulation is enabled and no output file name for ephemerides provided")
-
     if "SORCHA_SEED" in os.environ:
         cmd_args["seed"] = int(os.environ["SORCHA_SEED"])
         pplogger.info(f"Random seed overridden via environmental variable, SORCHA_SEED={cmd_args['seed']}")


### PR DESCRIPTION
Fixes #627 .

Removes the check that causes Sorcha to exit if there is no output ephemeris file defined when configured to run A&R.
## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
