### PR TITLE
Fix H columns for single-filter runs

### DIFF
--- a/src/sorcha/modules/PPCalculateApparentMagnitude.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitude.py
@@ -68,8 +68,7 @@ def PPCalculateApparentMagnitude(
             observations, phasefunction, othercolours, observing_filters, mainfilter
         )
     else:
-        observations.rename(columns={"H_" + mainfilter: "H_filter"}, inplace=True)
-        observations["H_original"] = observations["H_filter"].copy()
+        observations["H_filter"] = observations["H_" + mainfilter].copy()
 
     # calculate main body apparent magnitude in observation filter
     verboselog("Calculating apparent magnitude in filter...")

--- a/src/sorcha/modules/PPCalculateApparentMagnitude.py
+++ b/src/sorcha/modules/PPCalculateApparentMagnitude.py
@@ -69,6 +69,7 @@ def PPCalculateApparentMagnitude(
         )
     else:
         observations.rename(columns={"H_" + mainfilter: "H_filter"}, inplace=True)
+        observations["H_original"] = observations["H_filter"].copy()
 
     # calculate main body apparent magnitude in observation filter
     verboselog("Calculating apparent magnitude in filter...")

--- a/tests/sorcha/test_PPCalculateApparentMagnitude.py
+++ b/tests/sorcha/test_PPCalculateApparentMagnitude.py
@@ -211,7 +211,8 @@ def test_PPCalculateApparentMagnitude():
 
     assert_almost_equal(asteroid_out["TrailedSourceMag"].values[0], 13.281578, decimal=6)
     assert_almost_equal(asteroid_out["H_filter"].values[0], 7.19, decimal=6)
+    assert_almost_equal(asteroid_out["H_r"].values[0], 7.3, decimal=6)
 
     assert_almost_equal(asteroid_single["TrailedSourceMag"].values[0], 13.391578, decimal=6)
     assert_almost_equal(asteroid_single["H_filter"].values[0], 7.3, decimal=6)
-    assert_almost_equal(asteroid_single["H_original"].values[0], 7.3, decimal=6)
+    assert_almost_equal(asteroid_single["H_r"].values[0], 7.3, decimal=6)

--- a/tests/sorcha/test_PPCalculateApparentMagnitude.py
+++ b/tests/sorcha/test_PPCalculateApparentMagnitude.py
@@ -214,3 +214,4 @@ def test_PPCalculateApparentMagnitude():
 
     assert_almost_equal(asteroid_single["TrailedSourceMag"].values[0], 13.391578, decimal=6)
     assert_almost_equal(asteroid_single["H_filter"].values[0], 7.3, decimal=6)
+    assert_almost_equal(asteroid_single["H_original"].values[0], 7.3, decimal=6)


### PR DESCRIPTION
Fixes #760.

This makes sure columns are consistent across single and multi-filter runs by ensuring that both have the 'H_[mainfilter]' and 'H_filter' columns in output. In the case of a single filter run, these two columns will be identical. 

(We assume that in the case of a single-filter run, the user will have supplied H in the relevant filter.)

The unit test for PPCalculateApparentMagnitude now also checks to make sure both columns are created when a single observing filter is provided.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
