### PR TITLE
Moving the conditional check of `len(observations)` earlier.

### DIFF
--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -187,8 +187,6 @@ def runLSSTSimulation(args, configs, pplogger=None):
         verboselog("Start post processing for this chunk")
         verboselog("Matching pointing database information to observations on rough camera footprint")
 
-        observations = PPMatchPointingToObservations(observations, filterpointing)
-
         # If the ephemeris file doesn't have any observations for the objects in the chunk
         # PPReadAllInput will return an empty dataframe. We thus log a warning.
         if len(observations) == 0:
@@ -197,6 +195,8 @@ def runLSSTSimulation(args, configs, pplogger=None):
             )
             startChunk = startChunk + configs["size_serial_chunk"]
             continue
+
+        observations = PPMatchPointingToObservations(observations, filterpointing)
 
         verboselog("Calculating apparent magnitudes...")
         observations = PPCalculateApparentMagnitude(


### PR DESCRIPTION
Fixes #619  .

The check for an empty dataframe was already in the main while loop, it's just that some how the call to `PPMatchPointingToObservations` had been placed before it. Thus if `observations` was empty, sorcha would error out after trying to join to an empty dataframe. 

So I moved the conditional to an earlier point in the code, or if you want to look at it a different way, I moved the call to `PPMatchPointingToObservations` after the conditional check :) 

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
