### PR TITLE
Removing the version pin for `sphinx-autodoc`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,9 +9,9 @@ astropy
 scipy
 sbpy
 matplotlib
-sphinx==6.1.3
-sphinx-rtd-theme==1.2.0
-sphinx-autoapi==2.0.1
+sphinx
+sphinx-rtd-theme
+sphinx-autoapi
 nbsphinx
 ipython
 jupytext

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
     "pre-commit", # Used to run checks before finalizing a git commit
     "sphinx==6.1.3", # Used to automatically generate documentation
     "sphinx-rtd-theme==1.2.0", # Used to render documentation
-    "sphinx-autoapi==2.0.1", # Used to automatically generate api documentation
+    "sphinx-autoapi", # Used to automatically generate api documentation
     "black", # Used for static linting of files
     # if you add dependencies here while experimenting in a notebook and you
     # want that notebook to render in your documentation, please add the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ dev = [
     "pytest",
     "pytest-cov", # Used to report total code coverage
     "pre-commit", # Used to run checks before finalizing a git commit
-    "sphinx==6.1.3", # Used to automatically generate documentation
-    "sphinx-rtd-theme==1.2.0", # Used to render documentation
+    "sphinx", # Used to automatically generate documentation
+    "sphinx-rtd-theme", # Used to render documentation
     "sphinx-autoapi", # Used to automatically generate api documentation
     "black", # Used for static linting of files
     # if you add dependencies here while experimenting in a notebook and you


### PR DESCRIPTION
It appears that LINCC frameworks Python Project Template based projects that use auto documentation generation are seeing CI failures due to out of date versions of `sphinx-autodoc`. This PR removes the version pin so that documentation generation works as expected. 


## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
