### PR TITLE
Issue #607: Removing separatelycsv output option.

### DIFF
--- a/demo/OIFconfig_benchmark.ini
+++ b/demo/OIFconfig_benchmark.ini
@@ -135,8 +135,8 @@ SSP_maximum_time = 0.0625
 # -u or --outfile               Output file path.
 # -t or --stem                  Output file stem.
 
-# Output format. The 'separatelycsv' option saves output into separate CSVs for each object.
-# Options: csv, separatelycsv, sqlite3, hdf5
+# Output format.
+# Options: csv, sqlite3, hdf5
 output_format = csv
 
 # Size of output. Controls which columns are in the output files.

--- a/demo/OIFconfig_lca.ini
+++ b/demo/OIFconfig_lca.ini
@@ -131,8 +131,8 @@ SSP_maximum_time = 0.0625
 # -u or --outfile               Output file path.
 # -t or --stem                  Output file stem.
 
-# Output format. The 'separatelycsv' option saves output into separate CSVs for each object.
-# Options: csv, separatelycsv, sqlite3, hdf5
+# Output format.
+# Options: csv, sqlite3, hdf5
 output_format = csv
 
 # Size of output. Controls which columns are in the output files.

--- a/demo/config_for_ephemeris_unit_test.ini
+++ b/demo/config_for_ephemeris_unit_test.ini
@@ -145,8 +145,8 @@ SSP_track_window = 15
 
 [OUTPUT]
 
-# Output format. The 'separatelycsv' option saves output into separate CSVs for each object.
-# Options: csv, separatelycsv, sqlite3, hdf5
+# Output format.
+# Options: csv, sqlite3, hdf5
 output_format = csv
 
 # Size of output. Controls which columns are in the output files.

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -625,9 +625,9 @@ def PPConfigFileParser(configfile, survey_name):
     config_dict["output_format"] = PPGetOrExit(
         config, "OUTPUT", "output_format", "ERROR: output format not specified."
     ).lower()
-    if config_dict["output_format"] not in ["csv", "separatelycsv", "sqlite3", "hdf5", "h5"]:
-        pplogger.error("ERROR: output_format should be either csv, separatelycsv, sqlite3 or hdf5.")
-        sys.exit("ERROR: output_format should be either csv, separatelycsv, sqlite3 or hdf5.")
+    if config_dict["output_format"] not in ["csv", "sqlite3", "hdf5", "h5"]:
+        pplogger.error("ERROR: output_format should be either csv, sqlite3 or hdf5.")
+        sys.exit("ERROR: output_format should be either csv, sqlite3 or hdf5.")
 
     config_dict["output_size"] = PPGetOrExit(
         config, "OUTPUT", "output_size", "ERROR: output size not specified."

--- a/src/sorcha/modules/PPOutput.py
+++ b/src/sorcha/modules/PPOutput.py
@@ -144,20 +144,6 @@ def PPWriteOutput(cmd_args, configs, observations_in, endChunk=0, verbose=False)
         verboselog("Output to CSV file...")
         observations = PPOutWriteCSV(observations, out)
 
-    elif configs["output_format"] == "separatelycsv":
-        outputsuffix = ".csv"
-        objid_list = observations["ObjID"].unique().tolist()
-        verboselog("Output to " + str(len(objid_list)) + " separate output CSV files...")
-
-        i = 0
-        while i < len(objid_list):
-            single_object_df = pd.DataFrame(observations[observations["ObjID"] == objid_list[i]])
-            out = os.path.join(
-                cmd_args.outpath, str(objid_list[i]) + "_" + cmd_args.outfilestem + outputsuffix
-            )
-            observations = PPOutWriteCSV(single_object_df, out)
-            i = i + 1
-
     elif configs["output_format"] == "sqlite3":
         outputsuffix = ".db"
         out = os.path.join(cmd_args.outpath, cmd_args.outfilestem + outputsuffix)

--- a/tests/data/test_PPConfig.ini
+++ b/tests/data/test_PPConfig.ini
@@ -145,8 +145,8 @@ ar_healpix_order = 6
 
 [OUTPUT]
 
-# Output format. The 'separatelycsv' option saves output into separate CSVs for each object.
-# Options: csv, separatelycsv, sqlite3, hdf5
+# Output format.
+# Options: csv, sqlite3, hdf5
 output_format = csv
 
 # Size of output. Controls which columns are in the output files.

--- a/tests/data/test_ephem_config.ini
+++ b/tests/data/test_ephem_config.ini
@@ -142,8 +142,8 @@ ar_healpix_order = 6
 
 [OUTPUT]
 
-# Output format. The 'separatelycsv' option saves output into separate CSVs for each object.
-# Options: csv, separatelycsv, sqlite3, hdf5
+# Output format.
+# Options: csv, sqlite3, hdf5
 output_format = csv
 
 # Size of output. Controls which columns are in the output files.

--- a/tests/sorcha/test_PPOutput.py
+++ b/tests/sorcha/test_PPOutput.py
@@ -43,7 +43,6 @@ def setup_and_teardown_for_PPWriteOutput():
     tmp_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
 
     os.remove(os.path.join(tmp_path, "PPOutput_test_out.csv"))
-    os.remove(os.path.join(tmp_path, "S1000000a_PPOutput_test_out.csv"))
     os.remove(os.path.join(tmp_path, "PPOutput_test_out.db"))
 
 
@@ -117,10 +116,6 @@ def test_PPWriteOutput(setup_and_teardown_for_PPWriteOutput):
     PPWriteOutput(args, configs, observations, 10)
     csv_test_in = pd.read_csv(os.path.join(tmp_path, "PPOutput_test_out.csv"))
 
-    configs["output_format"] = "separatelycsv"
-    PPWriteOutput(args, configs, observations, 10)
-    sep_test_in = pd.read_csv(os.path.join(tmp_path, "S1000000a_PPOutput_test_out.csv"))
-
     configs["output_format"] = "sqlite3"
     PPWriteOutput(args, configs, observations, 10)
     cnx = sqlite3.connect(os.path.join(tmp_path, "PPOutput_test_out.db"))
@@ -150,7 +145,6 @@ def test_PPWriteOutput(setup_and_teardown_for_PPWriteOutput):
     )
 
     assert_equal(csv_test_in.loc[0, :].values, expected)
-    assert_equal(sep_test_in.loc[0, :].values, expected)
     assert_equal(sql_test_in.loc[0, :].values, expected)
 
     return


### PR DESCRIPTION
Fixes #607.

Removed 'separatelycsv' as an output option from PPOutput.py and also removed the related lines from the unit tests.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
