### PR TITLE
Only merge required columns of observation and pointing dataframes

### DIFF
--- a/demo/test_bench.py
+++ b/demo/test_bench.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":  # pragma: no cover
     cmd_args_dict = {
         "paramsinput": "./demo/mba_sample_1000_physical.csv",
         "orbinfile": "./demo/mba_sample_1000_orbit.csv",
-        "output_ephemeris_file": "./data/out/ephemeris_output.csv",
+        "output_ephemeris_file": "ephemeris_output.csv",
         "configfile": "./demo/test_bench_config.ini",
         "pointing_database": "./demo/baseline_v2.0_1yr.db",
         "outpath": "./data/out",

--- a/src/sorcha/modules/PPMatchPointingToObservations.py
+++ b/src/sorcha/modules/PPMatchPointingToObservations.py
@@ -23,8 +23,18 @@ def PPMatchPointingToObservations(padain, pointfildb):
 
     """
 
-    resdf = pd.merge(padain, pointfildb, left_on="FieldID", right_on="FieldID", how="left")
+    # resdf = pd.merge(padain, pointfildb, left_on="FieldID", right_on="FieldID", how="left")
 
+    # certain columns were added to the pointing db dataframe to help with ephemeris generation.
+    # they don't need to be included in the result df, so exclude them from the merge.
+    pointing_columns_to_skip = ["visit_vector", "JD_TDB", "pixels", "r_obs", "v_obs", "r_sun", "v_sun"]
+    resdf = pd.merge(
+        padain,
+        pointfildb.loc[:, ~pointfildb.columns.isin(pointing_columns_to_skip)],
+        left_on="FieldID",
+        right_on="FieldID",
+        how="left",
+    )
     colour_values = resdf.optFilter.unique()
     colour_values = pd.Series(colour_values).dropna()
 

--- a/tests/sorcha/test_PPMatchPointingToObservations.py
+++ b/tests/sorcha/test_PPMatchPointingToObservations.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 from pandas.testing import assert_frame_equal
 
 from sorcha.utilities.dataUtilitiesForTests import get_test_filepath
@@ -74,6 +75,12 @@ def test_PPMatchPointingToObservations():
     dbq = "SELECT observationId, observationStartMJD as observationStartMJD_TAI, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId"
 
     pointing_db = PPReadPointingDatabase(get_test_filepath("baseline_10klines_2.0.db"), ["g", "r", "i"], dbq)
+
+    # simulate adding extra columns to the pointing db for the precomputed values
+    # needed for ephemeris generation. This ensures that the extra columns are not
+    # included in the merge in PPMatchPointingToObservations.
+    r_sun = np.empty((len(pointing_db), 3))
+    pointing_db["r_sun"] = r_sun.tolist()
 
     final_join = PPMatchPointingToObservations(joined_df_2, pointing_db)
 


### PR DESCRIPTION
Exclude columns that were pre-computed for ephemeris generation from being merged with the observations df.

Fixes #654  .

Certain columns were added during the pre-computation phase for ephemeris generation. Those columns don't need to be included in the observation dataframe that is used during post processing. So we exclude them from the pandas merge operation.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
