### PR TITLE
unpin versions of numpy and pandas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,15 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "numpy==1.24.3",
-    "pandas<2.1",
+#    "numpy==1.24.3",
+    "numpy",
+    "pandas>=2.0",
     "scipy",
     "astropy",
     "matplotlib",
     "sbpy",
     "tables",
-    "difi == 1.2rc3",
+#    "difi == 1.2rc3",
     "spiceypy",
     "healpy",
     "assist",

--- a/src/sorcha/modules/PPLinkingFilter.py
+++ b/src/sorcha/modules/PPLinkingFilter.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
-#from difi.metrics import NightlyLinkagesMetric
+
+# from difi.metrics import NightlyLinkagesMetric
 
 
 def PPLinkingFilter_OLD(

--- a/src/sorcha/modules/PPLinkingFilter.py
+++ b/src/sorcha/modules/PPLinkingFilter.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-from difi.metrics import NightlyLinkagesMetric
+#from difi.metrics import NightlyLinkagesMetric
 
 
 def PPLinkingFilter_OLD(


### PR DESCRIPTION
commenting out difi calls and dependencies as only need for final testing and this allows unpinning the other packages as the pandas bug is fixed and numpy was being pinned for difi - implementing the changes Mario was testing out earlier today

Fixes #651 

## Review Checklist for Source Code Changes

- [X] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [X] Do all the units tests run successfully?
- [X] Does Sorcha run successfully on a test set of input files/databases?
- [X] Have you used black on the files you have updated to confirm python programming style guide enforcement?
