### PR TITLE
Doc strings reformatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Other software utilities can be found in this github repository: [https://github
 * All required input files for the main software or unit tests should have extensions that clearly describe the file format (e.g. .csv, .txt, .db, .fits)
 * If you are working on addressing a specific issue ticket, assign yourself the ticket.
 * When making a pull request that closes an issue, cite the issue ticket in the pull request summary
+* Docstrings should follow the [NumPy style](https://numpydoc.readthedocs.io/en/latest/format.html) 
 
 ## Collaboration
 This effort is a collaboration between Queen's University Belfast, the University of Washington's DiRAC Institute, 

--- a/src/sorcha/ephemeris/simulation_constants.py
+++ b/src/sorcha/ephemeris/simulation_constants.py
@@ -14,13 +14,16 @@ def create_ecl_to_eq_rotation_matrix(ecl):
     system's ecliptic obliquity is already provided as
     `ECL_TO_EQ_ROTATION_MATRIX`.
 
-    Parameters:
+    Parameters
     -----------
-    ecl (float): The ecliptical obliquity.
+    ecl : float
+        The ecliptical obliquity.
 
-    Returns:
+    Returns
     -----------
-    `numpy` array with shape (3,3).
+    rotmat: numpy array/matrix of floats
+        rotation matrix for transofmring ecliptical coordinates to equatorial coordinates.
+        Array has shape (3,3).
 
     """
     ce = np.cos(-ecl)

--- a/src/sorcha/ephemeris/simulation_data_files.py
+++ b/src/sorcha/ephemeris/simulation_data_files.py
@@ -74,16 +74,16 @@ def make_retriever(directory_path: str = None, registry: dict = REGISTRY) -> poo
 
     Parameters
     ----------
-    directory_path : str, optional
-        The base directory to place all downloaded files, by default None
-    registry : dict, optional
+    directory_path : string, optional
+        The base directory to place all downloaded files. Default = None
+    registry : dictionary, optional
         A dictionary of file names to SHA hashes. Generally we'll not use SHA=None
-        because the files we're tracking change frequently, by default REGISTRY
+        because the files we're tracking change frequently. Default = REGISTRY
 
     Returns
     -------
-    pooch.Pooch
-        The Pooch object used to track and retrieve files.
+    : pooch
+        The instance of a Pooch object used to track and retrieve files.
     """
     dir_path = pooch.os_cache("sorcha")
     if directory_path:

--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -35,29 +35,15 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
     """Generate a set of observations given a collection of orbits
     and set of pointings.
 
-    This works by calculating and regularly updating the sky-plane
-    locations (unit vectors) of all the objects in the collection
-    of orbits.  The HEALPix index for each of the locations is calculated.
-    A dictionary with pixel indices as keys and lists of ObjIDs for
-    those objects in each HEALPix tile as values.  One of these
-    calculations is called a 'picket', as one element of a long picket
-    fence.  At present,
-
-    Given a specific pointing, the set of HEALPix tiles that are overlapped
-    by the pointing (and a buffer region) is computed.  These the precise
-    locations of just those objects within that set of HEALPix tiles are
-    computed.  Details for those that actually do land within the field
-    of view are passed along.
-
     Parameters
     ----------
-    orbits_df : pd.DataFrame
+    orbits_df : pandas dataframe
         The dataframe containing the collection of orbits.
-    pointings_df : pd.DataFrame
+    pointings_df : pandas dataframe
         The dataframe containing the collection of telescope/camera pointings.
     args :
         Various arguments necessary for the calculation
-    configs : dict
+    configs : dictionary
         Various configuration parameters necessary for the calculation
         ang_fov : float
             The angular size (deg) of the field of view
@@ -74,14 +60,30 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
             The MPC code for the observatory.  (This is current a configuration
             parameter, but these should be included in the visit information,
             to allow for multiple observatories.
-        nside : int
+        nside : integer
             The nside value used for the HEALPIx calculations.  Must be a
             power of 2 (1, 2, 4, ...)  nside=64 is current default.
 
     Returns
     -------
-    pd.DataFrame
+    observations: pandas dataframe
         The dataframe of observations needed for Sorcha to continue
+
+    Notes
+    -------
+    This works by calculating and regularly updating the sky-plane
+    locations (unit vectors) of all the objects in the collection
+    of orbits.  The HEALPix index for each of the locations is calculated.
+    A dictionary with pixel indices as keys and lists of ObjIDs for
+    those objects in each HEALPix tile as values.  One of these
+    calculations is called a 'picket', as one element of a long picket
+    fence.  At present,
+
+    Given a specific pointing, the set of HEALPix tiles that are overlapped
+    by the pointing (and a buffer region) is computed.  These the precise
+    locations of just those objects within that set of HEALPix tiles are
+    computed.  Details for those that actually do land within the field
+    of view are passed along.
     """
     verboselog = args.pplogger.info if args.verbose else lambda *a, **k: None
 
@@ -254,14 +256,14 @@ def calculate_rates_and_geometry(pointing: pd.DataFrame, ephem_geom_params: Ephe
 
     Parameters
     ----------
-    pointing : pd.DataFrame
+    pointing : pandas dataframe
         The dataframe containing the pointing database.
     ephem_geom_params : EphemerisGeometryParameters
         Various parameters necessary to calculate the ephemeris
 
     Returns
     -------
-    tuple
+    : tuple
         Tuple containing the ephemeris parameters needed for Sorcha post processing.
     """
     ra0, dec0 = vec2ra_dec(ephem_geom_params.rho_hat)

--- a/src/sorcha/ephemeris/simulation_setup.py
+++ b/src/sorcha/ephemeris/simulation_setup.py
@@ -36,8 +36,12 @@ def create_assist_ephemeris(args) -> tuple:
 
     Returns
     -------
-    Ephem, gm_sun
+    Ephem : ASSIST ephemeris obejct
         The ASSIST ephemeris object
+    gm_sun : float
+        value for the GM_SUN value
+    gm_total : float
+        value for gm_total
     """
     pplogger = logging.getLogger(__name__)
 
@@ -133,16 +137,16 @@ def precompute_pointing_information(pointings_df, args, configs):
 
     Parameters
     ----------
-    pointings_df : pd.dataframe
+    pointings_df : pandas dataframe
         Contains the telescope pointing database.
-    args : dict
+    args : dictionary
         Command line arguments needed for initialization.
-    configs : dict
+    configs : dictionary
         Configuration settings.
 
     Returns
     -------
-    pointings_df : pd.dataframe
+    pointings_df : pandas dataframe
         The original dataframe with several additional columns of precomputed values.
     """
     ephem, _, _ = create_assist_ephemeris(args)

--- a/src/sorcha/lightcurves/base_lightcurve.py
+++ b/src/sorcha/lightcurves/base_lightcurve.py
@@ -64,7 +64,7 @@ class AbstractLightCurve(ABC):
 
         Parameters
         ----------
-        error_msg : str
+        error_msg : string
             The string to be appended to the error log
         """
         logger.error(error_msg)

--- a/src/sorcha/lightcurves/identity_lightcurve.py
+++ b/src/sorcha/lightcurves/identity_lightcurve.py
@@ -50,7 +50,7 @@ class IdentityLightCurve(AbstractLightCurve):
 
         Returns
         -------
-        str
+        string
             Unique identifier for this light curve calculator
         """
         return "identity"

--- a/src/sorcha/modules/PPAddUncertainties.py
+++ b/src/sorcha/modules/PPAddUncertainties.py
@@ -29,13 +29,15 @@ def degCos(x):
     """
     Calculate cosine of an angle in degrees.
 
-    Parameters:
+    Parameters
     -----------
-    x (float): angle in degrees.
+    x : float
+        angle in degrees.
 
-    Returns:
+    Returns
     -----------
-    The cosine of x.
+    float
+        The cosine of x.
     """
 
     return np.cos(x * np.pi / 180.0)
@@ -45,13 +47,15 @@ def degSin(x):
     """
     Calculate sine of an angle in degrees.
 
-    Parameters:
+    Parameters
     -----------
-    x (float): angle in degrees.
+    x : float
+        angle in degrees.
 
-    Returns:
+    Returns
     -----------
-    The sine of x.
+    float
+        The sine of x.
     """
 
     return np.sin(x * np.pi / 180.0)
@@ -62,19 +66,25 @@ def addUncertainties(detDF, configs, module_rngs, verbose=True):
     Generates astrometric and photometric uncertainties, and SNR. Uses uncertainties
     to randomize the photometry. Accounts for trailing losses.
 
-    Parameters:
+    Parameters
     -----------
-    detDF (Pandas dataframe): Dataframe of observations.
+    detDF : Pandas dataframe)
+        Dataframe of observations.
 
-    configs (dictionary): dictionary of configurations from config file.
+    configs : dictionary
+        dictionary of configurations from config file.
 
-    module_rngs (PerModuleRNG): A collection of random number generators (per module).
+    module_rngs : PerModuleRNG
+        A collection of random number generators (per module).
 
-    Returns:
+    verbose: Boolean, optional
+    Verbose Logging Flag. Default = True
+
+    Returns
     -----------
-    detDF (Pandas dataframe): dataframe of observations, with new columns for observed
-    magnitudes, SNR, and astrometric/photometric uncertainties.
-
+    detDF : Pandas dataframe
+        dataframe of observations, with new columns for observed
+        magnitudes, SNR, and astrometric/photometric uncertainties.
     """
 
     pplogger = logging.getLogger(__name__)
@@ -126,23 +136,48 @@ def uncertainties(
     """
     Add astrometric and photometric uncertainties to observations.
 
-    Parameters:
+    Parameters
     -----------
-    detDF (Pandas dataframe): dataframe containing observations.
+    detDF : Pandas dataframe
+        dataframe containing observations.
 
-    configs (dictionary): dictionary of configurations from config file.
+    configs : dictionary
+        dictionary of configurations from config file.
 
-    limMagName, seeingName, filterMagName, dra_name, ddec_name, dec_name (strings): column
-    names of the limiting magnitude, seeing, magnitude, RA rate, DEC rate and DEC.
+    limMagName : string, optional
+        pandas dataframe column name of the limiting magnitude.
+        Default = "fiveSigmaDepthAtSource"
 
-    Returns:
+    seeingName : string, optional
+        pandas dataframe column name of the seeing
+        Default = "seeingFwhmGeom"
+
+    filterMagName : string, optional
+        pandas dataframe column name of the object magnitude
+        Default = "TrailedSourceMag"
+
+    dra_name : string, optional
+        pandas dataframe column name of the object RA rate
+        Default = "AstRARate(deg/day)"
+
+    ddec_name: string, optional
+        pandas dataframe column name of the object declination rate
+        Default = "AstDecRate(deg/day)"
+
+    dec_name : string, optional
+        pandas dataframe column name of the object declination
+        Default = "AstDec(deg)"
+
+    Returns
     -----------
-    astrSigDeg (numpy array): astrometric uncertainties in degrees.
+    astrSigDeg: numpy array
+        astrometric uncertainties in degrees.
 
-    photometric_sigma (numpy array): photometric uncertainties in magnitude.
+    photometric_sigma: numpy array
+        photometric uncertainties in magnitude.
 
-    SNR (numpy array): signal-to-noise ratio.
-
+    SNR: numpy array
+        signal-to-noise ratio.
     """
 
     if configs.get("trailing_losses_on", False):
@@ -165,6 +200,51 @@ def calcAstrometricUncertainty(
     mag, m5, nvisit=1, FWHMeff=700.0, error_sys=10.0, astErrCoeff=0.60, output_units="mas"
 ):
     """Calculate the astrometric uncertainty, for object catalog purposes.
+
+
+    Parameters
+    -----------
+    mag : float or array of floats)
+        magnitude of the observation.
+
+    m5 : float or array of floats
+        5-sigma limiting magnitude.
+
+    nvisit :int, optional
+        number of visits to consider.
+        Default = 1
+
+    FWHMeff : float, optional
+        effective Full Width at Half Maximum of Point Spread Function [mas].
+        Default = 700.0
+
+    error_sys : float, optional
+        systematic error [mas].
+        Default = 10.0
+
+    astErrCoeff : float, optional
+        Astrometric error coefficient
+        (see calcRandomAstrometricErrorPerCoord description).
+        Default = 0.60
+
+    output_units : string, optional
+       Default: "mas"  (milliarcseconds)
+        other options: "arcsec" (arcseconds)
+
+    Returns
+    -----------
+    astrom_error : float or array of floats)
+        astrometric error.
+
+    SNR : float or array of floats)
+        signal to noise ratio.
+
+    error_rand : float or array of floats
+        random error.
+
+    Notes
+    ------------
+
     The effective FWHMeff MUST BE given in miliarcsec (NOT arcsec!).
     Systematic error, error_sys, must be given in miliarcsec.
     The result corresponds to a single-coordinate uncertainty.
@@ -172,40 +252,16 @@ def calcAstrometricUncertainty(
     matching two catalogs) will be sqrt(2) times larger.
     Default values for parameters are based on estimates for LSST.
 
-    Parameters:
-    -----------
-    mag (float/array of floats): magnitude of the observation.
-
-    m5 (float/array of floats): 5-sigma limiting magnitude.
-
-    nvisit (int): number of visits to consider.
-
-    FWHMeff (float): effective Full Width at Half Maximum of Point Spread Function [mas].
-
-    error_sys (float): systematic error [mas].
-
-    output_units (string): 'mas' (default): milliarcseconds, 'arcsec': arcseconds.
-
-    Returns:
-    -----------
-    astrom_error (float/array of floats): astrometric error.
-
-    SNR (float/array of floats): signal to noise ratio.
-
-    error_rand (float/array of floats): random error.
-
-    Description:
-    ------------
     The astrometric error can be applied to parallax or proper motion (for nvisit>1).
     If applying to proper motion, should also divide by the # of years of the survey.
     This is also referenced in the LSST overview paper (arXiv:0805.2366, ls.st/lop)
+
 
     - assumes sqrt(Nvisit) scaling, which is the best-case scenario
     - calcRandomAstrometricError assumes maxiumm likelihood solution,
       which is also the best-case scenario
     - the systematic error, error_sys = 10 mas, corresponds to the
       design spec from the LSST Science Requirements Document (ls.st/srd)
-
     """
 
     # first compute SNR
@@ -229,26 +285,35 @@ def calcAstrometricUncertainty(
 
 def calcRandomAstrometricErrorPerCoord(FWHMeff, SNR, AstromErrCoeff=0.60):
     """Calculate the random astrometric uncertainty, as a function of
-    effective FWHMeff and signal-to-noise ratio SNR
-    Returns astrometric uncertainty in the same units as FWHM.
+    effective FWHMeff and signal-to-noise ratio SNR and return
+    the astrometric uncertainty in the same units as FWHM.
+
     ** This error corresponds to a single-coordinate error **
     the total astrometric uncertainty (e.g. relevant when matching
     two catalogs) will be sqrt(2) times larger.
 
-    Parameters:
+    Parameters
     -----------
-    FWHMeff (float/array of floats): Effective Full Width at Half Maximum of Point Spread Function [mas].
+    FWHMeff : float or array of floats
+        Effective Full Width at Half Maximum of Point Spread Function [mas].
 
-    SNR (float/array of floats): Signal-to-noise ratio.
+    SNR : float or array of floats
+        Signal-to-noise ratio.
 
-    AstromErrCoeff (float): Astrometric error coefficient (see description below).
+    AstromErrCoeff : float, optional
+        Astrometric error coefficient (see description below).
+        Default =0.60
 
-    Returns:
+    Returns
     -----------
-    RandomAstrometricErrorPerCoord (float/array of floats): random astrometric uncertainty per coordinate.
+    RandomAstrometricErrorPerCoord: float or array of floats
+        random astrometric uncertainty per coordinate.
 
-    Description:
+    Returns astrometric uncertainty in the same units as FWHMeff.
+
+    Notes
     ------------
+
     The coefficient AstromErrCoeff for Maximum Likelihood
     solution is given by
 
@@ -281,14 +346,15 @@ def calcPhotometricUncertainty(snr):
     """
     Convert flux signal to noise ratio to an uncertainty in magnitude.
 
-    Parameters:
+    Parameters
     -----------
-    snr (float/array of floats): The signal-to-noise-ratio in flux.
+    snr : float or array of floats
+        The signal-to-noise-ratio in flux.
 
-    Returns:
+    Returns
     -----------
-    magerr (float/array of floats): The resulting uncertainty in magnitude.
-
+    magerr : float or rray of floats
+        The resulting uncertainty in magnitude.
     """
 
     # see e.g. www.ucolick.org/~bolte/AY257/s_n.pdf section 3.1

--- a/src/sorcha/modules/PPApplyColourOffsets.py
+++ b/src/sorcha/modules/PPApplyColourOffsets.py
@@ -11,21 +11,30 @@ def PPApplyColourOffsets(observations, function, othercolours, observing_filters
     If phase model variables exist for each colour, this function also selects the
     correct variables for each observation based on filter.
 
-    Parameters:
+    Parameters
     -----------
-    observations (Pandas dataframe): dataframe of observations.
+    observations: Pandas dataframe
+        dataframe of observations.
 
-    function (string): string of desired phase function model. Options are HG, HG12, HG1G2, linear, H.
+    function : string
+        string of desired phase function model. Options are HG, HG12, HG1G2, linear, H.
 
-    othercolours (list of strings): list of colour offsets present in input files.
+    othercolours : list of strings
+        list of colour offsets present in input files.
 
-    observing_filters (list of strings): list of observation filters of interest.
+    observing_filters : list of strings
+        list of observation filters of interest.
 
-    mainfilter (string): the main filter in which H is given and all colour offsets are calculated against.
+    mainfilter : string
+        the main filter in which H is given and all colour offsets are calculated against.
 
-    Returns:
+    Returns
     -----------
-    observations (Pandas dataframe): dataframe of observations with H calculated in relevant filter.
+    observations : Pandas dataframe
+        observations dataframe modified with H calculated in relevant filter (H_filter)
+        and renames the column for H in the main filter as H_original.
+        The dataframe has also been modified to have the appropriate phase curve filter specific values/columns.
+
 
     """
 

--- a/src/sorcha/modules/PPApplyFOVFilter.py
+++ b/src/sorcha/modules/PPApplyFOVFilter.py
@@ -7,26 +7,35 @@ from sorcha.modules.PPModuleRNG import PerModuleRNG
 
 def PPApplyFOVFilter(observations, configs, module_rngs, footprint=None, verbose=False):
     """
-    Wrapper function for PPFootprintFilter and PPFilterDetectionEfficiency. Checks to see
+    Wrapper function for PPFootprintFilter and PPFilterDetectionEfficiency that checks to see
     whether a camera footprint filter should be applied or if a simple fraction of the
-    circular footprint should be used, then applies the required filter.
+    circular footprint should be used, then applies the required filter where rows are
+     are removed from the inputted pandas dataframevfor moving objects that land outside of
+     their associated observation's footprint.
 
-    Parameters:
+    Parameters
     -----------
-    observations (Pandas dataframe): dataframe of observations.
+    observations: Pandas dataframe
+    dataframe of observations.
 
-    configs (dictionary): dictionary of variables from config file.
+    configs : dictionary
+        dictionary of variables from config file.
 
-    module_rngs (PerModuleRNG): A collection of random number generators (per module).
+    module_rngs : PerModuleRNG
+        A collection of random number generators (per module).
 
-    footprint (Footprint): A Footprint object that represents the boundaries of
-    the detector(s). Default `None`.
+    footprint: Footprint
+        A Footprint class object that represents the boundaries of the detector(s).
+        Default: None.
 
-    verbose (boolean): Verbose mode on or off.
+    verbose: boolean
+        Controls whether logging in verbose mode is on or off.
+        Default: False
 
-    Returns:
+    Returns
     -----------
-    observations (Pandas dataframe): dataframe of observations after FOV filters have been applied.
+    observations :  Pandas dataframe
+        dataframe of observations updated after field-of-view filters have been applied.
     """
 
     pplogger = logging.getLogger(__name__)
@@ -59,20 +68,25 @@ def PPGetSeparation(obj_RA, obj_Dec, cen_RA, cen_Dec):
     """
     Function to calculate the distance of an object from the field centre.
 
-    Parameters:
+    Parameters
     -----------
-    obj_RA (float): RA of object in decimal degrees.
+    obj_RA : float
+        RA of object in decimal degrees.
 
-    obj_Dec (float): Dec of object in decimal degrees.
+    obj_Dec: float
+        Dec of object in decimal degrees.
 
-    cen_RA (float): RA of field centre in decimal degrees.
+    cen_RA : float
+        RA of field centre in decimal degrees.
 
-    cen_Dec (float): Dec of field centre in decimal degrees.
+    cen_Dec : float
+        Dec of field centre in decimal degrees.
 
-    Returns:
+    Returns
     -----------
-    sep_degree (float): The separation of the object from the centre of the field, in decimal
-    degrees.
+    sep_degree : float
+        The separation of the object from the centre of the field, in decimal
+        degrees.
 
     """
 
@@ -89,16 +103,18 @@ def PPCircleFootprint(observations, circle_radius):
     Simple function which removes objects which lay outside of a circle
     of given radius centred on the field centre.
 
-    Parameters:
+    Parameters
     -----------
-    observations (Pandas dataframe): dataframe of observations.
+    observations : Pandas dataframe
+        dataframe of observations.
 
-    circle_radius (float): radius of circle footprint in degrees.
+    circle_radius : float
+        radius of circle footprint in degrees.
 
-    Returns:
+    Returns
     ----------
-    new_observations (Pandas dataframe): dataframe of observations with all lying
-    beyond the circle radius dropped.
+    new_observations : Pandas dataframe
+        dataframe of observations with all lying beyond the circle radius dropped.
 
     """
 
@@ -126,17 +142,23 @@ def PPSimpleSensorArea(ephemsdf, module_rngs, fillfactor=0.9):
     Randomly removes a number of observations proportional to the
     fraction of the field not covered by the detector.
 
-    Parameters:
+    Parameters
     -----------
-    ephemsdf (Pandas dataframe): dataframe containing observations.
+    ephemsdf : Pandas dataframe
+        Dataframe containing observations.
 
-    module_rngs (PerModuleRNG): A collection of random number generators (per module).
+    module_rngs : PerModuleRNG
+        A collection of random number generators (per module).
 
-    fillfactor (float): fraction of FOV covered by the sensor.
+    fillfactor : float
+        fraction of FOV covered by the sensor.
+        Default = 0.9
 
-    Returns:
+    Returns
     ----------
-    ephemsOut (Pandas dataframe): dataframe of observations with fraction removed.
+    ephemsOut : Pandas dataframe
+        Dataframe of observations with 1- fillfactor fraction of objects
+        removed per on-sky observation pointing.
 
     """
     # Set the module specific seed as an offset from the base seed.

--- a/src/sorcha/modules/PPBrightLimit.py
+++ b/src/sorcha/modules/PPBrightLimit.py
@@ -8,17 +8,23 @@ def PPBrightLimit(observations, observing_filters, bright_limit):
     limit. Can take either a single saturation limit for a straight cut, or
     filter-specific saturation limits.
 
-    Parameters:
+    Parameters
     -----------
-    observations (Pandas dataframe): dataframe of observations.
+    observations : Pandas dataframe
+        Dataframe of observations.
 
-    observing_filters (list of strings): observing filters present in the data.
+    observing_filters : list of strings
+        Observing filters present in the data.
 
-    bright_limit (float or list of floats): saturation limits: either single or per-filter.
+    bright_limit : float or list of floats
+        Saturation limits: either single value applied to all filters or a list of values for each filter.
 
-    Returns:
+    Returns
     ----------
-    observations_out (Pandas dataframe): dataframe of filtered observations.
+    observations_out : Pandas dataframe
+        observations dataframe modified with rows dropped for apparent
+        magnitudes brigher than the bright_limit for the given observation's
+        filter
 
     """
 

--- a/src/sorcha/modules/PPCalculateApparentMagnitude.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitude.py
@@ -16,29 +16,44 @@ def PPCalculateApparentMagnitude(
 ):
     """This function applies the correct colour offset to H for the relevant filter, checks to make sure
     the correct columns are included (with additional functionality for colour-specific phase curves),
-    then calculates the apparent magnitude.
+    then calculates the trailed source apparent magnitude including optional adjustments for
+    cometary activity and rotational light curves.
 
-    Parameters:
+    Parameters
     -----------
-    observations (Pandas dataframe): dataframe of observations.
+    observations : Pandas dataframe
+        dataframe of observations.
 
-    phasefunction (string): desired phase function model. Options are HG, HG12, HG1G2, linear, H.
+    phasefunction : string
+        Desired phase function model. Options are HG, HG12, HG1G2, linear, none
 
-    mainfilter (string): the main filter in which H is given and all colour offsets are calculated against.
+    mainfilter : string
+        The main filter in which H is given and all colour offsets are calculated against.
 
-    othercolours (list of strings): list of colour offsets present in input files.
+    othercolours : list of strings
+        List of colour offsets present in input files.
 
-    observing_filters (list of strings): list of observation filters of interest.
+    observing_filters : ist of strings
+        List of observation filters of interest.
 
-    cometary_activity_choice (string): type of object for cometary activity. Either 'comet' or 'none'.
+    cometary_activity_choice : string
+        Choice of cometary activity model.
+        Default = None
 
-    lc_choice (string): choice of lightcurve model. Default None
+    lc_choice : string
+        Choice of lightcurve model. Default =  None
 
-    verbose (boolean): True/False trigger for verbosity.
+    verbose : boolean
+        Flag for turning on verbose logging. Default = False
 
-    Returns:
+    Returns
     ----------
-    observations (Pandas dataframe): dataframe of observations with calculated magnitude column.
+    observations : Pandas dataframe
+        Modified observations pandas dataframe with calculated trailed source
+        apparent magnitude column, H calculated in relevant filter (H_filter),
+        renames the column for H in the main filter as H_original and
+        adds a column for the light curve contribution to the trailed source
+        apparent magnitude (if included)
     """
 
     pplogger = logging.getLogger(__name__)

--- a/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitudeInFilter.py
@@ -17,34 +17,47 @@ def PPCalculateApparentMagnitudeInFilter(
     cometary_activity_choice=None,
 ):
     """
-    This task calculates the apparent brightness of an object at a given pointing
-    according to one of the following photometric phase function models:
+    The trailed source apparent magnitude is calculated in the filter for given H,
+    phase function, light curve, and cometary activity parameters.
+
+    Notes
+    -------
+    PPApplyColourOffsets should be run beforehand to apply any needed colour offset to H and ensure correct
+    variables are present.
+
+    The phase function model options utlized are the sbpy package's implementation:
         - HG:                Bowell et al. (1989) Asteroids II book.
         - HG1G2:             Muinonen et al. (2010) Icarus 209 542.
         - HG12:              Penttilä et al. (2016) PSS 123 117.
         - linear:             (as implemented in sbpy)
+        - none :             No model is applied
 
-    The apparent magnitude is calculated in the filter for which the H and
-    phase function variables are given. PPApplyColourOffsets should be
-    run beforehand to apply any needed colour offset to H and ensure correct
-    variables are present.
 
-    The function makes use of implementations in the sbpy library.
-
-    Parameters:
+    Parameters
     -----------
-    padain (Pandas dataframe): dataframe of observations.
+    padain : Pandas dataframe
+        Dataframe of observations.
 
-    function (string): desired phase function model. Options are HG, HG12, HG1G2, linear, none.
+    function : string
+        Desired phase function model. Options are "HG", "HG12", "HG1G2", "linear", "none".
 
-    colname (string): column name in which to store calculated magnitude.
+    colname : string
+        Column name in which to store calculated magnitude to the padain dataframe.
+        Default = "TrailedSourceMag"
 
-    lightcurve_choice (string): choice of lightcurve model. Default None
+    lightcurve_choice : stringm optional
+        Choice of light curve model. Default = None
+
+    cometary_activity_choice : string, optional
+        Choice of cometary activity model. Default = None
 
 
-    Returns:
+    Returns
     ----------
-    padain (Pandas dataframe): dataframe of observations with calculated magnitude column.
+    padain : Pandas dataframe
+        Dataframe of observations (padain) modified with calculated trailed
+        source apparent magnitude column and any optional cometary actvity or
+        light curve added columns based on the models used.
 
     """
 

--- a/src/sorcha/modules/PPCalculateSimpleCometaryMagnitude.py
+++ b/src/sorcha/modules/PPCalculateSimpleCometaryMagnitude.py
@@ -11,11 +11,8 @@ def PPCalculateSimpleCometaryMagnitude(
     alpha: List[float],
     activity_choice: str = None,
 ) -> pd.DataFrame:
-    """This task calculates the brightness of the comet at a given pointing
-    using the model specified by `activity_choice`
-
-    The brightness is calculated first in the main filter, and the colour offset is
-    applied afterwards.
+    """Adjusts the  observations' trailed source apparent magnitude for cometary activity
+    using the model specified by `activity_choice` added by the user
 
     Parameters
     ----------
@@ -30,13 +27,14 @@ def PPCalculateSimpleCometaryMagnitude(
         Distance to Earth [units au]
     alpha : List[float]
         Phase angle [units degrees]
-    activity_choice : str, optional
+    activity_choice : string, optional
         The activity model to use, by default None
 
     Returns
     -------
     pd.DataFrame
-            The ``observations`` dataframe with updated brightness values.
+            The ``observations`` dataframe with updated trailed
+            source apparent magnitude values.
     """
 
     if activity_choice and CA_METHODS.get(activity_choice, False):

--- a/src/sorcha/modules/PPCheckInputObjectIDs.py
+++ b/src/sorcha/modules/PPCheckInputObjectIDs.py
@@ -6,20 +6,27 @@ import sys
 def PPCheckInputObjectIDs(orbin, colin, poiin):
     """
     Checks whether orbit and physical parameter files contain the same object IDs, and
-    additionally checks if the pointing database object iIDs is a subset of
-    all the object id:s found in the orbit/physical parameter files.}
+    additionally checks if the pointing database object IDs is a subset of
+    all the object ids found in the orbit/physical parameter files.
 
-    Parameters:
+    Parameters
     -----------
-    orbin (Pandas dataframe): dataframe of orbital information.
+    orbin : Pandas dataframe
+        Dataframe of orbital information.
 
-    colin (Pandas dataframe): dataframe of physical parameters.
+    colin : Pandas dataframe
+        Dataframe of physical parameters.
 
-    poiin (Pandas dataframe): dataframe of pointing database.
+    poiin : Pandas dataframe
+        Dataframe of pointing database.
 
-    Returns:
+    Returns
     ----------
-    None: will error out if a mismatch is found.
+    None
+
+    Notes
+    -------
+    Function will error out if a mismatch is found.
 
     """
 

--- a/src/sorcha/modules/PPCommandLineParser.py
+++ b/src/sorcha/modules/PPCommandLineParser.py
@@ -15,9 +15,9 @@ def warn_or_remove_file(filepath, force_remove, pplogger):
 
     Parameters
     ----------
-    filepath : str
+    filepath : string
         The full file path to a given file. i.e. /home/data/output.csv
-    force_remove : bool
+    force_remove : boolean
         Whether to remove the file if it exists.
     pplogger : Logger
         Used to log the output.
@@ -42,13 +42,15 @@ def PPCommandLineParser(args):
 
     Will only look for the comet parameters file if it's actually given at the command line.
 
-    Parameters:
+    Parameters
     -----------
-    args (ArgumentParser object): argparse object of command line arguments
+    args : ArgumentParser object
+        argparse object of command line arguments
 
-    Returns:
+    Returns
     ----------
-    cmd_args_dict (dictionary): dictionary of variables taken from command line arguments
+    cmd_args_dict : dictionary
+        dictionary of variables taken from command line arguments
 
     """
 

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -13,8 +13,13 @@ def log_error_and_exit(message: str) -> None:
 
     Parameters
     ----------
-    message : str
+    message : string
         The error message to be logged to the error output file.
+
+
+    Returns
+    --------
+    None
     """
 
     logging.error(message)
@@ -26,17 +31,21 @@ def PPGetOrExit(config, section, key, message):
     Checks to see if the config file parser has a key. If it does not, this
     function errors out and the code stops.
 
-    Parameters:
+    Parameters
     -----------
-    config (ConfigParser object): ConfigParser object containing configs.
+    config : ConfigParser
+        ConfigParser object containing configs.
 
-    section (string): section of the key being checked.
+    section : string
+        Section of the key being checked.
 
-    key (string): the key being checked.
+    key : string)
+        The key being checked.
 
-    message (string): the message to log and display if the key is not found.
+    message : string
+        The message to log and display if the key is not found.
 
-    Returns:
+    Returns
     ----------
     None.
 
@@ -54,17 +63,21 @@ def PPGetFloatOrExit(config, section, key, message):
     Checks to see if a key in the config parser is present and can be read as a
     float. If it cannot, this function errors out and the code stops.
 
-    Parameters:
+    Parameters
     -----------
-    config (ConfigParser object): ConfigParser object containing configs.
+    config : ConfigParser
+        ConfigParser object containing configs.
 
-    section (string): section of the key being checked.
+    section : string
+        section of the key being checked.
 
-    key (string): the key being checked.
+    key : string
+        The key being checked.
 
-    message (string): the message to log and display if the key is not found.
+    message : string
+        The message to log and display if the key is not found.
 
-    Returns:
+    Returns
     ----------
     None.
 
@@ -91,17 +104,21 @@ def PPGetIntOrExit(config, section, key, message):
     Checks to see if a key in the config parser is present and can be read as an
     int. If it cannot, this function errors out and the code stops.
 
-    Parameters:
+    Parameters
     -----------
-    config (ConfigParser object): ConfigParser object containing configs.
+    config : ConfigParser
+        ConfigParser object containing configs.
 
-    section (string): section of the key being checked.
+    section : string
+        Section of the key being checked.
 
-    key (string): the key being checked.
+    key : string
+        The key being checked.
 
-    message (string): the message to log and display if the key is not found.
+    message : string
+        The message to log and display if the key is not found.
 
-    Returns:
+    Returns
     ----------
     None.
 
@@ -128,17 +145,21 @@ def PPGetBoolOrExit(config, section, key, message):
     Checks to see if a key in the config parser is present and can be read as a
     Boolean. If it cannot, this function errors out and the code stops.
 
-    Parameters:
+    Parameters
     -----------
-    config (ConfigParser object): ConfigParser object containing configs.
+    config : ConfigParser object
+        ConfigParser object containing configs.
 
-    section (string): section of the key being checked.
+    section : string
+        Section of the key being checked.
 
-    key (string): the key being checked.
+    key : string
+        The key being checked.
 
-    message (string): the message to log and display if the key is not found.
+    message : string
+        The message to log and display if the key is not found.
 
-    Returns:
+    Returns
     ----------
     None.
 
@@ -162,24 +183,30 @@ def PPGetValueAndFlag(config, section, key, type_wanted):
     type and error-handling if it can't be forced. If the value is not present
     in the config fie, the flag is set to False; if it is, the flag is True.
 
-    Parameters:
+    Parameters
     -----------
-    config (ConfigParser object): ConfigParser object containing configs.
+    config : ConfigParser
+        ConfigParser object containing configs.
 
-    section (string): section of the key being checked.
+    section : string
+        Section of the key being checked.
 
-    key (string): the key being checked.
+    key : string
+        The key being checked.
 
-    type_wanted (string): the type the value should be forced to. Accepts int,
-    float, none (for no type-forcing).
+    type_wanted : string
+        The type the value should be forced to.
+        Accepts int, float, none (for no type-forcing).
 
-    Returns:
+    Returns
     ----------
-    value (any type): the value of the key, with type dependent on type_wanted.
-    Will be None if the key is not present.
+    value : any type
+        The value of the key, with type dependent on type_wanted.
+        Will be None if the key is not present.
 
-    flag (Boolean): will be False if the key is not present in the config file
-    and True if it is.
+    flag : boolean
+        Will be False if the key is not present in the config file
+        and True if it is.
 
     """
 
@@ -221,16 +248,18 @@ def PPFindFileOrExit(arg_fn, argname):
     """Checks to see if a file given by a filename exists. If it doesn't,
     this fails gracefully and exits to the command line.
 
-    Parameters:
+    Parameters
     -----------
-    arg_fn (string): the filepath/name of the file to be checked.
+    arg_fn : string
+        The filepath/name of the file to be checked.
 
-    argname (string): the name of the argument being checked. Used for error
-    message.
+    argname : string
+        The name of the argument being checked. Used for error message.
 
-    Returns:
+    Returns
     ----------
-    arg_fn (string): the filepath/name of the file to be checked.
+    arg_fn : string
+        The filepath/name of the file to be checked.
 
     """
 
@@ -247,17 +276,18 @@ def PPFindDirectoryOrExit(arg_fn, argname):
     """Checks to see if a directory given by a filepath exists. If it doesn't,
     this fails gracefully and exits to the command line.
 
-    Parameters:
+    Parameters
     -----------
-    arg_fn (string): the filepath of the directory to be checked.
+    arg_fn : string
+        The filepath of the directory to be checked.
 
-    argname (string): the name of the argument being checked. Used for error
-    message.
+    argname : string
+        The name of the argument being checked. Used for error message.
 
-    Returns:
+    Returns
     ----------
-    arg_fn (string): the filepath of the directory to be checked.
-
+    arg_fn : string
+        The filepath of the directory to be checked.
     """
 
     pplogger = logging.getLogger(__name__)
@@ -272,19 +302,24 @@ def PPFindDirectoryOrExit(arg_fn, argname):
 def PPCheckFiltersForSurvey(survey_name, observing_filters):
     """
     When given a list of filters, this function checks to make sure they exist in the
-    user-selected survey. Currently only has options for LSST, but can be expanded upon
-    later. If the filters given in the config file do not match the survey filters,
-    the function exits the program with an error.
+    user-selected survey, and if the filters given in the config file do not match the
+    survey filters, the function exits the program with an error.
 
-    Parameters:
+    Parameters
     -----------
-    survey_name (string): survey name. Currently only "LSST", "lsst" accepted.
+    survey_name : string
+        Survey name. Currently only "LSST", "lsst" accepted.
 
-    observing_filters (list of strings): observation filters of interest.
+    observing_filters: list of strings
+        Observation filters of interest.
 
-    Returns:
+    Returns
     ----------
     None.
+
+    Notes
+    -------
+    Currently only has options for LSST, but can be expanded upon later.
 
     """
 
@@ -315,20 +350,23 @@ def PPConfigFileParser(configfile, survey_name):
     Parses the config file, error-handles, then assigns the values into a single
     dictionary, which is passed out.
 
-    Chose not to use the original ConfigParser object for readability: it's a dict of
-    dicts, so calling the various values can become quite unwieldy.
-
-    This could easily be broken up even more, and probably should be.
-
-    Parameters:
+    Parameters
     -----------
-    configfile (string): filepath/name of config file.
+    configfile : string
+        Filepath/name of config file.
 
-    survey_name (string): survey name. Currently only "LSST", "lsst" accepted.
+    survey_name : string
+        Survey name. Currently only "LSST", "lsst" accepted.
 
-    Returns:
+    Returns
     ----------
-    config_dict (dictionary): dictionary of config file variables.
+    config_dict : dictionary
+        Dictionary of config file variables.
+
+    Notes
+    -------
+        We chose not to use the original ConfigParser object for readability: it's a dict of
+        dicts, so calling the various values can become quite unwieldy.
 
     """
     pplogger = logging.getLogger(__name__)
@@ -712,13 +750,15 @@ def PPPrintConfigsToLog(configs, cmd_args):
     """
     Prints all the values from the config file and command line to the log.
 
-    Parameters:
+    Parameters
     -----------
-    configs (dictionary): dictionary of config file variables.
+    configs : dictionary
+        Dictionary of config file variables.
 
-    cmd_args (dictionary): dictionary of command line arguments.
+    cmd_args : dictionary
+        Dictionary of command line arguments.
 
-    Returns:
+    Returns
     ----------
     None.
 

--- a/src/sorcha/modules/PPDetectionEfficiency.py
+++ b/src/sorcha/modules/PPDetectionEfficiency.py
@@ -10,18 +10,21 @@ def PPDetectionEfficiency(padain, threshold, module_rngs):
     threshold: if the threshold is 0.95, for example, 5% of observations will be
     randomly dropped. Used by PPLinkingFilter.
 
-    Parameters:
+    Parameters
     -----------
-    padain (Pandas dataframe): dataframe of observations.
+    padain : Pandas dataframe
+        Dataframe of observations.
 
-    threshold (float): Fraction between 0 and 1 of detections retained in the dataframe.
+    threshold : float
+        Fraction between 0 and 1 of detections retained in the dataframe.
 
-    module_rngs (PerModuleRNG): A collection of random number generators (per module).
+    module_rngs : PerModuleRNG
+        A collection of random number generators (per module).
 
-    Returns:
+    Returns
     ----------
-    padain_drop: dataframe of observations with a fraction equal to 1-threshold
-    randomly dropped.
+     : Pandas dataframe
+        Dataframe of observations with a fraction equal to 1-threshold randomly dropped.
 
     """
 

--- a/src/sorcha/modules/PPDetectionProbability.py
+++ b/src/sorcha/modules/PPDetectionProbability.py
@@ -26,19 +26,24 @@ def calcDetectionProbability(mag, limmag, fillFactor=1.0, w=0.1):
     limiting magnitude, and fill factor, determined by the fading function
     from Veres & Chesley (2017).
 
-    Parameters:
+    Parameters
     -----------
-    mag (float/array of floats): magnitude of object in filter used for that field.
+    mag : float or array of floats
+        Magnitude of object in filter used for that field.
 
-    limmag (float/array of floats): limiting magnitude of the field.
+    limmag : float or array of floats
+        Limiting magnitude of the field.
 
-    fillFactor (float): fraction of FOV covered by the camera sensor.
+    fillFactor : float), optional
+        Fraction of FOV covered by the camera sensor. Default = 1.0
 
-    w (float): distribution parameter.
+    w : float
+        Distribution parameter. Default = 0.1
 
-    Returns:
+    Returns
     ----------
-    P (float/array of floats): probability of detection.
+    P : float or array of floats
+        Probability of detection.
     """
 
     P = fillFactor / (1.0 + np.exp((mag - limmag) / w))
@@ -61,22 +66,35 @@ def PPDetectionProbability(
     Wrapper for calcDetectionProbability which takes into account column names
     and trailing losses. Used by PPFadingFunctionFilter.
 
-    Parameters:
+    Parameters
     -----------
-    oif_df (Pandas dataframe): dataframe of observations.
+    oif_df : Pandas dataframe
+        Dataframe of observations.
 
-    trailing_losses (Boolean): are trailing losses being applied?
+    trailing_losses : Boolean, optional
+        Are trailing losses being applied?, Default = False
 
-    *_name (string): Column names for trailing losses, magnitude, limiting magnitude
-    and field ID respectively.
+    trailing_loss_name : string, optional
+        oif_df column name for trailing losses, Default = dmagDetect
 
-    fillFactor (float): fraction of FOV covered by the camera sensor.
+    magnitude_name : string, optional
+        oif_df column name for observation limiting magnitude,
+        Default = fiveSigmaDepthAtSource
 
-    w (float): distribution parameter.
+    field ID : string, optional
+        oif_df column name for observation field_id
+        Default = FieldID
 
-    Returns:
+    fillFactor : float, optional
+        Fraction of FOV covered by the camera sensor. Default = 1.0
+
+    w : float
+        Distribution parameter. Default =0.1
+
+    Returns
     ----------
-    P (float/array of floats): probability of detection.
+     : float or array of floats
+        Probability of detection.
 
     """
 

--- a/src/sorcha/modules/PPDropObservations.py
+++ b/src/sorcha/modules/PPDropObservations.py
@@ -6,17 +6,21 @@ def PPDropObservations(observations, module_rngs, probability="detection probabi
     Drops rows where the probabilty of detection is less than sample drawn
     from a uniform distribution. Used by PPFadingFunctionFilter.
 
-    Parameters:
+    Parameters
     -----------
-    observations (Pandas dataframe): dataframe of observations with a column containing the probability of detection.
+    observations : Pandas dataframe
+        Dataframe of observations with a column containing the probability of detection.
 
-    module_rngs (PerModuleRNG): A collection of random number generators (per module).
+    module_rngs : PerModuleRNG
+        A collection of random number generators (per module).
 
-    probability (string): name of column containing detection probability.
+    probability : string
+        Name of column containing detection probability.
 
-    Returns:
+    Returns
     ----------
-    out (Pandas dataframe): new dataframe without observations that could not be observed.
+    out : Pandas dataframe
+        New dataframe of 'observations' modified to remove observations that could not be observed.
 
     """
     # Set the module specific seed as an offset from the base seed.

--- a/src/sorcha/modules/PPFadingFunctionFilter.py
+++ b/src/sorcha/modules/PPFadingFunctionFilter.py
@@ -12,18 +12,24 @@ def PPFadingFunctionFilter(observations, fillfactor, width, module_rngs, verbose
     Calculates detection probability based on a fading function, then drops rows where the
     probabilty of detection is less than sample drawn from a uniform distribution.
 
-    Parameters:
+    Parameters
     -----------
-    observations (Pandas dataframe): dataframe of observations with a column containing the probability of detection.
+    observations : Pandas dataframe
+        Dataframe of observations with a column containing the probability of detection.
 
-    fillFactor (float): fraction of FOV covered by the camera sensor.
+    fillFactor : float
+        Fraction of camera field-of-view covered by detectors
 
-    module_rngs (PerModuleRNG): A collection of random number generators (per module).
+    module_rngs : PerModuleRNG
+        A collection of random number generators (per module).
 
-    Returns:
+    verbose : boolean, optional
+        Verbose logging flag. Default = False
+
+    Returns
     ----------
-    observations_drop (Pandas dataframe): new dataframe without observations that could not be observed.
-
+    observations_drop : Pandas dataframe)
+        Modified 'observations' dataframe without observations that could not be observed.
     """
 
     pplogger = logging.getLogger(__name__)

--- a/src/sorcha/modules/PPFootprintFilter.py
+++ b/src/sorcha/modules/PPFootprintFilter.py
@@ -35,21 +35,27 @@ def distToSegment(points, x0, y0, x1, y1):
     units as the points are specified in (radians, degrees, etc.). Uses planar
     geometry for the calculations (assuming small angular distances).
 
-    Parameters:
+    Parameters
     -----------
-    points (array): array of shape (2, n) describing the corners of the sensor.
+    points : array
+        Array of shape (2, n) describing the corners of the sensor.
 
-    x0 (float): the x coordinate of the first end of the segment.
+    x0 : float
+        The x coordinate of the first end of the segment.
 
-    y0 (float): the y coordinate of the first end of the segment.
+    y0 : float
+        The y coordinate of the first end of the segment.
 
-    x1 (float): the x coordinate of the second end of the segment.
+    x1 : float
+        The x coordinate of the second end of the segment.
 
-    y1 (float): the y coordinate of the second end of the segment.
+    y1 : float
+        The y coordinate of the second end of the segment.
 
-    Returns:
+    Returns
     --------
-    dist (array): array of length n storing the distances.
+    dist : array
+        Array of length n storing the distances.
     """
     # Handle the case where the segment is a point: (x0 == x1) and (y0 == y1)
     len_sq = (x1 - x0) * (x1 - x0) + (y1 - y0) * (y1 - y0)
@@ -68,22 +74,28 @@ def distToSegment(points, x0, y0, x1, y1):
 
 
 class Detector:
+    """Detector class"""
+
     def __init__(self, points, ID=0, units="radians"):
         """
         Initiates a detector object.
 
-        Parameters:
+        Parameters
         -----------
-        points (array): array of shape (2, n) describing the corners of the sensor.
+        points : array
+            Array of shape (2, n) describing the corners of the sensor.
 
-        ID (int): an integer ID for the sensor.
+        ID : int, optional
+            Aan integer ID for the sensor. Default =0.
 
-        units (string): units that points is provided in, "radians" or "degrees" from
-                        center of the focal plane.
+        units : string, optional
+            Units that points is provided in, "radians" or "degrees" from
+            center of the focal plane. Default = "radians"
 
-        Returns:
+        Returns
         ----------
-        detector (Detector): a detector instance.
+        detector : Detector
+            A Detector object instance.
 
         """
 
@@ -115,21 +127,26 @@ class Detector:
         Determines whether a point (or array of points) falls on the
         detector.
 
-        Parameters:
+        Parameters
         -----------
-        point (array): array of shape (2, n) for n points.
+        point : array
+            Array of shape (2, n) for n points.
 
-        ϵ (float): threshold for whether point is on detector.
+        ϵ : float, optional
+            Threshold for whether point is on detector. Default: 10.0 ** (-11)
 
-        edge_thresh (float, optional): The focal plane distance (in arcseconds) from
-            the detector's edge for a point to be counted. Removes points that are too
-            close to the edge for source detection.
+        edge_thresh: float, optional
+            The focal plane distance (in arcseconds) from the detector's edge
+            for a point to be counted. Removes points that are too
+            close to the edge for source detection. Default = None
 
-        plot (Boolean): whether to plot the detector and the point.
+        plot : Boolean, optional
+            Flag for whether to plot the detector and the point. Default = False
 
-        Returns:
+        Returns
         ----------
-        ison (array): indices of points in point array that fall on the sensor.
+        selectedidx : array
+            Indices of points in point array that fall on the sensor.
         """
         pplogger = logging.getLogger(__name__)
 
@@ -183,13 +200,14 @@ class Detector:
         segmentedArea, but the test point is the mean of the corner coordinates.
         Will probably fail if the sensor is not convex.
 
-        Parameters:
+        Parameters
         -----------
         None.
 
-        Returns:
+        Returns
         ----------
-        area (float): the area of the detector.
+        area : float
+            The area of the detector.
 
         """
         x = self.x - self.centerx
@@ -210,14 +228,15 @@ class Detector:
         Fails if the point is not inside the sensor or if the sensor is not
         convex.
 
-        Parameters:
+        Parameters
         -----------
-        None.
+        point : array
+            Array of shape (2, n) for n points.
 
-        Returns:
+        Returns
         ----------
-        area (float): the area of the detector.
-
+        area : float
+            The area of the detector.
         """
 
         # so that both a single and many points work
@@ -247,11 +266,11 @@ class Detector:
         Sorts the corners to be counterclockwise by angle from center of
         the detector. Modifies self.
 
-        Parameters:
+        Parameters
         -----------
         None.
 
-        Returns:
+        Returns
         ----------
         None.
 
@@ -269,13 +288,15 @@ class Detector:
         Rotates a sensor around the origin of the coordinate system its
         corner locations are provided in.
 
-        Parameters:
+        Parameters
         -----------
-        θ (float): angle to rotate by, in radians.
+        θ : float
+            Angle to rotate by, in radians.
 
-        Returns:
+        Returns
         ----------
-        Detector: new Detector instance.
+        Detector:  Detector
+            New Detector instance.
 
         """
 
@@ -293,11 +314,11 @@ class Detector:
         """
         Converts corners from radians to degrees.
 
-        Parameters:
+        Parameters
         -----------
         None.
 
-        Returns:
+        Returns
         ----------
         None.
 
@@ -316,11 +337,11 @@ class Detector:
         """
         Converts corners from degrees to radians.
 
-        Parameters:
+        Parameters
         -----------
         None.
 
-        Returns:
+        Returns
         ----------
         None.
 
@@ -343,18 +364,22 @@ class Detector:
         internal demonstration purposes, but not for confirming algorithms or
         for offical plots.
 
-        Parameters:
+        Parameters
         -----------
-        θ (float): angle to rotate footprint by, radians or degrees.
+        θ : float, optional
+            Aangle to rotate footprint by, radians or degrees. Default =0.0
 
-        color  (string): line color.
+        color :string, optional
+            Line color. Default = "gray"
 
-        units (string): units θ is provided in ("deg" or "rad").
+        units: string, optional
+            Units. Units is provided in ("deg" or "rad"). Default = 'rad'.
 
-        annotate (Boolean): whether to annotate each sensor with its index in
-        self.detectors.
+        annotate : Boolean
+            Flag whether to annotate each sensor with its index in self.detectors.
+            Default = False
 
-        Returns:
+        Returns
         ----------
         None.
 
@@ -377,20 +402,26 @@ class Detector:
 
 
 class Footprint:
+
+    """Camera footprint class"""
+
     def __init__(self, path=None, detectorName="detector"):
         """
         Initiates a Footprint object.
 
-        Parameters:
+        Parameters
         -----------
-        path (string): path to a .csv file containing detector corners.
+        path : string, optional
+            Path to a .csv file containing detector corners. Default = None
 
-        detectorName (string): name of column in detector file indicating to
-        which sensor a corner belongs.
+        detectorName : string, optional
+            Name of column in detector file indicating to which sensor a
+            corner belongs. Default = "detector"
 
-        Returns:
+        Returns
         ----------
-        Footprint: Footprint object for the provided sensors.
+        Footprint : Footprint
+            Footprint object for the provided sensors.
 
         """
 
@@ -441,18 +472,22 @@ class Footprint:
         is <2.1 degrees), so should be fine for internal demonstration
         purposes, but not for confirming algorithms or for offical plots.
 
-        Parameters:
+        Parameters
         -----------
-        θ (float): angle to rotate footprint by, radians or degrees.
+        θ : float, optional
+            Angle to rotate footprint by, radians or degrees. Default = 0.0
 
-        color  (string): line color.
+        color : string, optional
+            Line color. Default = "gray"
 
-        units (string): units θ is provided in ("deg" or "rad").
+        units : string, optional
+            Units θ is provided in ("deg" or "rad"). Default = "rad"
 
-        annotate (Boolean): whether to annotate each sensor with its index in
-        self.detectors.
+        annotate : boolean, optional
+            Whether to annotate each sensor with its index in
+            self.detectors. Default = False
 
-        Returns:
+        Returns
         ----------
         None.
 
@@ -477,23 +512,42 @@ class Footprint:
         footprint. Also returns the an ID for the sensor a detection is made
         on.
 
-        Parameters:
+        Parameters
         -----------
-        field_df (Pandas dataframe): dataframe containing detection information with pointings.
+        field_df : Pandas dataframe
+            Dataframe containing detection information with pointings.
 
-        *_name (string): column names for object RA and Dec and field name.
+        ra_name : string, optional
+            "field_df" dataframe's column name for object's RA
+             for the given observation. Default = "AstRA(deg)" [units: degrees]
 
-        *_name_field (string): column names for field RA and Dec and rotation.
+        dec_name : string, optional
+            "field_df" dataframe's column name for object's declination
+             for the given observation. Default = "AstDec(deg)" [units: dgrees]
 
-        edge_thresh (float, optional): An angular threshold in arcseconds for dropping pixels too
-        close to the edge.
+        ra_name_field : string, optional
+            "field_df" dataframe's column name for the observation field's RA
+             Default = "fieldRA" [units: degrees]
 
-        Returns:
+        dec_name_field : string, optional
+            "field_df" dataframe's column name for the observation field's declination
+             Default = "fieldDec" [Units: degrees]
+
+        rot_name_field: string, optional
+            "field_df" dataframe's column name for the observation field's rotation angle
+            Default = "rotSkyPos" [Units: degrees]
+
+        edge_thresh: float, optional
+            An angular threshold in arcseconds for dropping pixels too close to the edge.
+            Default  = None
+
+        Returns
         ----------
-        detected (array): indices of rows in oifDF which fall on the sensor(s).
+        detected : array
+            Indices of rows in oifDF which fall on the sensor(s).
 
-        detectorID  (array): index corresponding to a detector in
-        self.detectors for each entry in detected.
+        detectorID : array
+            Index corresponding to a detector in self.detectors for each entry in detected.
 
         """
 
@@ -543,22 +597,32 @@ def radec2focalplane(ra, dec, fieldra, fielddec, fieldID=None):
     the same focal plane, but does not account for field rotation. Maintains
     alignment with the meridian passing through the field center.
 
-    Parameters:
+    Parameters
     -----------
-    ra (float/array of floats): observation Right Ascension, radians.
+    ra : float or array of floats
+        Observation Right Ascension, radians.
 
-    dec (float/array of floats): observation Declination, radians.
+    dec : float/array of floats
+        Observation Declination, radians.
 
-    fieldra (float/array of floats): field pointing Right Ascension, radians.
+    fieldra : float or array of floats
+        Field pointing Right Ascension, radians.
 
-    fielddec (float/array of floats): field pointing Declination, radians.
+    fielddec : float/array of floats)
+        Field pointing Declination, radians.
 
-    fieldID (float/array of floats): Field ID, optional.
+    fieldID : float/array of floats
+        Field ID, optional. Default = None
 
-    Returns:
+    Returns
     ----------
-    x, y (float/array of floats): Coordinates on the focal plane, radians projected
-    to the plane tangent to the unit sphere.
+    x : float or array of floats
+        x coordinates on the flocal plane, radians projected to the plane tagent ot the
+        unit sphere
+
+    y : float/array of floats
+        y coordinates on the focal plane, radians projected to the plane tangent to the
+        unit sphere.
 
     """
 

--- a/src/sorcha/modules/PPGetLogger.py
+++ b/src/sorcha/modules/PPGetLogger.py
@@ -13,21 +13,28 @@ def PPGetLogger(
     """
     Initialises log and error files.
 
-    Parameters:
+    Parameters
     -----------
-    log_location (string): filepath to directory in which to save logs.
+    log_location : string
+        Filepath to directory in which to save logs.
 
-    log_format (string): format for log filename.
+    log_format : string, optional
+        Format for log filename.
+        Default = "%(asctime)s %(name)-12s %(levelname)-8s %(message)s "
 
-    log_name (string): name of log.
+    log_name : string, optional
+        Name of log. Default = ""
 
-    log_file_info (string): name with which to save info log.
+    log_file_info : string, optional
+        Name with which to save info log. Default = "sorcha.log"
 
-    log_file_error (string): name with which to save error log.
+    log_file_error : string, optional
+        Name with which to save error log. Default = "sorcha.err"
 
-    Returns:
+    Returns
     ----------
-    log (logging object): log object.
+    log : logging object
+        Log object.
 
     """
 

--- a/src/sorcha/modules/PPGetMainFilterAndColourOffsets.py
+++ b/src/sorcha/modules/PPGetMainFilterAndColourOffsets.py
@@ -9,25 +9,31 @@ def PPGetMainFilterAndColourOffsets(filename, observing_filters, filesep):
     the expected colour offsets. Also makes sure that columns exist for all
     the expected colour offsets in the physical parameters file.
 
-    The main filter should be found as a column heading of H_[mainfilter]. If
-    this format isn't followed, this function will error out.
-
-    Parameters:
+    Parameters
     -----------
-    filename (string): the filename of the physical parameters file.
+    filename : string
+        The filename of the physical parameters file.
 
-    observing_filters (list of strings): the observation filters requested
-    in the config file.
+    observing_filters : list of strings
+        The observation filters requested in the configuration file.
 
-    filesep (string): the format of the physical parameters file. Should be "csv"/"comma"
-    or "whitespace".
+    filesep : string
+        The format of the physical parameters file. Should be "csv"/"comma"
+        or "whitespace".
 
-    Returns:
+    Returns
     ----------
-    mainfilter (string): the main filter in which H is defined.
+    mainfilter : string
+        The main filter in which H is defined.
 
-    colour_offsets (list of strings): a list of the colour offsets present in the
-    physical parameters file.
+    colour_offsets : list of strings
+        A list of the colour offsets present in the physical parameters file.
+
+    Notes
+    ------
+
+    The main filter should be found as a column heading of H_[mainfilter]. If
+    this format isn NOT followed, this function will error out.
 
     """
 

--- a/src/sorcha/modules/PPJoinEphemeridesAndOrbits.py
+++ b/src/sorcha/modules/PPJoinEphemeridesAndOrbits.py
@@ -8,15 +8,18 @@ def PPJoinEphemeridesAndOrbits(padafr, padaor):
     dataframe has to have same ObjIDs: NaNs will populate the fields for the
     missing objects.
 
-    Parameters:
+    Parameters
     -----------
-    padafr (Pandas dataframe): dataframe of ephemerides/OIF output.
+    padafr : Pandas dataframe
+        Dataframe of ephemerides output.
 
-    padaor (Pandas dataframe): dataframe of orbital information.
+    padaor : Pandas dataframe
+        Dataframe of orbital information.
 
-    Returns:
+    Returns
     ----------
-    resdf (Pandas dataframe): joined dataframe.
+    resdf : Pandas dataframe
+        Joined dataframe of "padafr" and "padaor"
 
     """
 

--- a/src/sorcha/modules/PPJoinEphemeridesAndParameters.py
+++ b/src/sorcha/modules/PPJoinEphemeridesAndParameters.py
@@ -4,15 +4,18 @@ def PPJoinEphemeridesAndParameters(padafr, padacl):
     dataframe. Each database has to have same ObjIDs: NaNs will
     be populate the fields for the missing objects.
 
-    Parameters:
+    Parameters
     -----------
-    padafr (Pandas dataframe): dataframe of ephemerides/OIF output.
+    padafr : Pandas dataframe:
+        Dataframe of ephemerides output.
 
-    padacl (Pandas dataframe): dataframe of physical parameters information.
+    padacl : Pandas dataframe
+        Dataframe of physical parameters information.
 
-    Returns:
+    Returns
     ----------
-    resdf (Pandas dataframe): joined dataframe.
+    resdf : Pandas dataframe
+        Joined dataframe of "padafr" and "padacl"
 
     """
 

--- a/src/sorcha/modules/PPMagnitudeLimit.py
+++ b/src/sorcha/modules/PPMagnitudeLimit.py
@@ -1,17 +1,21 @@
 def PPMagnitudeLimit(observations, mag_limit):
     """
-    Filter that performs a straight magnitude cut based on a defined limit.
+    Filter that performs a straight cut on apparent PSF magnitude
+    based on a defined threshold.
 
-    Parameters:
+    Parameters
     -----------
-    observations (Pandas dataframe) dataframe of observations. Must have
-    "observedTrailedSourceMag" column.
+    observations : pandas dataframe
+        Dataframe of observations. Must have "observedPSFMag" column.
 
-    mag_limit (float): limit for magnitude cut.
+    mag_limit : float
+        Limit for apparent magnitude cut.
 
-    Returns:
+    Returns
     -----------
-    observations (Pandas dataframe): same as input, but with entries fainter than the limit removed.
+    observations : pandas dataframe
+        "observations" dataframe modified with apparent PSF mag greater than
+        or equal to the limit removed.
 
     """
 

--- a/src/sorcha/modules/PPMatchPointingToObservations.py
+++ b/src/sorcha/modules/PPMatchPointingToObservations.py
@@ -10,16 +10,19 @@ def PPMatchPointingToObservations(padain, pointfildb):
     database onto the observations dataframe, then drops all observations which are not
     in one of the requested filters and any duplicate columns.
 
-    Parameters:
+    Parameters
     -----------
-    padain (Pandas dataframe): dataframe of observations.
+    padain : pandas dataframe
+        Dataframe of observations.
 
-    pointfildb (Pandas dataframe): dataframe of the pointing database.
+    pointfildb : pandas dataframe
+        Dataframe of the pointing database.
 
-    Returns:
+    Returns
     -----------
-    res_df (Pandas dataframe): Merged dataframe of observations with pointing
-    database, with all superfluous observations dropped.
+    res_df : Pandas dataframe
+        Merged dataframe of observations ("padain") with pointing
+        database ("pointfildb"), with all superfluous observations dropped.
 
     """
 

--- a/src/sorcha/modules/PPModuleRNG.py
+++ b/src/sorcha/modules/PPModuleRNG.py
@@ -6,10 +6,11 @@ class PerModuleRNG:
     """A collection of per-module random number generators."""
 
     def __init__(self, base_seed, pplogger=None):
-        """Parameters:
+        """Parameters
         --------------
 
-        base_seed (int): The base seed for a random number generator
+        base_seed : int
+            The base seed for a random number generator
         """
         self._base_seed = base_seed
         self._rngs = {}
@@ -25,13 +26,15 @@ class PerModuleRNG:
         Return a random number generator that is based on a base seed
         and the current module name.
 
-        Parameters:
+        Parameters
         -----------
-        module_name (str): The name of the module
+        module_name : string
+            The name of the module
 
-        Returns:
+        Returns
         ----------
-        rng (numpy Generator): The random number generator.
+        rng : numpy Generator
+            The random number generator.
         """
         if module_name in self._rngs:
             return self._rngs[module_name]

--- a/src/sorcha/modules/PPOutput.py
+++ b/src/sorcha/modules/PPOutput.py
@@ -12,13 +12,15 @@ def PPOutWriteCSV(padain, outf):
     """
     Writes a pandas dataframe out to a CSV file at a location given by the user.
 
-    Parameters:
+    Parameters
     -----------
-    padain (Pandas dataframe): dataframe of output.
+    padain : pandas dataframe
+        Dataframe of output.
 
-    outf (string): location to which file should be written.
+    outf : string
+        Location to which file should be written.
 
-    Returns:
+    Returns
     -----------
     None.
 
@@ -33,15 +35,18 @@ def PPOutWriteHDF5(pp_results, outf, keyin):
     """
     Writes a pandas dataframe out to a HDF5 file at a location given by the user.
 
-    Parameters:
+    Parameters
     -----------
-    padain (Pandas dataframe): dataframe of output.
+    padain : pandas dataframe
+        Dataframe of output.
 
-    outf (string): location to which file should be written.
+    outf : string
+        Location to which file should be written.
 
-    keyin (string): key at which data will be located.
+    keyin : string
+        Key at which data will be located.
 
-    Returns:
+    Returns
     -----------
     None.
 
@@ -64,13 +69,15 @@ def PPOutWriteSqlite3(pp_results, outf):
     """
     Writes a pandas dataframe out to a CSV file at a location given by the user.
 
-    Parameters:
+    Parameters
     -----------
-    pp_results (Pandas dataframe): dataframe of output.
+    pp_results : pandas dataframe
+        Dataframe of output.
 
-    outf (string): location to which file should be written.
+    outf : string
+        Location to which file should be written.
 
-    Returns:
+    Returns
     -----------
     None.
 
@@ -88,19 +95,25 @@ def PPWriteOutput(cmd_args, configs, observations_in, endChunk=0, verbose=False)
     Writes the output in the format specified in the config file to a location
     specified by the user.
 
-    Parameters:
+    Parameters
     -----------
-    cmd_args (dictionary): dictonary of command line arguments.
+    cmd_args : dictionary
+        Dictonary of command line arguments.
 
-    configs (dictionary): dictionary of config file arguments.
+    configs : Dictionary
+        Dictionary of config file arguments.
 
-    observations_in (Pandas dataframe): dataframe of output.
+    observations_in : Pandas dataframe
+        Dataframe of output.
 
-    endChunk (int): integer of last object in chunk. Used only for HDF5 output key.
+    endChunk : integer, optional
+        Integer of last object in chunk. Used only for HDF5 output key.
+        Default = 0
 
-    verbose (Boolean): verbose mode on or off.
+    verbose : boolean, optional
+        Verbose logging mode on or off. Default = False
 
-    Returns:
+    Returns
     -----------
     None.
 

--- a/src/sorcha/modules/PPRandomizeMeasurements.py
+++ b/src/sorcha/modules/PPRandomizeMeasurements.py
@@ -45,20 +45,49 @@ def randomizeAstrometry(
     module_rngs : PerModuleRNG
         A collection of random number generators (per module).
 
-    *Name (string): column names for right ascension, declination,
-    randomized right ascension, randomized declination, and standard deviation.
+    ra_Name : string, optional
+        "df" dataframe column name for the right ascension.
+        Default = "AstRA(deg)"
 
-    *Units (string): units for RA and Dec and sigma ('deg'/'rad'/'mas').
+    dec_Name : string, optional
+        "df" dataframe column name for the declination. Default = "AstDec(deg)"
+
+     raRndName : string, optional
+        "df" dataframe column name for where to store new randomized right
+        ascension. Default = "AstRARnd(deg)"
+
+     decRndName : string, optional
+        "df" dataframe column name for where to store  new randomized declination.
+        Default = "AstDecRnd(deg)"
+
+    sigName : string, optional
+        "df" dataframe column name for the standard deviation, uncertainty in the
+        astrometric position.
+        Default = "AstSig(deg)"
+
+    radecUnits : string
+        Units for RA and Dec ('deg'/'rad'/'mas'). Default = "deg"
+
+    sigUnits : string
+        Units for standard deviation ('deg'/'rad'/'mas'). Default = "mas"
+
 
     Returns
-    -----------
-    df (Pandas dataframe): as input, with randomized RADEC columns added
+    ---------
+    ra : numpy array of floats
+        Randomized right ascension values for each entry in "df"
+
+    dec : array of floats
+       Randomized dec values for each entry in "df"
 
     Notes
     -----------
     Covariances in RADEC are currently not supported. The routine calculates
     a normal distribution on the unit sphere, so as to allow for a correct modeling of
     the poles. Distributions close to the poles may look odd in RADEC.
+
+    "df" dataframe  is also modified with raRndName and decRndName columns added
+    with the new randomized right ascension and declination values stored
 
     """
 
@@ -101,19 +130,25 @@ def sampleNormalFOV(center, sigma, module_rngs, ndim=3):
     """
     Sample n points randomly (normal distribution) on a region on the unit (hyper-)sphere.
 
-    Parameters:
+    Parameters
     -----------
-    center (float, ndim): center of hpyer-sphere: can be an [n, ndim] dimensional array, but only if n == npoints.
+    center : float
+        Center of hpyer-sphere: can be an [n, ndim] dimensional array,
+        but only if n == npoints.
 
-    sigma (n-dimensional array): 1 sigma distance on unit sphere [radians]x
+    sigma : n-dimensional array
+        1 sigma distance on unit sphere [radians]x
 
-    module_rngs (PerModuleRNG): A collection of random number generators (per module).
+    module_rngs : PerModuleRNG
+        A collection of random number generators (per module).
 
-    ndim (int): dimension of hyper-sphere.
+    ndim : integer, optional
+        Dimension of hyper-sphere. Default = 3
 
-    Returns:
+    Return
     --------
-    vec ... numpy array [npoints, ndim]
+    vec : numpy array
+        Size [npoints, ndim]
 
     """
     rng = module_rngs.getModuleRNG(__name__)
@@ -151,27 +186,38 @@ def randomizePhotometry(
     """
     Randomize photometry with normal distribution around magName value.
 
-    Parameters:
+    Parameters
     -----------
-    df (Pandas dataframe): dataframe containing astrometry and sigma.
+    df : pandas dataframe
+        Dataframe containing astrometry and sigma.
 
-    module_rngs (PerModuleRNG): A collection of random number generators (per module).
+    module_rngs : PerModuleRNG
+        A collection of random number generators (per module).
 
-    magName (string): column name of photometric data [mag]
+    magName : string, optional
+        'df' column name of apparent magnitude. Default = "Filtermag"
 
-    magRndName (string): column name of randomized photometric data [mag].
+    magRndName : string, optional
+       'df' column name for storing randomized apparent magnitude, Default = "FiltermagRnd"
 
-    sigName (string): column name of standard deviation [mag].
+    sigName : float, optional
+            'df' column name for magnitude standard deviation. Default = "FiltermagSig"
 
-    Returns:
+    Returns
     -----------
-    df (Pandas dataframe): as input pandas dataframe, with added column magRndName.
+     : array of floats
+         randomized magnitudes for each row in 'df'
 
-    Comments:
+
+    Notes
     -----------
     The normal distribution here is in magnitudes while it should be in flux. This will fail for large sigmas.
     Should be fixed at some point.
 
+    We assume that apparent magnitudes are stored within 'df' and that 'magName'
+    corresponds to the corresponding column within 'df'
+
+     'df' is also modified with added column magRndNam to store the randomize apparent magnitude
     """
 
     rng = module_rngs.getModuleRNG(__name__)
@@ -187,15 +233,18 @@ def flux2mag(f, f0=3631):
     """
     AB ugriz system (f0 = 3631 Jy) to magnitude conversion.
 
-    Parameters:
+    Parameters
     -----------
-    f (float/array of floats): flux [Jy].
+    f : float or array of floats
+        flux. [Units : Jy].
 
-    f0 (float): zero point flux.
+    f0: float, optional
+        Zero point flux. Default = 3631
 
-    Returns:
+    Returns
     -----------
-    mag (float/array of floats: pogson magnitude.
+    mag : float or array of floats
+        pogson magnitude. [Units: mag]
 
     """
 
@@ -208,15 +257,17 @@ def mag2flux(mag, f0=3631):
     """
     AB ugriz system (f0 = 3631 Jy) magnitude to flux conversion.
 
-    Parameters:
+    Parameters
     -----------
-    mag (float/array of floats): pogson magnitude.
+    mag : float or rray of floats
+        Pogson magnitude. [Units: mag]
 
-    f0 (float): zero point flux.
+    f0 : float, optional
+        Zero point flux. Default = 3631
 
-    Returns:
+    Returns
     -----------
-    f (float/array of floats): flux [Jy].
+    f (float/array of floats): flux [Units: Jy].
 
     """
 
@@ -230,17 +281,21 @@ def icrf2radec(x, y, z, deg=True):
     Convert ICRF xyz to Right Ascension and Declination.
     Geometric states on unit sphere, no light travel time/aberration correction.
 
-    Parameters:
+    Parameters
     -----------
-    x, y, z (floats/arrays of floats): 3D vector of unit length (ICRF)
+    x, y, z : floats/arrays of floats
+        3D vector of unit length (ICRF)
 
-    deg (Boolean): True for angles in degrees, False for angles in radians.
+    de : boolean, optional
+        True for angles in degrees, False for angles in radians. Default = True
 
-    Returns:
+    Returns
     -----------
-    ra (float/array of floats): Right Ascension [deg].
+    ra : float or array of floats
+        Right Ascension. [Units: deg]
 
-    dec(float/array of floats): Declination [deg].
+    dec: float or array of floats
+        Declination. [Units: deg]
 
     """
 
@@ -280,17 +335,21 @@ def radec2icrf(ra, dec, deg=True):
     Convert Right Ascension and Declination to ICRF xyz unit vector.
     Geometric states on unit sphere, no light travel time/aberration correction.
 
-    Parameters:
+    Parameters
     -----------
-    ra (float/array of floats): Right Ascension [deg].
+    ra : float or array of floats
+        Right Ascension. [Units: deg]
 
-    dec(float/array of floats): Declination [deg].
+    dec: float or array of floats
+        Declination. [Units deg]
 
-    deg (Boolean): True for angles in degrees, False for angles in radians.
+    deg : boolean, optional
+        True for angles in degrees, False for angles in radians. Default = True
 
-    Returns:
+    Returns
     -----------
-    array([x, y, z]) (arrays of floats/arrays): 3D vector of unit length (ICRF)
+    array([x, y, z]) : arrays/matrix of floats
+        3D vector of unit length (ICRF)
     """
 
     deg2rad = np.deg2rad

--- a/src/sorcha/modules/PPRandomizeMeasurements.py
+++ b/src/sorcha/modules/PPRandomizeMeasurements.py
@@ -37,22 +37,24 @@ def randomizeAstrometry(
     Randomize astrometry with a normal distribution around the actual RADEC pointing.
     The randomized values are added to the input pandas data frame.
 
-    Parameters:
+    Parameters
     -----------
-    df (Pandas dataframe): dataframe containing astrometry and sigma.
+    df : pandas dataframe
+        Dataframe containing astrometry and sigma.
 
-    module_rngs (PerModuleRNG): A collection of random number generators (per module).
+    module_rngs : PerModuleRNG
+        A collection of random number generators (per module).
 
     *Name (string): column names for right ascension, declination,
     randomized right ascension, randomized declination, and standard deviation.
 
     *Units (string): units for RA and Dec and sigma ('deg'/'rad'/'mas').
 
-    Returns:
+    Returns
     -----------
     df (Pandas dataframe): as input, with randomized RADEC columns added
 
-    Comments:
+    Notes
     -----------
     Covariances in RADEC are currently not supported. The routine calculates
     a normal distribution on the unit sphere, so as to allow for a correct modeling of

--- a/src/sorcha/modules/PPReadPointingDatabase.py
+++ b/src/sorcha/modules/PPReadPointingDatabase.py
@@ -8,17 +8,21 @@ def PPReadPointingDatabase(bsdbname, observing_filters, dbquery, surveyname):
     """
     Reads in the pointing database as a Pandas dataframe.
 
-    Parameters:
+    Parameters
     -----------
-    bsdbname (string): file location of pointing database.
+    bsdbname : string
+        File location of pointing database.
 
-    observing_filters (list of strings): list of observation filters of interest.
+    observing_filters : list of strings
+        List of observation filters of interest.
 
-    dbquery (string): database query to perform on pointing database.
+    dbquery : string
+        Databse query to perform on pointing database.
 
-    Returns:
+    Returns
     -----------
-    dfo (Pandas dataframe): dataframe of pointing database.
+    dfo : pandas dataframe
+        Dataframe of pointing database.
 
     """
 

--- a/src/sorcha/modules/PPSNRLimit.py
+++ b/src/sorcha/modules/PPSNRLimit.py
@@ -1,17 +1,20 @@
 def PPSNRLimit(observations, sigma_limit=2.0):
     """
-    Filter that performs a straight SNR cut based on a limit.
+    Filter that performs a straight SNR cut based on a limit, removing
+    observations that are less than a SNR limit
 
-    Parameters:
+    Parameters
     -----------
-    observations (Pandas dataframe) dataframe of observations. Must have
-    "SNR" column.
+    observations : pandas dataframe
+        Dataframe of observations. Must have "SNR" column.
 
-    sigma_limit (float): limit for SNR cut.
+    sigma_limit : float, optional.
+        Limit for SNR cut.
 
-    Returns:
+    Returns
     -----------
-    observations (Pandas dataframe): same as input, but with entries with SNR < the limit removed.
+    observations : pandas dataframe
+        "observations" dataframed modified with entries with SNR < the limit removed.
 
     """
 

--- a/src/sorcha/modules/PPTrailingLoss.py
+++ b/src/sorcha/modules/PPTrailingLoss.py
@@ -36,31 +36,50 @@ def calcTrailingLoss(
     """
     Find the trailing loss from trailing and detection (Veres & Chesley 2017)
 
-    Parameters:
-    -----------
-    dRa (float/array of floats): on sky velocity component in RA*Cos(Dec), deg/day.
+    Parameters
+    -------------
+    dRa : float or array of floats
+        on sky velocity component in RA*Cos(Dec). [Units: deg/day]
 
-    dDec (float/array of floats): on sky velocity component in Dec, deg/day.
+    dDec : float/array of floats
+        on sky velocity component in Dec. [Units: deg/day]
 
-    seeing (float/array of floats): FWHM of the seeing disk, arcseconds.
+    seeing : float or array of floats
+        FWHM of the seeing disk. [Units: arcseconds]
 
-    texp (float): exposure length in seconds, defaults to 30 seconds.
+    texp : float, optional
+        Exposure length. [Units: seconds] Default = 30
 
-    model (str):
-        - 'circularPSF': Trailing loss due to the DM detection algorithm. Limit SNR:
+    model : string, optional
+        Options: 'circularPSF' or trailedSource'
+        'circularPSF': Trailing loss due to the DM detection algorithm. Limit SNR:
         5 sigma in a PSF-convolved image with a circular PSF (no trail fitting). Peak
         fluxes will be lower due to motion of the object.
-        -'trailedSource': Unavoidable trailing loss due to spreading the PSF
+        'trailedSource': Unavoidable trailing loss due to spreading the PSF
         over more pixels lowering the SNR in each pixel.
         See https://github.com/rhiannonlynne/318-proceedings/blob/master/Trailing%20Losses.ipynb for details.
+        Default = "circularPSF"
 
-    *_trail (float): fit parameters for trailedSource model. Default parameters from Veres & Chesley (2017).
+    a_trail : float, optional
+        a fit parameters for trailedSource model. Default parameters from Veres & Chesley (2017).
+        Default = 0.761
 
-    *_det (float): fit parameters for circularPSF model. Default parameters from Veres & Chesley (2017).
+    b_trail : float, optional
+        b fit parameters for trailedSource model. Default parameters from Veres & Chesley (2017).
+        Default = 1.162
 
-    Returns:
+    a_det : float, optional
+        a fit parameters for circularPSF model. Default parameters from Veres & Chesley (2017).
+        Default = 0.420
+
+    b_det : float, optional
+        b fit parameters for circularPSF model. Default parameters from Veres & Chesley (2017).
+        Default = 0.003
+
+    Returns
     -----------
-    dmag (float/array of floats): loss in detection magnitude due to trailing.
+    dmag : float or array of floats
+        Loss in detection magnitude due to trailing.
 
     """
 
@@ -95,20 +114,35 @@ def PPTrailingLoss(
     """
     Calculates detection trailing losses. Wrapper for calcTrailingLoss.
 
-    Parameters:
+    Parameters
+    -------------
+    oif_df : pandas dataframe
+        Dataframe of observations for which to calculate trailing losses.
+
+    model : string, optional
+        Photometric model. Either 'circularPSF' or 'trailedSource': see docstring for
+        calcTrailingLoss for details. Default = "circularPSF"
+
+    dra_name : string, optional
+        "oif_df" column name for object RA rate. Default = "AstRARate(deg/day)"
+
+    ddec_name : string, optional
+        "oif_df" column name for object dec rate. Default = "AstDecRate(deg/day)"
+
+    dec_name : string, default
+            "oif_df" column name for object declination. Default = "AstDec(deg)"
+
+    seeing_name_survey : string, optional
+        "oif_df" column name for seeing. Default = "seeingFwhmEff"
+
+    Returns
     -----------
-    oif_df (Pandas dataframe): dataframe of observations for which to calculate trailing losses.
+    dmag : float or array of floats
+        Loss in detection magnitude due to trailing losses.
 
-    model (string): Either 'circularPSF' or 'trailedSource': see docstring for calcTrailingLoss for details.
-
-    *_name (string): Column names for object RA rate, Dec rate and Dec respectively.
-
-    seeing_name_survey (string): Column name for seeing.
-
-    Returns:
-    -----------
-    dmag (float/array of floats): loss in detection magnitude due to trailing.
-
+    Notes
+    --------
+    Assumes 'oif_df" has RA and Dec stored in deg/dayrates and the seeing in arcseconds
     """
 
     dmag = calcTrailingLoss(

--- a/src/sorcha/modules/PPVignetting.py
+++ b/src/sorcha/modules/PPVignetting.py
@@ -16,26 +16,34 @@ def vignettingEffects(
 ):
     """
     Calculates effective limiting magnitude at source, taking vignetting into account.
-    Wrapper for calcVignettingLosses.
+    Wrapper for calcVignettingLosses().
 
-    Parameters:
+    Parameters
     -----------
     oif_df : pandas dataframe
         dataframe of observations.
 
     raNameOIF : string, optional
         'oif_df' column name of object RA. Default = "AstRA(deg)"
-    
+
     decNameOIF : string, optional
         'oif_df' column name of object declination. Default = "AstDec(deg)"
 
-    field ID, field RA and field Dec respectively.
+    fieldNameOIF : string, optional
+        'oif_df' column name for observation pointing field ID. Default = "FieldID"
 
-    Returns:
+    raNameSurvey : string, optional
+         'oif_df' column name for observation pointing RA. Default = "fieldRA"
+
+
+     decNameSurvey : string, optional
+         'oif_df' column name for observation pointing declination. Default = "fieldDec"
+
+    Returns
     -----------
-     : list
+     : list of floats
          Five sigma limiting magnitude at object location adjusted for vignetting for each
-         row in "oif_df".
+         row in 'oif_df' dataframe.
 
     """
 
@@ -128,7 +136,7 @@ def vignetFunc(x):
     -----------
     :   float or array of floats
         Magnitude of dimming due to vignetting at object position.
-    
+
     Notes
     --------
     Grabbed from sims_selfcal. From VignettingFunc_v3.3.TXT. r is in degrees,

--- a/src/sorcha/modules/PPVignetting.py
+++ b/src/sorcha/modules/PPVignetting.py
@@ -20,13 +20,22 @@ def vignettingEffects(
 
     Parameters:
     -----------
-    oif_df (Pandas dataframe): dataframe of observations.
+    oif_df : pandas dataframe
+        dataframe of observations.
 
-    *NameOIF (strings): column names of object RA, object Dec, field ID, field RA and field Dec respectively.
+    raNameOIF : string, optional
+        'oif_df' column name of object RA. Default = "AstRA(deg)"
+    
+    decNameOIF : string, optional
+        'oif_df' column name of object declination. Default = "AstDec(deg)"
+
+    field ID, field RA and field Dec respectively.
 
     Returns:
     -----------
-    Pandas series: five sigma depth at object location, adjusted for vignetting.
+     : list
+         Five sigma limiting magnitude at object location adjusted for vignetting for each
+         row in "oif_df".
 
     """
 
@@ -42,19 +51,24 @@ def calcVignettingLosses(ra, dec, fieldra, fielddec):
     Calculates magnitude loss due to vignetting for a point with the telescope
     centered on fieldra, fielddec.
 
-    Parameters:
+    Parameters
     -----------
-    ra (float/array of floats): RA of object(s).
+    ra : float or aarray of floats
+        RA of object(s).
 
-    dec (float/array of floats): Dec of object(s).
+    dec : float or array of floats
+        Dec of object(s).
 
-    fieldra (float/array of floats): RA of field(s).
+    fieldra : float or array of floats
+        RA of field(s).
 
-    fielddec (float/array of floats): Dec of field(s).
+    fielddec: float or array of floats
+        Dec of field(s).
 
-    Returns:
+    Returns
     -----------
-    Magnitude loss due to vignetting at object position (float/array of floats).
+    : floats or array of floats
+        Magnitude loss due to vignetting at object position.
 
     """
 
@@ -74,19 +88,24 @@ def haversine(ra1, dec1, ra2, dec2):
     errors for antipodal points, which are not intended to be encountered within
     the scope of this module.
 
-    Parameters:
+    Parameters
     -----------
-    ra1 (float/array of floats): RA of first point.
+    ra1 : float or array of floats
+        RA of first point.
 
-    dec1 (float/array of floats): Dec of first point.
+    dec1  or float or array of floats
+        Dec of first point.
 
-    ra2 (float/array of floats): RA of second point.
+    ra2 : float or array of floats
+        RA of second point.
 
-    dec2 (float/array of floats): Dec of second point.
+    dec2 : float/array of floats
+        Dec of second point.
 
-    Returns:
+    Returns
     -----------
-    Angular distance between two points (float/array of floats).
+     : float or array of floats
+         Angular distance between two points.
 
     """
 
@@ -97,17 +116,23 @@ def haversine(ra1, dec1, ra2, dec2):
 
 def vignetFunc(x):
     """
+    Returns the magnitude of dimming caused by the vignetting relative to the
+    center of the field.
+
+    Parameters
+    -----------
+    x : float or array of floats
+        Angular separation of point from field centre.
+
+    Returns
+    -----------
+    :   float or array of floats
+        Magnitude of dimming due to vignetting at object position.
+    
+    Notes
+    --------
     Grabbed from sims_selfcal. From VignettingFunc_v3.3.TXT. r is in degrees,
-    frac is fraction of rays which were not vignetted. Returns the magnitudes
-    of dimming caused by the vignetting relative to the center of the field.
-
-    Parameters:
-    -----------
-    x (float/array of floats): angular separation of point from field centre.
-
-    Returns:
-    -----------
-    Magnitude of dimming due to vignetting at object position (float/array of floats).
+    frac is fraction of rays which were not vignetted.
 
     """
 

--- a/src/sorcha/modules/miniDifi.py
+++ b/src/sorcha/modules/miniDifi.py
@@ -10,6 +10,28 @@ def haversine_np(lon1, lat1, lon2, lat2):
     Calculate the great circle distance between two points
     on the earth (specified in decimal degrees)
 
+    Parameters
+    -----------------
+
+    lon1 : float or array of floats
+        longitude of point 1
+
+    lat1 : float or array of floats
+        latitude of point 1
+
+    lon2 : float or array of floats
+        longitude of point 2
+
+    lat1 : float or array of floats
+        latitude of point 1
+
+    Returns
+    ----------
+        : float or array of floats
+        Great distance between the two points [Units: Decimal degrees]
+
+    Notes
+    -------
     All args must be of equal length.
 
     Because SkyCoord is slow AF.
@@ -29,12 +51,28 @@ def haversine_np(lon1, lat1, lon2, lat2):
 @njit(cache=True)
 def hasTracklet(mjd, ra, dec, maxdt_minutes, minlen_arcsec):
     """
-    Given a set of observations in one night, calculate it has at least one
-    detectable tracklet.
+     Given a set of observations in one night, calculate it has at least one
+     detectable tracklet.
 
-    Inputs: numpy arrays of mjd (time, days), ra (degrees), dec(degrees).
+    Parameters
+    -------------
+    mjd : numpy array of floats
+        Modified Julian date time [Units: days]
 
-    Output: True or False
+     ra : numpy array of floats
+         Object's RA at given mjd  [Units: degrees]
+
+     dec : numpy array of floats
+             Object's dec at given mjd  [Units: degrees]
+
+     maxdt_mintes: float
+
+     minlen_arcsec : float
+
+     Returns
+     ---------
+     : boolean
+         True if tracklet can be made else False
     """
     ## a tracklet must be longer than some minimum separation (1arcsec)
     ## and shorter than some maximum time (90 minutes). We find

--- a/src/sorcha/readers/CSVReader.py
+++ b/src/sorcha/readers/CSVReader.py
@@ -92,7 +92,7 @@ class CSVDataReader(ObjectDataReader):
             block_start=2 would skip the first two lines after the header
             and return data starting on row=2. [Default=0]
 
-        block_size int, optional, default=None
+        block_size: int, optional, default=None
             The number of rows to read in.
             Use block_size=None to read in all available data.
 

--- a/src/sorcha/readers/CSVReader.py
+++ b/src/sorcha/readers/CSVReader.py
@@ -17,14 +17,19 @@ class CSVDataReader(ObjectDataReader):
 
         Parameters
         -----------
-        filename : str
+        filename : string
             Location/name of the data file.
 
-        sep : str, optional
+        sep : string, optional
             Format of input file ("whitespace"/"comma"/"csv").
+            Default = csv
 
-        header : int, optional
+        header : integer, optional
             The row number of the header. If not provided, does an automatic search.
+            Default = -1
+
+        **kwargs: dictionary, optional
+            Extra arguments
         """
         super().__init__(**kwargs)
         self.filename = filename
@@ -50,7 +55,7 @@ class CSVDataReader(ObjectDataReader):
 
         Returns
         --------
-        name : str
+        name : string
             The reader information.
         """
         return f"CSVDataReader:{self.filename}"
@@ -61,7 +66,7 @@ class CSVDataReader(ObjectDataReader):
 
         Returns
         --------
-        int
+        : integer
             The line index of the header.
 
         """
@@ -86,19 +91,23 @@ class CSVDataReader(ObjectDataReader):
 
         Parameters
         -----------
-        block_start : int, optional
+        block_start : integer, optional
             The 0-indexed row number from which
             to start reading the data. For example in a CSV file
             block_start=2 would skip the first two lines after the header
-            and return data starting on row=2. [Default=0]
+            and return data starting on row=2. Default =0
 
-        block_size: int, optional, default=None
+        block_size: integer, optional, default=None
             The number of rows to read in.
             Use block_size=None to read in all available data.
+            default =None
+
+        **kwargs : dictionary, optional
+            Extra arguments
 
         Returns
         -----------
-        Pandas dataframe
+        res_df : pandas dataframe
             Dataframe of the object data.
         """
         # Skip the rows before the header and then begin_loc rows after the header.
@@ -155,9 +164,12 @@ class CSVDataReader(ObjectDataReader):
         obj_ids : list
             A list of object IDs to use.
 
+        **kwargs : dictionary, optional
+            Extra arguments
+
         Returns
         -----------
-        Pandas dataframe
+        res_df : pandas dataframe
             The dataframe for the object data.
         """
         self._build_id_map()
@@ -197,9 +209,12 @@ class CSVDataReader(ObjectDataReader):
         input_table : Pandas dataframe
             A loaded table.
 
+        **kwargs : dictionary, optional
+            Extra arguments
+
         Returns
         -----------
-        Pandas dataframe
+        input_table: pandas dataframe
             Returns the input dataframe modified in-place.
         """
         # Perform the parent class's validation (checking object ID column).

--- a/src/sorcha/readers/CombinedDataReader.py
+++ b/src/sorcha/readers/CombinedDataReader.py
@@ -25,12 +25,12 @@ class CombinedDataReader:
         """
         Parameters
         ----------
-        ephem_primary: bool, optional
+        ephem_primary: boolean, optional
             Use the ephemeris reader as the primary
             reader. Otherwise uses the first auxiliary data reader.
-            Default = false
+            Default = False
 
-        **kwargs : dict, optional
+        **kwargs : dictionary, optional
         Extra arguments
 
         """
@@ -69,21 +69,21 @@ class CombinedDataReader:
 
         Parameters
         -----------
-        block_size: int, optional
+        block_size: integer, optional
             the number of rows to read in.
             Use block_size=None to read in all available data.
             Default = None
 
-        verbose : bool, optional
+        verbose : boolean, optional
             Use verbose logging.
-            Default = None
+            Default = False
 
-        **kwargs : dict, optional
+        **kwargs : dictionary, optional
             Extra arguments
 
         Returns
         -----------
-        res_df : Pandas dataframe
+        res_df : pandas dataframe
             dataframe of the combined object data.
 
         """
@@ -160,21 +160,21 @@ class CombinedDataReader:
 
         Parameters
         -----------
-        block_size : int, optional
+        block_size : integer, optional
             the number of rows to read in.
             Use block_size=None to read in all available data.
-            [Default = None]
+            Default = None
 
-        verbose : bool, optional
+        verbose : boolean, optional
             use verbose logging.
             Default = False
 
-        **kwargs : dict, optional
+        **kwargs : dictionary, optional
             Extra arguments
 
         Returns
         -----------
-        res_df : Pandas dataframe
+        res_df : pandas dataframe
             dataframe of the combined object data, excluding any ephemeris data.
         """
         pplogger = logging.getLogger(__name__)

--- a/src/sorcha/readers/CombinedDataReader.py
+++ b/src/sorcha/readers/CombinedDataReader.py
@@ -25,8 +25,14 @@ class CombinedDataReader:
         """
         Parameters
         ----------
-        ephem_primary (bool, optional): Use the ephemeris reader as the primary
+        ephem_primary: bool, optional
+            Use the ephemeris reader as the primary
             reader. Otherwise uses the first auxiliary data reader.
+            Default = false
+
+        **kwargs : dict, optional
+        Extra arguments
+
         """
         self.ephem_reader = None
         self.aux_data_readers = []
@@ -38,7 +44,8 @@ class CombinedDataReader:
 
         Parameters
         ----------
-        new_reader (ObjectDataReader): The reader for a specific input file.
+        new_reader : ObjectDataReader
+            The reader for a specific input file.
         """
         pplogger = logging.getLogger(__name__)
         if self.ephem_reader is not None:
@@ -51,7 +58,8 @@ class CombinedDataReader:
 
         Parameters
         ----------
-        new_reader (ObjectDataReader): The reader for a specific input file.
+        new_reader : ObjectDataReader
+            The reader for a specific input file.
         """
         self.aux_data_readers.append(new_reader)
 
@@ -59,17 +67,24 @@ class CombinedDataReader:
         """Reads in a set number of rows from the input, performs
         post-processing and validation, and returns a data frame.
 
-        Parameters:
+        Parameters
         -----------
-        block_size (int, optional): the number of rows to read in.
+        block_size: int, optional
+            the number of rows to read in.
             Use block_size=None to read in all available data.
-            [Default = None]
+            Default = None
 
-        verbose (bool, optional): use verbose logging.
+        verbose : bool, optional
+            Use verbose logging.
+            Default = None
 
-        Returns:
+        **kwargs : dict, optional
+            Extra arguments
+
+        Returns
         -----------
-        res_df (Pandas dataframe): dataframe of the combined object data.
+        res_df : Pandas dataframe
+            dataframe of the combined object data.
 
         """
         pplogger = logging.getLogger(__name__)
@@ -143,19 +158,24 @@ class CombinedDataReader:
         This function DOES NOT include the ephemeris data in the returned data frame.
         It is to be used when generating the ephemeris during the execution of Sorcha.
 
-        Parameters:
+        Parameters
         -----------
-        block_size (int, optional): the number of rows to read in.
+        block_size : int, optional
+            the number of rows to read in.
             Use block_size=None to read in all available data.
             [Default = None]
 
-        verbose (bool, optional): use verbose logging.
+        verbose : bool, optional
+            use verbose logging.
+            Default = False
 
-        Returns:
+        **kwargs : dict, optional
+            Extra arguments
+
+        Returns
         -----------
-        res_df (Pandas dataframe): dataframe of the combined object data, excluding
-        any ephemeris data.
-
+        res_df : Pandas dataframe
+            dataframe of the combined object data, excluding any ephemeris data.
         """
         pplogger = logging.getLogger(__name__)
         verboselog = pplogger.info if verbose else lambda *a, **k: None

--- a/src/sorcha/readers/DatabaseReader.py
+++ b/src/sorcha/readers/DatabaseReader.py
@@ -8,6 +8,13 @@ from sorcha.readers.ObjectDataReader import ObjectDataReader
 # NOTE: this was written for a now-defunct functionality, but has been left
 # in the code as a database reader class may be useful later.
 
+"""
+!!!!!!!!!!!!!!!!
+This class is Not currently used in Sorcha. This was written for a now-defunct functionality,
+but have kept this class in case it may be useful in future iterations of the codebase.
+!!!!!!!!!!!!!!!!
+"""
+
 
 class DatabaseReader(ObjectDataReader):
     """A class to read in object data stored in a sqlite database."""
@@ -15,9 +22,10 @@ class DatabaseReader(ObjectDataReader):
     def __init__(self, intermdb, **kwargs):
         """A class for reading the object data from a sqlite database.
 
-        Parameters:
+        Parameters
         -----------
-        intermdb (string): filepath/name of temporary database.
+        intermdb : string
+            filepath/name of temporary database.
         """
         super().__init__(**kwargs)
         self.intermdb = intermdb
@@ -26,35 +34,38 @@ class DatabaseReader(ObjectDataReader):
         """Return a string identifying the current reader name
         and input information (for logging and output).
 
-        Returns:
+        Returns
         --------
-        name (str): The reader information.
+        name : string
+            The reader information.
         """
         return f"DatabaseReader:{self.intermdb}"
 
     def _read_rows_internal(self, block_start=0, block_size=None, **kwargs):
         """Reads in a set number of rows from the input.
 
-        Parameters:
+        Parameters
         -----------
-        block_start (int, optional): The 0-indexed row number from which
+        block_start : int, optional
+            The 0-indexed row number from which
             to start reading the data. For example in a CSV file
             block_start=2 would skip the first two lines after the header
             and return data starting on row=2. [Default=0]
 
-        block_size (int, optional): the number of rows to read in.
+        block_size : int, optional
+            the number of rows to read in.
             Use block_size=None to read in all available data.
             A non-None block size must be provided if block_start > 0.
 
-        validate_data (bool, optional): if True then checks the data for
-            NaNs or nulls.
+        validate_data : bool, optional
+            if True then checks the data for NaNs or nulls.
 
-        Returns:
+        Returns
         ----------
-        res_df (Pandas dataframe): dataframe of the object data.
+        res_df : Pandas dataframe
+            dataframe of the object data.
 
-
-        Notes:
+        Notes
         ------
         A non-None block size must be provided if block_start > 0.
         """
@@ -74,13 +85,15 @@ class DatabaseReader(ObjectDataReader):
     def _read_objects_internal(self, obj_ids, **kwargs):
         """Read in a chunk of data for given object IDs.
 
-        Parameters:
+        Parameters
         -----------
-        obj_ids (list): A list of object IDs to use.
+        obj_ids : list
+            A list of object IDs to use.
 
-        Returns:
+        Returns
         -----------
-        res_df (Pandas dataframe): The dataframe for the object data.
+        res_df : Pandas dataframe
+            The dataframe for the object data.
         """
         con = sqlite3.connect(self.intermdb)
         prm_list = ", ".join("?" for _ in obj_ids)
@@ -93,19 +106,21 @@ class DatabaseReader(ObjectDataReader):
         """Perform any input-specific processing and validation on the input table.
         Modifies the input dataframe in place.
 
-        Note
-        ----
+        Notes
+        ------
         The base implementation includes filtering that is common to most
         input types. Subclasses should call super.process_and_validate()
         to ensure that the ancestor’s validation is also applied.
 
-        Parameters:
+        Parameters
         -----------
-        input_table (Pandas dataframe): A loaded table.
+        input_table : Pandas dataframe
+            A loaded table.
 
-        Returns:
+        Returns
         -----------
-        input_table (Pandas dataframe): Returns the input dataframe modified in-place.
+        input_table : Pandas dataframe
+            Returns the input dataframe modified in-place.
         """
         # Perform the parent class's validation (checking object ID column).
         input_table = super()._process_and_validate_input_table(input_table, **kwargs)

--- a/src/sorcha/readers/DatabaseReader.py
+++ b/src/sorcha/readers/DatabaseReader.py
@@ -26,6 +26,11 @@ class DatabaseReader(ObjectDataReader):
         -----------
         intermdb : string
             filepath/name of temporary database.
+
+            Default = None
+
+        **kwargs : dictionary, optional
+            Extra arguments
         """
         super().__init__(**kwargs)
         self.intermdb = intermdb
@@ -46,23 +51,24 @@ class DatabaseReader(ObjectDataReader):
 
         Parameters
         -----------
-        block_start : int, optional
+        block_start : integer, optional
             The 0-indexed row number from which
             to start reading the data. For example in a CSV file
             block_start=2 would skip the first two lines after the header
-            and return data starting on row=2. [Default=0]
+            and return data starting on row=2. Default=0
 
         block_size : int, optional
             the number of rows to read in.
             Use block_size=None to read in all available data.
             A non-None block size must be provided if block_start > 0.
+            Default = None
 
-        validate_data : bool, optional
-            if True then checks the data for NaNs or nulls.
+        **kwargs : dictionary, optional
+            Extra arguments
 
         Returns
         ----------
-        res_df : Pandas dataframe
+        res_df : pandas dataframe
             dataframe of the object data.
 
         Notes
@@ -90,9 +96,12 @@ class DatabaseReader(ObjectDataReader):
         obj_ids : list
             A list of object IDs to use.
 
+        **kwargs : dictionary, optional
+            Extra arguments
+
         Returns
         -----------
-        res_df : Pandas dataframe
+        res_df : pandas dataframe
             The dataframe for the object data.
         """
         con = sqlite3.connect(self.intermdb)
@@ -114,12 +123,15 @@ class DatabaseReader(ObjectDataReader):
 
         Parameters
         -----------
-        input_table : Pandas dataframe
+        input_table : pandas dataframe
             A loaded table.
+
+        **kwargs : dictionary, optional
+            Extra arguments
 
         Returns
         -----------
-        input_table : Pandas dataframe
+        input_table : pandas dataframe
             Returns the input dataframe modified in-place.
         """
         # Perform the parent class's validation (checking object ID column).

--- a/src/sorcha/readers/HDF5Reader.py
+++ b/src/sorcha/readers/HDF5Reader.py
@@ -37,23 +37,24 @@ class HDF5DataReader(ObjectDataReader):
 
         Parameters
         -----------
-        block_start : int, optional
+        block_start : integer, optional
             The 0-indexed row number from which
             to start reading the data. For example in a CSV file
             block_start=2 would skip the first two lines after the header
-            and return data starting on row=2. [Default=0]
+            and return data starting on row=2. Default=0
 
-        block_size : int, optional
+        block_size : integer, optional
             the number of rows to read in.
             Use block_size=None to read in all available data.
-            [Default = None]
+            Default = None
 
-        validate_data : bool, optional
-            if True then checks the data for NaNs or nulls.
+        **kwargs : dictionary, optional
+            Extra arguments
 
         Returns
         -----------
-        res_df (Pandas dataframe): dataframe of the object data.
+        res_df  : pandas dataframe
+            Dataframe of the object data.
         """
         if block_size is None:
             res_df = pd.read_hdf(
@@ -83,6 +84,9 @@ class HDF5DataReader(ObjectDataReader):
         obj_ids : list
             A list of object IDs to use.
 
+        **kwargs : dictionary, optional
+            Extra arguments
+
         Returns
         -----------
         res_df : Pandas dataframe
@@ -106,12 +110,15 @@ class HDF5DataReader(ObjectDataReader):
 
         Parameters
         -----------
-        input_table : Pandas dataframe
+        input_table : pandas dataframe
             A loaded table.
+
+        **kwargs : dictionary, optional
+            Extra arguments
 
         Returns
         -----------
-        input_table : Pandas dataframe
+        input_table : pandas dataframe
             Returns the input dataframe modified in-place.
         """
         # Perform the parent class's validation (checking object ID column).

--- a/src/sorcha/readers/HDF5Reader.py
+++ b/src/sorcha/readers/HDF5Reader.py
@@ -9,9 +9,10 @@ class HDF5DataReader(ObjectDataReader):
     def __init__(self, filename, **kwargs):
         """A class for reading the object data from an HDF5 file.
 
-        Parameters:
+        Parameters
         -----------
-        filename (string): location/name of the data file.
+        filename : string
+            location/name of the data file.
         """
         super().__init__(**kwargs)
         self.filename = filename
@@ -24,30 +25,33 @@ class HDF5DataReader(ObjectDataReader):
         """Return a string identifying the current reader name
         and input information (for logging and output).
 
-        Returns:
+        Returns
         --------
-        name (str): The reader information.
+        name : string
+            The reader information.
         """
         return f"HDF5DataReader:{self.filename}"
 
     def _read_rows_internal(self, block_start=0, block_size=None, **kwargs):
         """Reads in a set number of rows from the input.
 
-        Parameters:
+        Parameters
         -----------
-        block_start (int, optional): The 0-indexed row number from which
+        block_start : int, optional
+            The 0-indexed row number from which
             to start reading the data. For example in a CSV file
             block_start=2 would skip the first two lines after the header
             and return data starting on row=2. [Default=0]
 
-        block_size (int, optional): the number of rows to read in.
+        block_size : int, optional
+            the number of rows to read in.
             Use block_size=None to read in all available data.
             [Default = None]
 
-        validate_data (bool, optional): if True then checks the data for
-            NaNs or nulls.
+        validate_data : bool, optional
+            if True then checks the data for NaNs or nulls.
 
-        Returns:
+        Returns
         -----------
         res_df (Pandas dataframe): dataframe of the object data.
         """
@@ -74,13 +78,15 @@ class HDF5DataReader(ObjectDataReader):
     def _read_objects_internal(self, obj_ids, **kwargs):
         """Read in a chunk of data for given object IDs.
 
-        Parameters:
+        Parameters
         -----------
-        obj_ids (list): A list of object IDs to use.
+        obj_ids : list
+            A list of object IDs to use.
 
-        Returns:
+        Returns
         -----------
-        res_df (Pandas dataframe): The dataframe for the object data.
+        res_df : Pandas dataframe
+            The dataframe for the object data.
         """
         self._build_id_map()
         row_match = self.obj_id_table["ObjID"].isin(obj_ids)
@@ -92,19 +98,21 @@ class HDF5DataReader(ObjectDataReader):
         """Perform any input-specific processing and validation on the input table.
         Modifies the input dataframe in place.
 
-        Note
-        ----
+        Notes
+        ------
         The base implementation includes filtering that is common to most
         input types. Subclasses should call super.process_and_validate()
         to ensure that the ancestor’s validation is also applied.
 
-        Parameters:
+        Parameters
         -----------
-        input_table (Pandas dataframe): A loaded table.
+        input_table : Pandas dataframe
+            A loaded table.
 
-        Returns:
+        Returns
         -----------
-        input_table (Pandas dataframe): Returns the input dataframe modified in-place.
+        input_table : Pandas dataframe
+            Returns the input dataframe modified in-place.
         """
         # Perform the parent class's validation (checking object ID column).
         input_table = super()._process_and_validate_input_table(input_table, **kwargs)

--- a/src/sorcha/readers/OIFReader.py
+++ b/src/sorcha/readers/OIFReader.py
@@ -20,11 +20,13 @@ class OIFDataReader(ObjectDataReader):
     def __init__(self, filename, inputformat, **kwargs):
         """A class for reading the object data from a CSV file.
 
-        Parameters:
+        Parameters
         -----------
-        filename (string): location/name of the data file.
+        filename : string
+            location/name of the data file.
 
-        inputformat (string): format of input file ("whitespace"/"comma"/"csv"/"h5"/"hdf5").
+        inputformat : string
+            format of input file ("whitespace"/"comma"/"csv"/"h5"/"hdf5").
         """
         super().__init__(**kwargs)
 
@@ -46,29 +48,33 @@ class OIFDataReader(ObjectDataReader):
         """Return a string identifying the current reader name
         and input information (for logging and output).
 
-        Returns:
+        Returns
         --------
-        name (str): The reader information.
+        name : string
+            The reader information.
         """
         return f"OIFDataReader|{self.reader.get_reader_info()}"
 
     def _read_rows_internal(self, block_start=0, block_size=None, **kwargs):
         """Reads in a set number of rows from the input.
 
-        Parameters:
+        Parameters
         -----------
-        block_start (int, optional): The 0-indexed row number from which
+        block_start : int, optional
+            The 0-indexed row number from which
             to start reading the data. For example in a CSV file
             block_start=2 would skip the first two lines after the header
             and return data starting on row=2. [Default=0]
 
-        block_size (int, optional): the number of rows to read in.
+        block_size : int, optional
+            the number of rows to read in.
             Use block_size=None to read in all available data.
             [Default = None]
 
-        Returns:
+        Returns
         -----------
-        res_df (Pandas dataframe): dataframe of the object data.
+        res_df : Pandas dataframe
+            dataframe of the object data.
 
         """
         res_df = self.reader.read_rows(block_start, block_size, **kwargs)
@@ -78,13 +84,15 @@ class OIFDataReader(ObjectDataReader):
         """Read in a chunk of data corresponding to all rows for
         a given set of object IDs.
 
-        Parameters:
+        Parameters
         -----------
-        obj_ids (list): A list of object IDs to use.
+        obj_ids : list
+            A list of object IDs to use.
 
-        Returns:
+        Returns
         -----------
-        res_df (Pandas dataframe): The dataframe for the object data.
+        res_df : Pandas dataframe
+            The dataframe for the object data.
         """
         res_df = self.reader.read_objects(obj_ids, **kwargs)
         return res_df
@@ -93,19 +101,21 @@ class OIFDataReader(ObjectDataReader):
         """Perform any input-specific processing and validation on the input table.
         Modifies the input dataframe in place.
 
-        Note
-        ----
+        Notes
+        -----
         The base implementation includes filtering that is common to most
         input types. Subclasses should call super.process_and_validate()
         to ensure that the ancestor’s validation is also applied.
 
-        Parameters:
+        Parameters
         -----------
-        input_table (Pandas dataframe): A loaded table.
+        input_table : Pandas dataframe
+            A loaded table.
 
-        Returns:
+        Returns
         -----------
-        input_table (Pandas dataframe): Returns the input dataframe modified in-place.
+        input_table : Pandas dataframe
+            Returns the input dataframe modified in-place.
         """
         # We do not call reader.process_and_validate_input_table() or
         # super().process_and_validate_input_table() because reader's read functions have
@@ -159,15 +169,18 @@ class OIFDataReader(ObjectDataReader):
 def read_full_oif_table(filename, inputformat):
     """A helper function for testing that reads and returns an entire OIF table.
 
-    Parameters:
+    Parameters
     -----------
-    filename (string): location/name of the data file.
+    filename : string
+        location/name of the data file.
 
-    inputformat (string): format of input file ("whitespace"/"comma"/"csv"/"h5"/"hdf5").
+    inputformat : string
+        format of input file ("whitespace"/"comma"/"csv"/"h5"/"hdf5").
 
-    Returns:
+    Returns
     -----------
-    res_df (Pandas dataframe): dataframe of the object data.
+    res_df : Pandas dataframe
+        dataframe of the object data.
 
     """
     reader = OIFDataReader(filename, inputformat)

--- a/src/sorcha/readers/OIFReader.py
+++ b/src/sorcha/readers/OIFReader.py
@@ -27,6 +27,10 @@ class OIFDataReader(ObjectDataReader):
 
         inputformat : string
             format of input file ("whitespace"/"comma"/"csv"/"h5"/"hdf5").
+
+        **kwargs : dictionary, optional
+            Extra arguments
+
         """
         super().__init__(**kwargs)
 
@@ -50,7 +54,7 @@ class OIFDataReader(ObjectDataReader):
 
         Returns
         --------
-        name : string
+        : string
             The reader information.
         """
         return f"OIFDataReader|{self.reader.get_reader_info()}"
@@ -64,12 +68,15 @@ class OIFDataReader(ObjectDataReader):
             The 0-indexed row number from which
             to start reading the data. For example in a CSV file
             block_start=2 would skip the first two lines after the header
-            and return data starting on row=2. [Default=0]
+            and return data starting on row=2. Default =0
 
         block_size : int, optional
             the number of rows to read in.
             Use block_size=None to read in all available data.
-            [Default = None]
+            Default = None
+
+        **kwargs : dictionary, optional
+            Extra arguments
 
         Returns
         -----------
@@ -89,9 +96,12 @@ class OIFDataReader(ObjectDataReader):
         obj_ids : list
             A list of object IDs to use.
 
+        **kwargs : dictionary, optional
+            Extra arguments
+
         Returns
         -----------
-        res_df : Pandas dataframe
+        res_df : pandas dataframe
             The dataframe for the object data.
         """
         res_df = self.reader.read_objects(obj_ids, **kwargs)
@@ -101,21 +111,25 @@ class OIFDataReader(ObjectDataReader):
         """Perform any input-specific processing and validation on the input table.
         Modifies the input dataframe in place.
 
+        Parameters
+        -----------
+        input_table : Pandas dataframe
+            A loaded table.
+
+        **kwargs : dictionary, optional
+            Extra arguments
+
+        Returns
+        -----------
+        input_table : Pandas dataframe
+            Returns the input dataframe modified in-place.
+
         Notes
         -----
         The base implementation includes filtering that is common to most
         input types. Subclasses should call super.process_and_validate()
         to ensure that the ancestor’s validation is also applied.
 
-        Parameters
-        -----------
-        input_table : Pandas dataframe
-            A loaded table.
-
-        Returns
-        -----------
-        input_table : Pandas dataframe
-            Returns the input dataframe modified in-place.
         """
         # We do not call reader.process_and_validate_input_table() or
         # super().process_and_validate_input_table() because reader's read functions have
@@ -179,7 +193,7 @@ def read_full_oif_table(filename, inputformat):
 
     Returns
     -----------
-    res_df : Pandas dataframe
+    res_df : pandas dataframe
         dataframe of the object data.
 
     """

--- a/src/sorcha/readers/ObjectDataReader.py
+++ b/src/sorcha/readers/ObjectDataReader.py
@@ -57,12 +57,15 @@ class ObjectDataReader(abc.ABC):
             The 0-indexed row number from which
             to start reading the data. For example in a CSV file
             block_start=2 would skip the first two lines after the header
-            and return data starting on row=2. [Default=0]
+            and return data starting on row=2. Default=0
 
         block_size : int (optional)
             the number of rows to read in.
             Use block_size=None to read in all available data.
-            [Default = None]
+            Default = None
+
+        **kwargs : dictionary, optional
+            Extra arguments
 
         Returns
         -----------
@@ -101,6 +104,9 @@ class ObjectDataReader(abc.ABC):
         -----------
         obj_ids : list
             A list of object IDs to use.
+
+        **kwargs : dictionary, optional
+            Extra arguments
 
         Returns
         -----------
@@ -153,24 +159,30 @@ class ObjectDataReader(abc.ABC):
         """Perform any input-specific processing and validation on the input table.
         Modifies the input dataframe in place.
 
-        Note
-        ----
-        The base implementation includes filtering that is common to most
-        input types. Subclasses should call super.process_and_validate()
-        to ensure that the ancestor’s validation is also applied.
-
         Parameters
         -----------
         input_table : Pandas dataframe
             A loaded table.
 
-        disallow_nan : bool (optional)
-            if True then checks the data for  NaNs or nulls.
+        **kwargs : dictionary, optional
+                Extra arguments
 
         Returns
         -----------
         input_table :Pandas dataframe
             Returns the input dataframe modified in-place.
+            
+        Notes
+        --------
+        The base implementation includes filtering that is common to most
+        input types. Subclasses should call super.process_and_validate()
+        to ensure that the ancestor’s validation is also applied.
+
+        Additional arguments to use:
+
+        disallow_nan : boolean
+            if True then checks the data for  NaNs or nulls.
+            
         """
         input_table = self._validate_object_id_column(input_table)
 

--- a/src/sorcha/readers/ObjectDataReader.py
+++ b/src/sorcha/readers/ObjectDataReader.py
@@ -29,7 +29,8 @@ class ObjectDataReader(abc.ABC):
 
         Parameters
         ----------
-        cache_table (bool, optional): Indicates whether to keep the entire table in memory.
+        cache_table : bool, optional
+            Indicates whether to keep the entire table in memory.
         """
         self._cache_table = cache_table
         self._table = None
@@ -39,9 +40,10 @@ class ObjectDataReader(abc.ABC):
         """Return a string identifying the current reader name
         and input information (for logging and output).
 
-        Returns:
+        Returns
         --------
-        name (str): The reader information.
+        name : str
+            The reader information.
         """
         pass  # pragma: no cover
 
@@ -49,20 +51,23 @@ class ObjectDataReader(abc.ABC):
         """Reads in a set number of rows from the input, performs
         post-processing and validation, and returns a data frame.
 
-        Parameters:
+        Parameters
         -----------
-        block_start (int, optional): The 0-indexed row number from which
+        block_start : int (optional)
+            The 0-indexed row number from which
             to start reading the data. For example in a CSV file
             block_start=2 would skip the first two lines after the header
             and return data starting on row=2. [Default=0]
 
-        block_size (int, optional): the number of rows to read in.
+        block_size : int (optional)
+            the number of rows to read in.
             Use block_size=None to read in all available data.
             [Default = None]
 
-        Returns:
+        Returns
         -----------
-        res_df (Pandas dataframe): dataframe of the object data.
+        res_df : Pandas dataframe
+            dataframe of the object data.
 
         """
         if self._cache_table:
@@ -92,13 +97,15 @@ class ObjectDataReader(abc.ABC):
         """Read in a chunk of data corresponding to all rows for
         a given set of object IDs.
 
-        Parameters:
+        Parameters
         -----------
-        obj_ids (list): A list of object IDs to use.
+        obj_ids : list
+            A list of object IDs to use.
 
-        Returns:
+        Returns
         -----------
-        res_df (Pandas dataframe): The dataframe for the object data.
+        res_df : Pandas dataframe
+            The dataframe for the object data.
         """
         if self._cache_table:
             # Load the entire table the first time.
@@ -121,13 +128,15 @@ class ObjectDataReader(abc.ABC):
         """Checks that the object ID column exists and converts it to a string.
         This is the common validity check for all object data tables.
 
-        Parameters:
+        Parameters
         -----------
-        input_table (Pandas dataframe): A loaded table.
+        input_table : Pandas dataframe
+            A loaded table.
 
-        Returns:
+        Returns
         -----------
-        input_table (Pandas dataframe): Returns the input dataframe modified in-place.
+        input_table : Pandas dataframe
+            Returns the input dataframe modified in-place.
         """
         # Check that the ObjID column exists and convert it to a string.
         try:
@@ -150,16 +159,18 @@ class ObjectDataReader(abc.ABC):
         input types. Subclasses should call super.process_and_validate()
         to ensure that the ancestor’s validation is also applied.
 
-        Parameters:
+        Parameters
         -----------
-        input_table (Pandas dataframe): A loaded table.
+        input_table : Pandas dataframe
+            A loaded table.
 
-        disallow_nan (bool, optional): if True then checks the data for
-            NaNs or nulls.
+        disallow_nan : bool (optional)
+            if True then checks the data for  NaNs or nulls.
 
-        Returns:
+        Returns
         -----------
-        input_table (Pandas dataframe): Returns the input dataframe modified in-place.
+        input_table :Pandas dataframe
+            Returns the input dataframe modified in-place.
         """
         input_table = self._validate_object_id_column(input_table)
 

--- a/src/sorcha/readers/ObjectDataReader.py
+++ b/src/sorcha/readers/ObjectDataReader.py
@@ -171,7 +171,7 @@ class ObjectDataReader(abc.ABC):
         -----------
         input_table :Pandas dataframe
             Returns the input dataframe modified in-place.
-            
+
         Notes
         --------
         The base implementation includes filtering that is common to most
@@ -182,7 +182,7 @@ class ObjectDataReader(abc.ABC):
 
         disallow_nan : boolean
             if True then checks the data for  NaNs or nulls.
-            
+
         """
         input_table = self._validate_object_id_column(input_table)
 

--- a/src/sorcha/readers/OrbitAuxReader.py
+++ b/src/sorcha/readers/OrbitAuxReader.py
@@ -18,9 +18,14 @@ class OrbitAuxReader(CSVDataReader):
 
         sep : string, optional
             format of input file ("whitespace"/"csv").
+            Default = "csv"
 
         header : int
             The row number of the header. If not provided, does an automatic search.
+            Default = -1
+
+        **kwargs : dictionary, optional
+            Extra arguments
         """
         super().__init__(filename, sep, header, **kwargs)
 
@@ -30,7 +35,7 @@ class OrbitAuxReader(CSVDataReader):
 
         Returns
         --------
-        name : string
+        : string
             The reader information.
         """
         return f"OrbitAuxReader:{self.filename}"
@@ -39,21 +44,24 @@ class OrbitAuxReader(CSVDataReader):
         """Perform any input-specific processing and validation on the input table.
         Modifies the input dataframe in place.
 
+        Parameters
+        -----------
+        input_table : pandas dataframe
+            A loaded table.
+
+        **kwargs : dictionary, optional
+
+        Returns
+        -----------
+        res_df : pandas dataframe
+            Returns the input dataframe modified in-place.
+
         Notes
         ------
         The base implementation includes filtering that is common to most
         input types. Subclasses should call super.process_and_validate()
         to ensure that the ancestor’s validation is also applied.
 
-        Parameters
-        -----------
-        input_table : Pandas dataframe
-            A loaded table.
-
-        Returns
-        -----------
-        res_df : Pandas dataframe
-            Returns the input dataframe modified in-place.
         """
         # Do standard CSV file processing
         super()._process_and_validate_input_table(input_table, **kwargs)

--- a/src/sorcha/readers/OrbitAuxReader.py
+++ b/src/sorcha/readers/OrbitAuxReader.py
@@ -11,13 +11,16 @@ class OrbitAuxReader(CSVDataReader):
     def __init__(self, filename, sep="csv", header=-1, **kwargs):
         """A class for reading the object data from a CSV file.
 
-        Parameters:
+        Parameters
         -----------
-        filename (string): location/name of the data file.
+        filename : string
+            location/name of the data file.
 
-        sep (string, optional): format of input file ("whitespace"/"csv").
+        sep : string, optional
+            format of input file ("whitespace"/"csv").
 
-        header (int): The row number of the header. If not provided, does an automatic search.
+        header : int
+            The row number of the header. If not provided, does an automatic search.
         """
         super().__init__(filename, sep, header, **kwargs)
 
@@ -25,9 +28,10 @@ class OrbitAuxReader(CSVDataReader):
         """Return a string identifying the current reader name
         and input information (for logging and output).
 
-        Returns:
+        Returns
         --------
-        name (str): The reader information.
+        name : string
+            The reader information.
         """
         return f"OrbitAuxReader:{self.filename}"
 
@@ -35,19 +39,21 @@ class OrbitAuxReader(CSVDataReader):
         """Perform any input-specific processing and validation on the input table.
         Modifies the input dataframe in place.
 
-        Note
-        ----
+        Notes
+        ------
         The base implementation includes filtering that is common to most
         input types. Subclasses should call super.process_and_validate()
         to ensure that the ancestor’s validation is also applied.
 
-        Parameters:
+        Parameters
         -----------
-        input_table (Pandas dataframe): A loaded table.
+        input_table : Pandas dataframe
+            A loaded table.
 
-        Returns:
+        Returns
         -----------
-        res_df (Pandas dataframe): Returns the input dataframe modified in-place.
+        res_df : Pandas dataframe
+            Returns the input dataframe modified in-place.
         """
         # Do standard CSV file processing
         super()._process_and_validate_input_table(input_table, **kwargs)

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -65,13 +65,14 @@ def runLSSTSimulation(args, configs, pplogger=None):
 
     Parameters
     -----------
-    args (dictionary or `sorchaArguments` object):
+    args : dictionary or `sorchaArguments` object
         dictionary of command-line arguments.
 
     pplogger : logging.Logger, optional
         The logger to use in this function. If None creates a new one.
+        Default = None
 
-    Returns:
+    Returns
     -----------
     None.
 
@@ -307,32 +308,33 @@ def main():
     model Solar System small body population to what the specified wide-field
     survey would observe.
 
-    usage: sorcha [-h] -c C -o O -ob OB -p P -pd PD [-er E] [-ew E] [-cp CP] [-dw [DW]] [-dr DR] [-dl] [-f] [-s S] [-t T] [-v]
+    usage: sorcha [-h] -c C -o O -ob OB -p P -pd PD [-er ER] [-ew EW] [-ar AR] [-cp CP] [-f] [-s S] [-t T] [-v]
 
     options:
-      -h, --help            show this help message and exit
+        -h, --help            show this help message and exit
 
     Required arguments:
-      -c C, --config C      Input configuration file name (default: None)
-      -o O, --outfile O     Path to store output and logs. (default: None)
-      -ob OB, --orbit OB    Orbit file name (default: None)
-      -p P, --params P      Physical parameters file name (default: None)
-      -pd PD, --pointing_database PD
+        -c C, --config C      Input configuration file name (default: None)
+        -o O, --outfile O     Path to store output and logs. (default: None)
+        -ob OB, --orbit OB
+                            Orbit file name (default: None)
+        -p P, --params P      Physical parameters file name (default: None)
+        -pd PD, --pointing_database PD
                             Survey pointing information (default: None)
 
     Optional arguments:
-      -er E, --ephem_read E Existing ephemeris simulation output file name (default: None)
-      -ew E, --ephem_write E
-                            Output file name for newly generated ephemeris simulation (default: None)
-      -cp CP, --complex_physical_parameters CP
-                            Complex physical parameters file name (default: None)
-      -dw [DW]              Make temporary ephemeris database. If no filepath/name supplied, default name and ephemeris input location used. (default: None)
-      -dr DR                Location of existing/previous temporary ephemeris database to read from if wanted. (default: None)
-      -dl                   Delete the temporary ephemeris database after code has completed. (default: False)
-      -f, --force           Force deletion/overwrite of existing output file(s). (default: False)
-      -s S, --survey S      Survey to simulate (default: LSST)
-      -t T, --stem T        Output file name stem. (default: SSPPOutput)
-      -v, --verbose         Verbosity. Default currently true; include to turn off verbosity. (default: True)
+        -er ER, --ephem_read ER
+            Previously generated ephemeris simulation file name, required if ephemerides_type in config file is 'external'. (default: None)
+        -ew EW, --ephem_write EW
+            Output file name for newly generated ephemeris simulation, required if ephemerides_type in config file is not 'external'. (default: None)
+        -ar AR, --ar_data_path AR
+            Directory path where Assist+Rebound data files where stored when running bootstrap_sorcha_data_files from the command line. (default: None)
+        -cp CP, --complex_physical_parameters CP
+                        Complex physical parameters file name (default: None)
+        -f, --force           Force deletion/overwrite of existing output file(s). Default False. (default: False)
+        -s S, --survey S      Survey to simulate (default: LSST)
+        -t T, --stem T        Output file name stem. (default: SSPPOutput)
+        -v, --verbose         Verbosity. Default currently true; include to turn off verbosity. (default: True)
     """
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -45,6 +45,14 @@ from sorcha.utilities.citation_text import cite_sorcha
 def cite():
     """Providing the bibtex, AAS Journals software latex command, and acknowledgement
     statements for Sorcha and the associated packages that power it.
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    --------
+    None
     """
     cite_sorcha()
 
@@ -55,7 +63,7 @@ def runLSSTSimulation(args, configs, pplogger=None):
     filters to bias a model Solar System small body population to what the
     Vera C. Rubin Observatory Legacy Survey of Space and Time would observe.
 
-    Parameters:
+    Parameters
     -----------
     args (dictionary or `sorchaArguments` object):
         dictionary of command-line arguments.
@@ -215,6 +223,7 @@ def runLSSTSimulation(args, configs, pplogger=None):
         # These are the columns that should be used moving forward for filters etc.
         # Do NOT use TrailedSourceMag or PSFMag, these are cut later.
         verboselog("Calculating astrometric and photometric uncertainties...")
+        verboselog("Values are then used to randomize the photometry....")
         observations = PPAddUncertainties.addUncertainties(
             observations, configs, args._rngs, verbose=args.verbose
         )

--- a/src/sorcha/utilities/citation_text.py
+++ b/src/sorcha/utilities/citation_text.py
@@ -4,6 +4,14 @@ import rebound
 def cite_sorcha():
     """Providing the bibtex, AAS Journals software latex command, and acknowledgement
     statements for Sorcha and the associated packages that power it.
+
+    Parameters
+    -----------
+    None
+
+    Returns
+    -----------
+    None
     """
     print("\nSorcha: \n")
     print("Merritt et al. (in prep)")

--- a/src/sorcha/utilities/createResultsSQLDatabase.py
+++ b/src/sorcha/utilities/createResultsSQLDatabase.py
@@ -16,25 +16,30 @@ import os
 from sorcha.modules.PPConfigParser import PPFindDirectoryOrExit
 
 
-def create_results_table(cnx_out, filename, output_path, output_stem, table_name="pp_results"):
+def create_results_table(cnx_out, filename, output_path, output_stem, table_name="sorcha_results"):
     """
     Creates a table in a SQLite database from SSPP results.
 
-    Parameters:
+    Parameters
     -----------
-    cnx_out (sqlite3 connection): Connection to sqlite3 database.
+    cnx_out : sqlite3 connection
+        Connection to sqlite3 database.
 
-    filename (string): filepath/name of sqlite3 database.
+    filename : string
+        filepath/name of sqlite3 database.
 
-    output_path (string): filepath of directory containing SSPP output folders.
+    output_path : string
+        filepath of directory containing SSPP output folders.
 
-    output_stem (string): stem filename for SSPP outputs.
+    output_stem : string
+        stem filename for SSPP outputs.
 
-    table_name (string): name of table of SSPP results.
+    table_name : string, optional
+        name of table of for storing sorcha results. Default ="sorcha_results"
 
-    Returns:
+    Returns
     -----------
-    None.
+    None
 
     """
 
@@ -83,17 +88,20 @@ def create_inputs_table(cnx_out, input_path, table_type):
     Creates a table in a SQLite database from the input files (i.e. orbits,
     physical parameters, etc).
 
-    Parameters:
+    Parameters
     -----------
-    cnx_out (sqlite3 connection): Connection to sqlite3 database.
+    cnx_out : sqlite3 connection
+        Connection to sqlite3 database.
 
-    input_path (string): filepath of directory containing input files.
+    input_path : string
+        Filepath of directory containing input files.
 
-    table_type (string): type of file. Should be "orbits"/"params"/"comet".
+    table_type : string
+        Type of file. Should be "orbits"/"params"/"comet".
 
-    Returns:
+    Returns
     -----------
-    None.
+    None
 
     """
 
@@ -121,13 +129,14 @@ def create_results_database(args):
     Creates a SQLite database with tables of SSPP results and all orbit/physical
     parameters/comet files.
 
-    Parameters:
+    Parameters
     -----------
-    args (argparse ArgumentParser object): command line arguments.
+    args : ArgumentParser
+        argparse ArgumentParser object; command line arguments.
 
-    Returns:
+    Returns
     -----------
-    None.
+    None
 
     """
 
@@ -147,17 +156,19 @@ def create_results_database(args):
         create_inputs_table(cnx_out, "comet")
 
 
-def get_column_names(filename, table_name="pp_results"):
+def get_column_names(filename, table_name="sorcha_results"):
     """
     Obtains column names from a table in a SQLite database.
 
-    Parameters:
+    Parameters
     -----------
-    filename (string): filepath/name of sqlite3 database.
+    filename : string
+        Filepath/name of sqlite3 database.
 
-    table_name (string): name of table.
+    table_name : string, optional
+        Name of table. Default = "sorcha_results"
 
-    Returns:
+    Returns
     -----------
     col_names (list): list of column names.
 

--- a/src/sorcha/utilities/createResultsSQLDatabase.py
+++ b/src/sorcha/utilities/createResultsSQLDatabase.py
@@ -16,7 +16,7 @@ import os
 from sorcha.modules.PPConfigParser import PPFindDirectoryOrExit
 
 
-def create_results_table(cnx_out, filename, output_path, output_stem, table_name="sorcha_results"):
+def create_results_table(cnx_out, filename, output_path, output_stem, table_name="pp_results"):
     """
     Creates a table in a SQLite database from SSPP results.
 
@@ -35,7 +35,7 @@ def create_results_table(cnx_out, filename, output_path, output_stem, table_name
         stem filename for SSPP outputs.
 
     table_name : string, optional
-        name of table of for storing sorcha results. Default ="sorcha_results"
+        name of table of for storing sorcha results. Default ="pp_results"
 
     Returns
     -----------
@@ -156,7 +156,7 @@ def create_results_database(args):
         create_inputs_table(cnx_out, "comet")
 
 
-def get_column_names(filename, table_name="sorcha_results"):
+def get_column_names(filename, table_name="pp_results"):
     """
     Obtains column names from a table in a SQLite database.
 
@@ -166,7 +166,7 @@ def get_column_names(filename, table_name="sorcha_results"):
         Filepath/name of sqlite3 database.
 
     table_name : string, optional
-        Name of table. Default = "sorcha_results"
+        Name of table. Default = "pp_results"
 
     Returns
     -----------

--- a/src/sorcha/utilities/dataUtilitiesForTests.py
+++ b/src/sorcha/utilities/dataUtilitiesForTests.py
@@ -18,12 +18,12 @@ def get_test_filepath(filename):
 
     Parameters
     ----------
-    filename : `str`
+    filename : string
         The name of the file inside the ``tests/data`` directory.
 
     Returns
     -------
-    filepath : `str`
+    : string
         The full path to the file.
     """
 
@@ -40,12 +40,12 @@ def get_demo_filepath(filename):
 
     Parameters
     ----------
-    filename : `str`
+    filename : string
         The name of the file inside the ``demo`` directory.
 
     Returns
     -------
-    filepath : `str`
+    : string
         The full path to the file.
     """
 
@@ -62,12 +62,12 @@ def get_data_out_filepath(filename):
 
     Parameters
     ----------
-    filename : `str`
+    filename : string
         The name of the file inside the ``data/out`` directory.
 
     Returns
     -------
-    filepath : `str`
+    : string
         The full path to the file.
     """
 

--- a/src/sorcha/utilities/diffTestUtils.py
+++ b/src/sorcha/utilities/diffTestUtils.py
@@ -15,13 +15,16 @@ def compare_result_files(test_output, golden_output):
 
     Parameters
     ----------
-    test_output (str): The path and file name of the test results.
+    test_output : string
+        The path and file name of the test results.
 
-    golden_output (str): The path and file name of the golden set results.
+    golden_output : string
+        The path and file name of the golden set results.
 
     Returns
     -------
-    bool : Indicates whether the results are the same.
+    : bool
+        Indicates whether the results are the same.
     """
     test_data = pd.read_csv(test_output)
     golden_data = pd.read_csv(golden_output)
@@ -79,7 +82,14 @@ def override_seed_and_run(outpath, arg_set="baseline"):
 
     Parameters
     ----------
-    outpath (str): The path for the output files.
+    outpath : string
+        The path for the output files.
+
+    arg_set : string, optional
+        set of arguments for setting up the run. Options: "baseline" or "with_ephemeris".
+        "baseline"" run does not ephemeris generation. "with_ephemeeris" is a full end to end run
+        of all main components of sorcha.
+        Default = "baseline"
     """
 
     if arg_set == "baseline":

--- a/src/sorcha/utilities/generateGoldens.py
+++ b/src/sorcha/utilities/generateGoldens.py
@@ -8,6 +8,11 @@ from sorcha.utilities.diffTestUtils import override_seed_and_run
 from sorcha.utilities.dataUtilitiesForTests import get_demo_filepath
 
 if __name__ == "__main__":
+    """
+    Generates "golden" output for sorcha runs for testing. This should only b
+    be run sparingly when confident all changes have been confirmed and tested with
+    unit tests
+    """
     # Create a goldens directory if it does not exist.
     golden_dir = get_demo_filepath("goldens")
     if not os.path.exists(golden_dir):

--- a/src/sorcha/utilities/generate_meta_kernel.py
+++ b/src/sorcha/utilities/generate_meta_kernel.py
@@ -35,8 +35,12 @@ def build_meta_kernel_file(retriever: pooch.Pooch) -> None:
 
     Parameters
     ----------
-    retriever : pooch.Pooch
+    retriever : pooch
         Pooch object that maintains the registry of files to download
+
+    Returns
+    ---------
+    None
     """
     # build meta_kernel file path
     meta_kernel_file_path = os.path.join(retriever.abspath, META_KERNEL)
@@ -62,16 +66,16 @@ def _build_file_name(cache_dir: str, file_path: str) -> str:
 
     Parameters
     ----------
-    cache_dir : str
+    cache_dir : string
         The full path to the cache directory used when retrieving files for Assist
         and Rebound.
-    file_path : str
+    file_path : string
         The full file path for a given file that will have the cache directory
         segment replace.
 
     Returns
     -------
-    str
+    : string
         Shortened file path, appropriate for use in kernel_meta files.
     """
 

--- a/src/sorcha/utilities/retrieve_ephemeris_data_files.py
+++ b/src/sorcha/utilities/retrieve_ephemeris_data_files.py
@@ -19,12 +19,16 @@ def _decompress(fname, action, pup):
 
     Parameters
     ----------
-    fname : str
+    fname : string
         Original filename
-    action : str
+    action : string
         One of []"download", "update", "fetch"]
-    pup : pooch.Pooch
+    pup : pooch
         The Pooch object that defines the location of the file.
+
+    Returns
+    ----------
+    None
     """
     known_extentions = [".gz", ".bz2", ".xz"]
     if os.path.splitext(fname)[-1] in known_extentions:
@@ -39,7 +43,7 @@ def _remove_files(retriever: pooch.Pooch) -> None:
 
     Parameters
     ----------
-    retriever : pooch.Pooch
+    retriever : pooch
         Pooch object that maintains the registry of files to download.
     """
 
@@ -51,19 +55,19 @@ def _remove_files(retriever: pooch.Pooch) -> None:
 
 def _check_for_existing_files(retriever: pooch.Pooch, file_list: list[str]) -> bool:
     """Will check for existing local files, any file not found will be printed
-    to the terminal.
+     to the terminal.
 
-    Parameters
-    ----------
-    retriever : pooch.Pooch
-        Pooch object that maintains the registry of files to download.
-    file_list : list[str]
-        A list of file names look for in the local cache.
+     Parameters
+     ----------
+     retriever : pooch
+         Pooch object that maintains the registry of files to download.
+     file_list : list of strings
+         A list of file names look for in the local cache.
 
-    Returns
-    -------
-    bool
-        Returns True if all files are found in the local cache, False otherwise.
+     Returns
+     -------
+    :  bool
+         Returns True if all files are found in the local cache, False otherwise.
     """
 
     # choosing clarity over brevity with these variables.

--- a/src/sorcha/utilities/sorchaArguments.py
+++ b/src/sorcha/utilities/sorchaArguments.py
@@ -45,7 +45,19 @@ class sorchaArguments:
             self.read_from_dict(cmd_args_dict)
 
     def read_from_dict(self, args):
-        """set the parameters from a cmd_args dict."""
+        """set the parameters from a cmd_args dict.
+
+        Parameters
+        ---------------
+        aguments : dictionary
+            dictionary of configuration parameters
+
+        Returns
+        ----------
+        None
+
+        """
+
         self.paramsinput = args["paramsinput"]
         self.orbinfile = args["orbinfile"]
         self.oifoutput = args.get("oifoutput")

--- a/tests/sorcha/test_createResultsSQLDatabase.py
+++ b/tests/sorcha/test_createResultsSQLDatabase.py
@@ -91,7 +91,7 @@ def test_create_results_table(tmp_path):
 
     cnx_in = sqlite3.connect(os.path.join(tmp_path, "test_results_table.db"))
     cur = cnx_in.cursor()
-    cur.execute("select * from pp_results")
+    cur.execute("select * from sorcha_results")
     col_names = list(map(lambda x: x[0], cur.description))
     test_inputs = pd.DataFrame(cur.fetchall(), columns=col_names)
     cnx_out.close()
@@ -125,7 +125,7 @@ def test_create_results_database(tmp_path):
     col_names = list(map(lambda x: x[0], cur.description))
     test_orbits = pd.DataFrame(cur.fetchall(), columns=col_names)
 
-    cur.execute("select * from pp_results")
+    cur.execute("select * from sorcha_results")
     col_names = list(map(lambda x: x[0], cur.description))
     test_results = pd.DataFrame(cur.fetchall(), columns=col_names)
 

--- a/tests/sorcha/test_createResultsSQLDatabase.py
+++ b/tests/sorcha/test_createResultsSQLDatabase.py
@@ -91,7 +91,7 @@ def test_create_results_table(tmp_path):
 
     cnx_in = sqlite3.connect(os.path.join(tmp_path, "test_results_table.db"))
     cur = cnx_in.cursor()
-    cur.execute("select * from sorcha_results")
+    cur.execute("select * from pp_results")
     col_names = list(map(lambda x: x[0], cur.description))
     test_inputs = pd.DataFrame(cur.fetchall(), columns=col_names)
     cnx_out.close()
@@ -125,7 +125,7 @@ def test_create_results_database(tmp_path):
     col_names = list(map(lambda x: x[0], cur.description))
     test_orbits = pd.DataFrame(cur.fetchall(), columns=col_names)
 
-    cur.execute("select * from sorcha_results")
+    cur.execute("select * from pp_results")
     col_names = list(map(lambda x: x[0], cur.description))
     test_results = pd.DataFrame(cur.fetchall(), columns=col_names)
 


### PR DESCRIPTION
Reformat doc strings so that they match the required format for the LINCC Framesworks incubator template setup for our documentation sphinx setup (which follows the numpy standard https://numpydoc.readthedocs.io/en/latest/format.html)

Fixes #142 
