### PR TITLE
Include attempt to import SCU when starting Sorcha.

### DIFF
--- a/src/sorcha/__init__.py
+++ b/src/sorcha/__init__.py
@@ -2,3 +2,12 @@ from . import modules
 from . import readers
 from . import lightcurves
 from .sorcha import cite
+
+# Attempt to import sorcha_community_utils [SCU]. Sorcha does not depend on SCU
+# and will not include it during a typical installation. If plugins from SCU are
+# desired, the user should install SCU manually in their virtual environment
+# prior to executing Sorcha.
+try:
+    from sorcha_community_utils import *
+except ModuleNotFoundError:
+    pass


### PR DESCRIPTION
Fixes #686  .

Add a try/except to attempt to import sorcha community utils (even if it's not currently included in the virtual environment) so that slurm scripts can more easily make use of SCU.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
