### PR TITLE
Breaking down the ephemeris calculation into smaller functions

### DIFF
--- a/demo/test_bench.py
+++ b/demo/test_bench.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":  # pragma: no cover
     cmd_args_dict = {
         "paramsinput": "./demo/mba_sample_1000_physical.csv",
         "orbinfile": "./demo/mba_sample_1000_orbit.csv",
-        "output_ephemeris_file": "./data/out/ephemeris_output.csv",
+        "output_ephemeris_file": "ephemeris_output.csv",
         "configfile": "./demo/test_bench_config.ini",
         "pointing_database": "./demo/baseline_v2.0_1yr.db",
         "outpath": "./data/out",

--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -1,7 +1,7 @@
+from dataclasses import dataclass
 from collections import defaultdict
 from csv import writer
 from io import StringIO
-from os import path
 
 import numpy as np
 import pandas as pd
@@ -18,6 +18,17 @@ from sorcha.ephemeris.simulation_parsing import *
 from sorcha.utilities.dataUtilitiesForTests import get_data_out_filepath
 
 out_csv_path = get_data_out_filepath("ephemeris_output.csv")
+
+
+@dataclass
+class EphemerisGeometryParameters:
+    obj_id: str = None
+    mjd_tai: float = None
+    rho: float = None
+    rho_hat: float = None
+    rho_mag: float = None
+    r_ast: float = None
+    v_ast: float = None
 
 
 def create_ephemeris(orbits_df, pointings_df, args, configs):
@@ -92,62 +103,30 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
             desigs.update(pixel_dict[pix])
 
         for obj_id in sorted(desigs):
+            ephem_geom_params = EphemerisGeometryParameters()
+            ephem_geom_params.obj_id = obj_id
+            ephem_geom_params.mjd_tai = mjd_tai
+
             v = sim_dict[obj_id]
             sim, ex, rho_hat_rough = v["sim"], v["ex"], v["rho_hat"]
             ang = np.arccos(np.dot(rho_hat_rough, pointing["visit_vector"])) * 180 / np.pi
             if ang < ang_fov + buffer:
-                rho, rho_mag, lt, r_ast, v_ast = integrate_light_time(
+                (
+                    ephem_geom_params.rho,
+                    ephem_geom_params.rho_mag,
+                    _,
+                    ephem_geom_params.r_ast,
+                    ephem_geom_params.v_ast,
+                ) = integrate_light_time(
                     sim, ex, pointing["JD_TDB"] - ephem.jd_ref, pointing["r_obs"], lt0=0.01
                 )
-                rho_hat = rho / rho_mag
+                ephem_geom_params.rho_hat = ephem_geom_params.rho / ephem_geom_params.rho_mag
 
-                ang_from_center = 180 / np.pi * np.arccos(np.dot(rho_hat, pointing["visit_vector"]))
+                ang_from_center = (
+                    180 / np.pi * np.arccos(np.dot(ephem_geom_params.rho_hat, pointing["visit_vector"]))
+                )
                 if ang_from_center < ang_fov:
-                    # Only do rates and geometry if the object is within the FOV
-                    ra0, dec0 = vec2ra_dec(rho_hat)
-                    drhodt = v_ast - pointing["v_obs"]
-                    drho_magdt = (1 / rho_mag) * np.dot(rho, drhodt)
-                    ddeltatdt = drho_magdt / (SPEED_OF_LIGHT)
-                    drhodt = v_ast * (1 - ddeltatdt) - pointing["v_obs"]
-                    A, D = get_residual_vectors(rho_hat)
-                    drho_hatdt = drhodt / rho_mag - drho_magdt * rho_hat / rho_mag
-                    dradt = np.dot(A, drho_hatdt)
-                    ddecdt = np.dot(D, drho_hatdt)
-                    r_ast_sun = r_ast - pointing["r_sun"]
-                    v_ast_sun = v_ast - pointing["v_sun"]
-                    r_ast_obs = r_ast - pointing["r_obs"]
-                    phase_angle = np.arccos(
-                        np.dot(r_ast_sun, r_ast_obs) / (np.linalg.norm(r_ast_sun) * np.linalg.norm(r_ast_obs))
-                    )
-                    obs_sun = np.asarray(pointing["r_obs"]) - np.asarray(pointing["r_sun"])
-                    dobs_sundt = np.asarray(pointing["v_obs"]) - np.asarray(pointing["v_sun"])
-
-                    out_tuple = (
-                        obj_id,
-                        pointing["FieldID"],
-                        mjd_tai,
-                        pointing["JD_TDB"],
-                        rho_mag * AU_KM,
-                        drho_magdt * AU_KM / (24 * 60 * 60),
-                        ra0,
-                        dradt * 180 / np.pi,
-                        dec0,
-                        ddecdt * 180 / np.pi,
-                        r_ast_sun[0] * AU_KM,
-                        r_ast_sun[1] * AU_KM,
-                        r_ast_sun[2] * AU_KM,
-                        v_ast_sun[0] * AU_KM / (24 * 60 * 60),
-                        v_ast_sun[1] * AU_KM / (24 * 60 * 60),
-                        v_ast_sun[2] * AU_KM / (24 * 60 * 60),
-                        obs_sun[0] * AU_KM,
-                        obs_sun[1] * AU_KM,
-                        obs_sun[2] * AU_KM,
-                        dobs_sundt[0] * AU_KM / (24 * 60 * 60),
-                        dobs_sundt[1] * AU_KM / (24 * 60 * 60),
-                        dobs_sundt[2] * AU_KM / (24 * 60 * 60),
-                        phase_angle * 180 / np.pi,
-                    )
-
+                    out_tuple = calculate_rates_and_geometry(pointing, ephem_geom_params)
                     in_memory_csv.writerow(out_tuple)
 
     # reset to the beginning of the in-memory CSV
@@ -199,3 +178,66 @@ def update_pixel_dict(JD_TDB, t_picket, picket_interval, sim_dict, ephem, obsCod
         this_pix = hp.vec2pix(nside, rho_hat[0], rho_hat[1], rho_hat[2], nest=True)
         pixel_dict[this_pix].append(k)
     return t_picket, pixel_dict, r_obs
+
+
+def calculate_rates_and_geometry(pointing: pd.DataFrame, ephem_geom_params: EphemerisGeometryParameters):
+    """Calculate rates and geometry for objects within the field of view
+
+    Parameters
+    ----------
+    pointing : pd.DataFrame
+        The dataframe containing the pointing database.
+    ephem_geom_params : EphemerisGeometryParameters
+        Various parameters necessary to calculate the ephemeris
+
+    Returns
+    -------
+    tuple
+        Tuple containing the ephemeris parameters needed for Sorcha post processing.
+    """
+    ra0, dec0 = vec2ra_dec(ephem_geom_params.rho_hat)
+    drhodt = ephem_geom_params.v_ast - pointing["v_obs"]
+    drho_magdt = (1 / ephem_geom_params.rho_mag) * np.dot(ephem_geom_params.rho, drhodt)
+    ddeltatdt = drho_magdt / (SPEED_OF_LIGHT)
+    drhodt = ephem_geom_params.v_ast * (1 - ddeltatdt) - pointing["v_obs"]
+    A, D = get_residual_vectors(ephem_geom_params.rho_hat)
+    drho_hatdt = (
+        drhodt / ephem_geom_params.rho_mag
+        - drho_magdt * ephem_geom_params.rho_hat / ephem_geom_params.rho_mag
+    )
+    dradt = np.dot(A, drho_hatdt)
+    ddecdt = np.dot(D, drho_hatdt)
+    r_ast_sun = ephem_geom_params.r_ast - pointing["r_sun"]
+    v_ast_sun = ephem_geom_params.v_ast - pointing["v_sun"]
+    r_ast_obs = ephem_geom_params.r_ast - pointing["r_obs"]
+    phase_angle = np.arccos(
+        np.dot(r_ast_sun, r_ast_obs) / (np.linalg.norm(r_ast_sun) * np.linalg.norm(r_ast_obs))
+    )
+    obs_sun = np.asarray(pointing["r_obs"]) - np.asarray(pointing["r_sun"])
+    dobs_sundt = np.asarray(pointing["v_obs"]) - np.asarray(pointing["v_sun"])
+
+    return (
+        ephem_geom_params.obj_id,
+        pointing["FieldID"],
+        ephem_geom_params.mjd_tai,
+        pointing["JD_TDB"],
+        ephem_geom_params.rho_mag * AU_KM,
+        drho_magdt * AU_KM / (24 * 60 * 60),
+        ra0,
+        dradt * 180 / np.pi,
+        dec0,
+        ddecdt * 180 / np.pi,
+        r_ast_sun[0] * AU_KM,
+        r_ast_sun[1] * AU_KM,
+        r_ast_sun[2] * AU_KM,
+        v_ast_sun[0] * AU_KM / (24 * 60 * 60),
+        v_ast_sun[1] * AU_KM / (24 * 60 * 60),
+        v_ast_sun[2] * AU_KM / (24 * 60 * 60),
+        obs_sun[0] * AU_KM,
+        obs_sun[1] * AU_KM,
+        obs_sun[2] * AU_KM,
+        dobs_sundt[0] * AU_KM / (24 * 60 * 60),
+        dobs_sundt[1] * AU_KM / (24 * 60 * 60),
+        dobs_sundt[2] * AU_KM / (24 * 60 * 60),
+        phase_angle * 180 / np.pi,
+    )

--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -97,7 +97,9 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
             )
             first = 0
 
-        # This should be a separate function
+        # This loop builds a python set containing ids for objects in the pixels
+        # around the current pointing. The function `update_pixel_dict` does
+        # the majority of the computation to build out `pixel_dict`.
         desigs = set()
         for pix in pointing["pixels"]:
             desigs.update(pixel_dict[pix])

--- a/tests/ephemeris/test_simulation_driver.py
+++ b/tests/ephemeris/test_simulation_driver.py
@@ -14,7 +14,7 @@ def test_calculate_rates_and_geometry():
     ephem_geom_params.r_ast = np.asarray([2.22134111, -1.4666382, -0.88530195])
     ephem_geom_params.v_ast = np.asarray([0.00608846, 0.00585226, 0.00487886])
 
-    pointing = pd.DataFrame(
+    pointing_df = pd.DataFrame(
         {
             "FieldID": 848,
             "observationStartMJD_TAI": 60218.984626,
@@ -26,17 +26,19 @@ def test_calculate_rates_and_geometry():
             "fieldDec": -23.54289743479277,
             "rotSkyPos": 112.25651472435484,
             "observationId_": 848,
-            "visit_vector": [0.555998946329719, -0.7289145382156643, -0.399435561333849],
+            "visit_vector": [[0.555998946329719, -0.7289145382156643, -0.399435561333849]],
             "JD_TDB": 2460219.484998981,
             "pixels": None,
-            "r_obs": [0.9825025212987633, 0.12894773431445178, 0.056115072741286603],
-            "v_obs": [-0.002514846222194574, 0.015645226468919866, 0.006740310710189443],
-            "r_sun": [-0.008375571318557293, -0.0021278397223137443, -0.0006896179222345509],
-            "v_sun": [4.014508061373484e-06, -7.199434717117629e-06, -3.1502131721138966e-06],
+            "r_obs": [[0.9825025212987633, 0.12894773431445178, 0.056115072741286603]],
+            "v_obs": [[-0.002514846222194574, 0.015645226468919866, 0.006740310710189443]],
+            "r_sun": [[-0.008375571318557293, -0.0021278397223137443, -0.0006896179222345509]],
+            "v_sun": [[4.014508061373484e-06, -7.199434717117629e-06, -3.1502131721138966e-06]],
         }
     )
 
-    output_tuple = calculate_rates_and_geometry(pointing, ephem_geom_params)
+    single_pointing = pointing_df.iloc[0]
+
+    output_tuple = calculate_rates_and_geometry(single_pointing, ephem_geom_params)
 
     expected_tuple = (
         "S100cuR2a",
@@ -64,5 +66,4 @@ def test_calculate_rates_and_geometry():
         18.73383934462223,
     )
 
-    # assert np.allclose(output_tuple[1:], expected_tuple[1:])
-    assert True
+    assert np.allclose(output_tuple[1:], expected_tuple[1:])

--- a/tests/ephemeris/test_simulation_driver.py
+++ b/tests/ephemeris/test_simulation_driver.py
@@ -1,0 +1,68 @@
+import pytest
+import numpy as np
+import pandas as pd
+from sorcha.ephemeris.simulation_driver import calculate_rates_and_geometry, EphemerisGeometryParameters
+
+
+def test_calculate_rates_and_geometry():
+    ephem_geom_params = EphemerisGeometryParameters()
+    ephem_geom_params.obj_id = "S100cuR2a"
+    ephem_geom_params.mjd_tai = 60218.98462644687
+    ephem_geom_params.rho = np.asarray([1.23883859, -1.59558594, -0.94141702])
+    ephem_geom_params.rho_mag = 2.2286501594614134
+    ephem_geom_params.rho_hat = np.asarray([0.55586947, -0.71594276, -0.42241579])
+    ephem_geom_params.r_ast = np.asarray([2.22134111, -1.4666382, -0.88530195])
+    ephem_geom_params.v_ast = np.asarray([0.00608846, 0.00585226, 0.00487886])
+
+    pointing = pd.DataFrame(
+        {
+            "FieldID": 848,
+            "observationStartMJD_TAI": 60218.984626,
+            "optFilter": "i",
+            "seeingFwhmGeom": 1.1027086372149535,
+            "seeingFwhmEff": 1.2782343518430093,
+            "fiveSigmaDepth": 22.951091131134614,
+            "fieldRA": 307.3355402760053,
+            "fieldDec": -23.54289743479277,
+            "rotSkyPos": 112.25651472435484,
+            "observationId_": 848,
+            "visit_vector": [0.555998946329719, -0.7289145382156643, -0.399435561333849],
+            "JD_TDB": 2460219.484998981,
+            "pixels": None,
+            "r_obs": [0.9825025212987633, 0.12894773431445178, 0.056115072741286603],
+            "v_obs": [-0.002514846222194574, 0.015645226468919866, 0.006740310710189443],
+            "r_sun": [-0.008375571318557293, -0.0021278397223137443, -0.0006896179222345509],
+            "v_sun": [4.014508061373484e-06, -7.199434717117629e-06, -3.1502131721138966e-06],
+        }
+    )
+
+    output_tuple = calculate_rates_and_geometry(pointing, ephem_geom_params)
+
+    expected_tuple = (
+        "S100cuR2a",
+        848,
+        60218.98462644687,
+        2460219.484998981,
+        333401318.3906429,
+        21.781422998045304,
+        307.8263396305563,
+        0.020288816433054996,
+        -24.987200752790443,
+        0.09791651860940978,
+        333560867.6659607,
+        -219087631.65531665,
+        -132336121.193526,
+        10.534961069620792,
+        10.145404535726742,
+        8.452994256388143,
+        148233252.77882853,
+        19608626.776680324,
+        8497860.769034933,
+        -4.361298632362694,
+        27.101499843444632,
+        11.676011519485472,
+        18.73383934462223,
+    )
+
+    # assert np.allclose(output_tuple[1:], expected_tuple[1:])
+    assert True


### PR DESCRIPTION
Fixes #638  .

This PR breaks down the `create_ephemeris` function into smaller functions to easier unit testing. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
