### PR TITLE
Fixing error/warnings when writing to HDF5, circleRadius bug.

### DIFF
--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -779,7 +779,7 @@ def PPPrintConfigsToLog(configs, cmd_args):
             pplogger.info(
                 "The code will approximate chip gaps using filling factor: " + str(configs["fill_factor"])
             )
-        elif configs["circleRadius"]:
+        elif configs["circle_radius"]:
             pplogger.info(
                 "A circular footprint will be applied with radius: " + str(configs["circle_radius"])
             )

--- a/src/sorcha/modules/PPOutput.py
+++ b/src/sorcha/modules/PPOutput.py
@@ -3,6 +3,10 @@ import os
 import sqlite3
 import logging
 
+# this is for suppressing a warning in PyTables when writing to HDF5
+import warnings
+from tables import NaturalNameWarning
+
 
 def PPOutWriteCSV(padain, outf):
     """
@@ -42,6 +46,14 @@ def PPOutWriteHDF5(pp_results, outf, keyin):
     None.
 
     """
+
+    # pytables doesn't like the Pandas extension dtype StringDtype
+    # converting the ObjID to 'str' type fixes this
+    pp_results = pp_results.astype({"ObjID": str})
+
+    # this suppresses a warning when ObjIDs begin with a number
+    # as long as the user isn't going to use PyTables to access the data this doesn't matter
+    warnings.filterwarnings("ignore", category=NaturalNameWarning)
 
     of = pp_results.to_hdf(outf, mode="a", format="table", append=True, key=keyin)
 


### PR DESCRIPTION
Fixes #722.
Fixes #727 

The NaturalNameWarning is now suppressed when writing to HDF5 when your object IDs start with a number (or don't otherwise fit PyTables' rather strict naming pattern `^[a-zA-Z_][a-zA-Z0-9_]*$`). Unless the user is going to be using PyTables to look at the data, this won't be an issue - we can warn them about this in the docs.

While recreating this error, I also found a bug. At some point in the code -- I have no idea why or where, grepping didn't help -- the ObjID column is being changed to a Pandas dtype that PyTables doesn't support ('StringDtype'), leading to errors when writing out to HDF5. 

This wasn't caught in the unit test because the unit test for `PPOutWriteHDF5()` just loads in some data from a CSV file then writes it out. Short of running all of Sorcha in `test_PPOutWriteHDF5()`, I'm not sure this COULD have been caught - might be an argument for having end-to-end tests for all the output formats.

I have inserted a line in `PPOutWriteHDF5()` that changes the type of that column to a standard 'str' instead. 

**ADDITIONAL FIX:**
I have also fixed that one horrible lonely instance of `circleRadius` being used instead of `circle_radius` in `PPPrintConfigsToLog()`. Finally.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
