### PR TITLE
Adding logging to ephemeris generation.

### DIFF
--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -100,7 +100,7 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
     ephem, gm_sun = create_assist_ephemeris(args)
     verboselog("Furnishing SPICE kernels.")
     furnish_spiceypy(args)
-    verboselog("Generating simulations.")
+    verboselog("Generating ASSIST+REBOUND simulations.")
     sim_dict = generate_simulations(ephem, gm_sun, orbits_df)
     pixel_dict = defaultdict(list)
     observatories = Observatory(args)


### PR DESCRIPTION
This is the setup for #525. I've added verbose logging to `create_ephemeris` in `simulation_driver.py`, and also added a few logging info messages in that function. 

If you want to add more log messages:

```
verboselog("This prints a message to the info log if verbose == True.")
args.pplogger.info("This forces a log message to the info log.")
args.pplogger.error("This prints a message to the error log.")
```

Adding logging to _another_ function is as simple as making sure args is passed to that function, then to enable verbose logging, add at the top of the function:

`verboselog = args.pplogger.info if args.verbose else lambda *a, **k: None`

You can see how I've done this at the top of `create_ephemeris`.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
