### PR TITLE
Small change to getModuleRNG for readability

### DIFF
--- a/demo/test_bench.py
+++ b/demo/test_bench.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":  # pragma: no cover
     debug = False
     if debug:
         runLSSTSimulation(cmd_args_dict, configs)
-    else: # benchmark
+    else:  # benchmark
         cProfile.run("runLSSTSimulation(cmd_args_dict, configs)", "./tests/out/restats")
 
         p = pstats.Stats("./tests/out/restats")

--- a/src/sorcha/modules/PPModuleRNG.py
+++ b/src/sorcha/modules/PPModuleRNG.py
@@ -36,7 +36,8 @@ class PerModuleRNG:
         if module_name in self._rngs:
             return self._rngs[module_name]
 
-        seed_offset = int(hashlib.md5(module_name.encode("utf-8")).hexdigest(), 16)
+        hashed_name = hashlib.md5(module_name.encode())
+        seed_offset = int(hashed_name.hexdigest(), base=16)
         module_seed = (self._base_seed + seed_offset) % (2**31)
         new_rng = np.random.default_rng(module_seed)
         self._rngs[module_name] = new_rng


### PR DESCRIPTION
A very small change to make getModuleRNG more readable. Breaks the `seed_offset` into two lines. The first does the hashing (and uses the default encoding). The second maps the hashed value to an integer (making the `base` argument explicit).

Also adds a very small change from running `black`.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
