### PR TITLE
Log and exit if complex parameter file wasn't provided

### DIFF
--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -480,6 +480,14 @@ def main():
         pplogger.error("ERROR: A+R simulation not enabled and no ephemerides file provided")
         sys.exit("ERROR: A+R simulation not enabled and no ephemerides file provided")
 
+    if configs["lc_model"] and cmd_args["complex_physical_parameters"] is None:
+        pplogger.error("ERROR: No complex physical parameter file provided for light curve model")
+        sys.exit("ERROR: No complex physical parameter file provided for light curve model")
+
+    if configs["comet_activity"] and cmd_args["complex_physical_parameters"] is None:
+        pplogger.error("ERROR: No complex physical parameter file provided for comet activity model")
+        sys.exit("ERROR: No complex physical parameter file provided for comet activity model")
+
     if "SORCHA_SEED" in os.environ:
         cmd_args["seed"] = int(os.environ["SORCHA_SEED"])
         pplogger.info(f"Random seed overridden via environmental variable, SORCHA_SEED={cmd_args['seed']}")


### PR DESCRIPTION
Log and exit if user requested lightcurve or comet model, but no complex param file was provided.

Fixes #578 .

The logic is fairly straight forward here. But there was a question in the issue about whether it makes sense to enforce this or not - because it's possible that some user defined light curve or comet activity model may not require any additional parameters at all. 

I think it's a valid case to consider, but I can't immediately think of a simple way to enable that functionality.  I'll try to think a little more about this though. 

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
