### PR TITLE
Use of PATH_VALUES and PATH_SYMBOLS to shorten the qualified path names in META_KERNEL file.

### DIFF
--- a/src/sorcha/utilities/generate_meta_kernel.py
+++ b/src/sorcha/utilities/generate_meta_kernel.py
@@ -1,0 +1,78 @@
+import os
+import pooch
+
+from sorcha.ephemeris.simulation_data_files import (
+    META_KERNEL,
+    ORDERED_KERNEL_FILES,
+)
+
+"""
+    An example output from running `build_meta_kernel_file` might look like
+    the following:
+
+    \begindata
+
+    PATH_VALUES = ('/Users/scientist/sorcha/data_files/assist_and_rebound')
+
+    PATH_SYMBOLS = ('A')
+
+    KERNELS_TO_LOAD=(
+        '$A/naif0012.tls',
+        '$A/earth_720101_230601.bpc',
+        '$A/earth_200101_990825_predict.bpc',
+        '$A/pck00010.pck',
+        '$A/de440s.bsp',
+        '$A/earth_latest_high_prec.bpc',
+    )
+
+    \begintext
+"""
+
+
+def build_meta_kernel_file(retriever: pooch.Pooch) -> None:
+    """Builds a specific text file that will be fed into `spiceypy` that defines
+    the list of spice kernel to load, as well as the order to load them.
+
+    Parameters
+    ----------
+    retriever : pooch.Pooch
+        Pooch object that maintains the registry of files to download
+    """
+    # build meta_kernel file path
+    meta_kernel_file_path = os.path.join(retriever.abspath, META_KERNEL)
+
+    # build a meta_kernel.txt file
+    with open(meta_kernel_file_path, "w") as meta_file:
+        meta_file.write("\\begindata\n\n")
+        meta_file.write(f"PATH_VALUES = ('{retriever.abspath}')\n\n")
+        meta_file.write("PATH_SYMBOLS = ('A')\n\n")
+        meta_file.write("KERNELS_TO_LOAD=(\n")
+        for file_name in ORDERED_KERNEL_FILES:
+            shortened_file_name = _build_file_name(retriever.abspath, retriever.fetch(file_name))
+            meta_file.write(f"    '{shortened_file_name}',\n")
+        meta_file.write(")\n\n")
+        meta_file.write("\\begintext\n")
+
+
+def _build_file_name(cache_dir: str, file_path: str) -> str:
+    """Given a string defining the cache directory, and a string defining the full
+    path to a given file. This function will strip out the cache directory from
+    the file path and replace it with the required meta_kernel directory
+    substitution character.
+
+    Parameters
+    ----------
+    cache_dir : str
+        The full path to the cache directory used when retrieving files for Assist
+        and Rebound.
+    file_path : str
+        The full file path for a given file that will have the cache directory
+        segment replace.
+
+    Returns
+    -------
+    str
+        Shortened file path, appropriate for use in kernel_meta files.
+    """
+
+    return file_path.replace(str(cache_dir), "$A")

--- a/src/sorcha/utilities/retrieve_ephemeris_data_files.py
+++ b/src/sorcha/utilities/retrieve_ephemeris_data_files.py
@@ -7,9 +7,8 @@ from functools import partial
 from sorcha.ephemeris.simulation_data_files import (
     make_retriever,
     DATA_FILES_TO_DOWNLOAD,
-    META_KERNEL,
-    ORDERED_KERNEL_FILES,
 )
+from sorcha.utilities.generate_meta_kernel import build_meta_kernel_file
 
 
 def _decompress(fname, action, pup):
@@ -43,28 +42,6 @@ def _remove_files(retriever: pooch.Pooch) -> None:
         file_path = retriever.fetch(file_name)
         print(f"Deleting file: {file_path}")
         os.remove(file_path)
-
-
-def _build_meta_kernel_file(retriever: pooch.Pooch) -> None:
-    """Builds a specific text file that will be fed into `spiceypy` that defines
-    the list of spice kernel to load, as well as the order to load them.
-
-    Parameters
-    ----------
-    retriever : pooch.Pooch
-        Pooch object that maintains the registry of files to download
-    """
-    # build meta_kernel file path
-    meta_kernel_file_path = os.path.join(retriever.abspath, META_KERNEL)
-
-    # build a meta_kernel.txt file
-    with open(meta_kernel_file_path, "w") as meta_file:
-        meta_file.write("\\begindata\n\n")
-        meta_file.write("KERNELS_TO_LOAD=(\n")
-        for file_name in ORDERED_KERNEL_FILES:
-            meta_file.write(f"    '{retriever.fetch(file_name)}',\n")
-        meta_file.write(")\n\n")
-        meta_file.write("\\begintext\n")
 
 
 def main():
@@ -101,7 +78,7 @@ def main():
         executor.map(fetch_partial, DATA_FILES_TO_DOWNLOAD)
 
     # build the meta_kernel.txt file
-    _build_meta_kernel_file(retriever)
+    build_meta_kernel_file(retriever)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #628 .

Moved the META_KERNEL file generation functions to a new module in `sorcha/utilities`. Now makes use of the data file location that the user specifies when downloading files with `bootstrap_sorcha_data_files` and replaces long file names with PATH_SYMBOLS. Support for those is defined here: https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/kernel.html#Loading%20Kernels in the Path Symbols in Meta-kernels
section. 

Running `boostrap_sorcha_data_files` will regenerate the META_KERNEL file (and only download the data files if they don't already exist in the user specified cache directory)

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
