### PR TITLE
Adding command to copy config files.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ sorcha = "sorcha.sorcha:main"
 makeSLURMscript = "sorcha.utilities.makeSLURMscript:main"
 createResultsSQLDatabase = "sorcha.utilities.createResultsSQLDatabase:main"
 bootstrap_sorcha_data_files = "sorcha.utilities.retrieve_ephemeris_data_files:main"
+sorcha_copy_configs = "sorcha.utilities.sorcha_copy_configs:main"
 
 [project.urls]
 "Documentation" = "https://sorcha.readthedocs.io/en/latest/"

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -8,7 +8,7 @@ from sorcha.modules.PPConfigParser import PPFindDirectoryOrExit
 
 
 def copy_demo_configs(copy_location, which_configs):
-    """ "
+    """
     Copies the example Sorcha configuration files to a user-specified location.
 
     Parameters
@@ -66,7 +66,7 @@ def main():
     usage: sorcha_copy_configs [-h] [-f FILEPATH] [-c [{rubin,demo,all}]]
         arguments:
           -h, --help                                             Show this help message and exit.
-          [-f FILEPATH, --filename FILEPATH]                       Filepath where you want to copy the config files. Default is current working directory.
+          [-f FILEPATH, --filename FILEPATH]                     Filepath where you want to copy the config files. Default is current working directory.
           [-c [{rubin,demo,all}]],--configs [{rubin,demo,all}]   Which config files you want: options are "rubin", "demo" and "all". Default is "all".
     """
 

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -75,7 +75,7 @@ def parse_file_selection(file_select):
     except ValueError:
         sys.exit("Input could not be converted to a valid integer. Please try again.")
 
-    if file_select not in [1, 2, 3, 4]:
+    if file_select not in [1, 2, 3]:
         sys.exit("Input could not be converted to a valid integer. Please input an integer between 1 and 3.")
 
     selection_dict = {1: "rubin_circle", 2: "rubin_footprint", 3: "all"}

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -1,0 +1,104 @@
+import os
+import argparse
+from pathlib import Path
+import shutil
+import sys
+
+from sorcha.modules.PPConfigParser import PPFindDirectoryOrExit
+
+
+def copy_demo_configs(copy_location, which_configs):
+    """ "
+    Copies the example Sorcha configuration files to a user-specified location.
+
+    Parameters
+    -----------
+    copy_location : string
+        String containing the filepath of the location to which the configuration files should be copied.
+
+    which_configs : string
+        String indicating which configuration files to retrieve. Should be "rubin", "demo" or "all".
+
+    Returns
+    -----------
+    None
+
+    """
+
+    _ = PPFindDirectoryOrExit(copy_location, "-f, --filepath")
+
+    path_to_file = os.path.abspath(__file__)
+
+    path_to_surveys = os.path.join(str(Path(path_to_file).parents[3]), "survey_setups")
+    path_to_demo = os.path.join(str(Path(path_to_file).parents[3]), "demo")
+
+    if which_configs == "rubin":
+        config_locations = [
+            os.path.join(path_to_surveys, "Rubin_circular_approximation.ini"),
+            os.path.join(path_to_surveys, "Rubin_full_footprint.ini"),
+        ]
+    elif which_configs == "demo":
+        config_locations = [os.path.join(path_to_demo, "sorcha_config_demo.ini")]
+    elif which_configs == "all":
+        config_locations = [
+            os.path.join(path_to_surveys, "Rubin_circular_approximation.ini"),
+            os.path.join(path_to_surveys, "Rubin_full_footprint.ini"),
+            os.path.join(path_to_demo, "sorcha_config_demo.ini"),
+        ]
+    else:
+        sys.exit(
+            "String '{}' not recognised for 'configs' variable. Must be 'rubin', 'demo' or 'all'.".format(
+                which_configs
+            )
+        )
+
+    for config in config_locations:
+        shutil.copy(config, copy_location)
+
+    print("Example configuration files {} copied to {}.".format(config_locations, copy_location))
+
+
+def main():
+    """
+    Copies example configuration files for Sorcha from the installation location
+    to a user-specified location.
+
+    usage: sorcha_copy_configs [-h] [-f FILEPATH] [-c [{rubin,demo,all}]]
+        arguments:
+          -h, --help                                             Show this help message and exit.
+          [-f FILEPATH, --filename FILEPATH]                       Filepath where you want to copy the config files. Default is current working directory.
+          [-c [{rubin,demo,all}]],--configs [{rubin,demo,all}]   Which config files you want: options are "rubin", "demo" and "all". Default is "all".
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Copies example Sorcha configuration files to a user-specified location."
+    )
+
+    parser.add_argument(
+        "-f",
+        "--filepath",
+        help="Filepath where you want to copy the config files. Default is current working directory.",
+        type=str,
+        default="./",
+    )
+
+    parser.add_argument(
+        "-c",
+        "--configs",
+        help="Which config files you want: options are 'rubin', 'demo' and 'all'. Default is 'all'.",
+        default="all",
+        const="all",
+        nargs="?",
+        choices=["rubin", "demo", "all"],
+    )
+
+    args = parser.parse_args()
+
+    copy_location = os.path.abspath(args.filepath)
+    which_configs = args.configs
+
+    copy_demo_configs(copy_location, which_configs)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -109,6 +109,10 @@ def main():
 
     """
 
+    parser = argparse.ArgumentParser(
+        description="Copies example Sorcha configuration files to a user-specified location."
+    )
+
     parser.add_argument(
         "-f",
         "--filepath",

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -25,7 +25,7 @@ def copy_demo_configs(copy_location, which_configs):
 
     """
 
-    _ = PPFindDirectoryOrExit(copy_location, "-f, --filepath")
+    _ = PPFindDirectoryOrExit(copy_location, "filepath")
 
     path_to_file = os.path.abspath(__file__)
 
@@ -58,45 +58,64 @@ def copy_demo_configs(copy_location, which_configs):
     print("Example configuration files {} copied to {}.".format(config_locations, copy_location))
 
 
+def parse_file_selection(file_select):
+    """Turns the number entered by the user at the command line into a string
+    prompt. Also performs error handling.
+
+    Parameters
+    -----------
+    file_select : int
+        Integer entered by the user at command line.
+
+    Returns
+    -----------
+    which_configs : string
+        String indicating which configuration files to retrieve. Should be "rubin", "demo" or "all".
+
+    """
+
+    try:
+        file_select = int(file_select)
+    except ValueError:
+        sys.exit("Input could not be converted to a valid integer. Please try again.")
+
+    if file_select not in [1, 2, 3]:
+        sys.exit("Input could not be converted to a valid integer. Please input an integer between 1 and 3.")
+
+    selection_dict = {1: "rubin", 2: "demo", 3: "all"}
+
+    which_configs = selection_dict[file_select]
+
+    return which_configs
+
+
 def main():
     """
     Copies example configuration files for Sorcha from the installation location
-    to a user-specified location.
+    to a user-specified location. Controlled via command-line input from the user.
 
-    usage: sorcha_copy_configs [-h] [-f FILEPATH] [-c [{rubin,demo,all}]]
-        arguments:
-          -h, --help                                             Show this help message and exit.
-          [-f FILEPATH, --filename FILEPATH]                     Filepath where you want to copy the config files. Default is current working directory.
-          [-c [{rubin,demo,all}]],--configs [{rubin,demo,all}]   Which config files you want: options are "rubin", "demo" and "all". Default is "all".
+    Parameters
+    -----------
+    None
+
+    Returns
+    -----------
+    None
+
     """
 
-    parser = argparse.ArgumentParser(
-        description="Copies example Sorcha configuration files to a user-specified location."
-    )
+    print("\nWhich configuration files would you like to copy?:\n")
+    print("1. Rubin-specific configuration files.\n")
+    print("2. Basic demo configuration file.\n")
+    print("3. All.\n")
+    file_select = input("Please enter a number and hit Return/Enter.\n")
 
-    parser.add_argument(
-        "-f",
-        "--filepath",
-        help="Filepath where you want to copy the config files. Default is current working directory.",
-        type=str,
-        default="./",
-    )
+    which_configs = parse_file_selection(file_select)
 
-    parser.add_argument(
-        "-c",
-        "--configs",
-        help="Which config files you want: options are 'rubin', 'demo' and 'all'. Default is 'all'.",
-        default="all",
-        const="all",
-        nargs="?",
-        choices=["rubin", "demo", "all"],
-    )
+    print("\nWhere would you like the configuration files to be copied to?\n")
+    copy_location = input("Enter a filepath, or simply . to copy to this location.\n")
 
-    args = parser.parse_args()
-
-    copy_location = os.path.abspath(args.filepath)
-    which_configs = args.configs
-
+    copy_location = os.path.abspath(copy_location)
     copy_demo_configs(copy_location, which_configs)
 
 

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -36,17 +36,14 @@ def copy_demo_configs(copy_location, which_configs):
         config_locations = [os.path.join(path_to_surveys, "Rubin_circular_approximation.ini")]
     elif which_configs == "rubin_footprint":
         config_locations = [os.path.join(path_to_surveys, "Rubin_full_footprint.ini")]
-    elif which_configs == "demo":
-        config_locations = [os.path.join(path_to_demo, "sorcha_config_demo.ini")]
     elif which_configs == "all":
         config_locations = [
             os.path.join(path_to_surveys, "Rubin_circular_approximation.ini"),
             os.path.join(path_to_surveys, "Rubin_full_footprint.ini"),
-            os.path.join(path_to_demo, "sorcha_config_demo.ini"),
         ]
     else:
         sys.exit(
-            "String '{}' not recognised for 'configs' variable. Must be 'rubin', 'demo' or 'all'.".format(
+            "String '{}' not recognised for 'configs' variable. Must be 'rubin_circle', 'rubin_footprint' or 'all'.".format(
                 which_configs
             )
         )
@@ -79,9 +76,9 @@ def parse_file_selection(file_select):
         sys.exit("Input could not be converted to a valid integer. Please try again.")
 
     if file_select not in [1, 2, 3, 4]:
-        sys.exit("Input could not be converted to a valid integer. Please input an integer between 1 and 4.")
+        sys.exit("Input could not be converted to a valid integer. Please input an integer between 1 and 3.")
 
-    selection_dict = {1: "rubin_circle", 2: "rubin_footprint", 3: "demo", 4: "all"}
+    selection_dict = {1: "rubin_circle", 2: "rubin_footprint", 3: "all"}
 
     which_configs = selection_dict[file_select]
 
@@ -126,8 +123,7 @@ def main():
     print("\nWhich configuration file(s) would you like to copy?:\n")
     print("1. Rubin-specific configuration file using circular approximation of camera footprint (faster).\n")
     print("2. Rubin-specific configuration file using full camera footprint (slower, but more accurate).\n")
-    print("3. Basic demo configuration file.\n")
-    print("4. All.\n")
+    print("3. All.\n")
     file_select = input("Please enter a number and hit Return/Enter.\n")
 
     which_configs = parse_file_selection(file_select)

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -32,11 +32,10 @@ def copy_demo_configs(copy_location, which_configs):
     path_to_surveys = os.path.join(str(Path(path_to_file).parents[3]), "survey_setups")
     path_to_demo = os.path.join(str(Path(path_to_file).parents[3]), "demo")
 
-    if which_configs == "rubin":
-        config_locations = [
-            os.path.join(path_to_surveys, "Rubin_circular_approximation.ini"),
-            os.path.join(path_to_surveys, "Rubin_full_footprint.ini"),
-        ]
+    if which_configs == "rubin_circle":
+        config_locations = [os.path.join(path_to_surveys, "Rubin_circular_approximation.ini")]
+    elif which_configs == "rubin_footprint":
+        config_locations = [os.path.join(path_to_surveys, "Rubin_full_footprint.ini")]
     elif which_configs == "demo":
         config_locations = [os.path.join(path_to_demo, "sorcha_config_demo.ini")]
     elif which_configs == "all":
@@ -79,10 +78,10 @@ def parse_file_selection(file_select):
     except ValueError:
         sys.exit("Input could not be converted to a valid integer. Please try again.")
 
-    if file_select not in [1, 2, 3]:
-        sys.exit("Input could not be converted to a valid integer. Please input an integer between 1 and 3.")
+    if file_select not in [1, 2, 3, 4]:
+        sys.exit("Input could not be converted to a valid integer. Please input an integer between 1 and 4.")
 
-    selection_dict = {1: "rubin", 2: "demo", 3: "all"}
+    selection_dict = {1: "rubin_circle", 2: "rubin_footprint", 3: "demo", 4: "all"}
 
     which_configs = selection_dict[file_select]
 
@@ -92,7 +91,13 @@ def parse_file_selection(file_select):
 def main():
     """
     Copies example configuration files for Sorcha from the installation location
-    to a user-specified location. Controlled via command-line input from the user.
+    to a user-specified location. Filepath to copy files to is specified by command-line
+    flag. Selection of configuration files is done via user input.
+
+    usage: sorcha_copy_configs [-h] [-f FILEPATH]
+        arguments:
+          -h, --help                                  Show this help message and exit.
+          [-f FILEPATH, --filename FILEPATH]          Filepath where you want to copy the config files. Default is current working directory.
 
     Parameters
     -----------
@@ -104,18 +109,26 @@ def main():
 
     """
 
-    print("\nWhich configuration files would you like to copy?:\n")
-    print("1. Rubin-specific configuration files.\n")
-    print("2. Basic demo configuration file.\n")
-    print("3. All.\n")
+    parser.add_argument(
+        "-f",
+        "--filepath",
+        help="Filepath where you want to copy the config files. Default is current working directory.",
+        type=str,
+        default="./",
+    )
+
+    args = parser.parse_args()
+
+    print("\nWhich configuration file(s) would you like to copy?:\n")
+    print("1. Rubin-specific configuration file using circular approximation of camera footprint (faster).\n")
+    print("2. Rubin-specific configuration file using full camera footprint (slower, but more accurate).\n")
+    print("3. Basic demo configuration file.\n")
+    print("4. All.\n")
     file_select = input("Please enter a number and hit Return/Enter.\n")
 
     which_configs = parse_file_selection(file_select)
 
-    print("\nWhere would you like the configuration files to be copied to?\n")
-    copy_location = input("Enter a filepath, or simply . to copy to this location.\n")
-
-    copy_location = os.path.abspath(copy_location)
+    copy_location = os.path.abspath(args.filepath)
     copy_demo_configs(copy_location, which_configs)
 
 

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -7,7 +7,7 @@ import sys
 from sorcha.modules.PPConfigParser import PPFindDirectoryOrExit
 
 
-def copy_demo_configs(copy_location, which_configs):
+def copy_demo_configs(copy_location, which_configs, force_overwrite):
     """
     Copies the example Sorcha configuration files to a user-specified location.
 
@@ -18,6 +18,9 @@ def copy_demo_configs(copy_location, which_configs):
 
     which_configs : string
         String indicating which configuration files to retrieve. Should be "rubin", "demo" or "all".
+
+    force_overwrite: boolean
+        Flag for determining whether existing files should be overwritten.
 
     Returns
     -----------
@@ -49,6 +52,9 @@ def copy_demo_configs(copy_location, which_configs):
         )
 
     for config in config_locations:
+        if not force_overwrite and os.path.isfile(config):
+            sys.exit("Identical file exists at location. Re-run with -f or --force to force overwrite.")
+
         shutil.copy(config, copy_location)
 
     print("Example configuration files {} copied to {}.".format(config_locations, copy_location))
@@ -91,10 +97,10 @@ def main():
     to a user-specified location. Filepath to copy files to is specified by command-line
     flag. Selection of configuration files is done via user input.
 
-    usage: sorcha_copy_configs [-h] [-f FILEPATH]
+    usage: sorcha_copy_configs [-h] [-p PATH]
         arguments:
           -h, --help                                  Show this help message and exit.
-          [-f FILEPATH, --filename FILEPATH]          Filepath where you want to copy the config files. Default is current working directory.
+          [-p PATH, --path PATH]          Filepath where you want to copy the config files. Default is current working directory.
 
     Parameters
     -----------
@@ -111,11 +117,19 @@ def main():
     )
 
     parser.add_argument(
-        "-f",
-        "--filepath",
+        "-p",
+        "--path",
         help="Filepath where you want to copy the config files. Default is current working directory.",
         type=str,
         default="./",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--force",
+        help="Force deletion/overwrite of existing config file(s). Default False.",
+        action="store_true",
+        default=False,
     )
 
     args = parser.parse_args()
@@ -128,8 +142,8 @@ def main():
 
     which_configs = parse_file_selection(file_select)
 
-    copy_location = os.path.abspath(args.filepath)
-    copy_demo_configs(copy_location, which_configs)
+    copy_location = os.path.abspath(args.path)
+    copy_demo_configs(copy_location, which_configs, args.force)
 
 
 if __name__ == "__main__":

--- a/tests/sorcha/test_sorcha_copy_configs.py
+++ b/tests/sorcha/test_sorcha_copy_configs.py
@@ -6,9 +6,12 @@ def test_sorcha_copy_configs(tmp_path):
     from sorcha.utilities.sorcha_copy_configs import copy_demo_configs
 
     # test that the Rubin files are successfully copied
-    copy_demo_configs(tmp_path, "rubin")
+    copy_demo_configs(tmp_path, "rubin_circle")
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
+
+    copy_demo_configs(tmp_path, "rubin_footprint")
+
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
 
     # test that the demo config is successfully copied
@@ -51,11 +54,13 @@ def test_parse_file_selection():
     from sorcha.utilities.sorcha_copy_configs import parse_file_selection
 
     # test to make sure the inputs align with the correct options
-    test_rubin = parse_file_selection("1")
-    test_demo = parse_file_selection("2")
-    test_all = parse_file_selection("3")
+    test_rubin_circle = parse_file_selection("1")
+    test_rubin_footprint = parse_file_selection("2")
+    test_demo = parse_file_selection("3")
+    test_all = parse_file_selection("4")
 
-    assert test_rubin == "rubin"
+    assert test_rubin_circle == "rubin_circle"
+    assert test_rubin_footprint == "rubin_footprint"
     assert test_demo == "demo"
     assert test_all == "all"
 
@@ -71,5 +76,5 @@ def test_parse_file_selection():
 
     assert (
         e2.value.code
-        == "Input could not be converted to a valid integer. Please input an integer between 1 and 3."
+        == "Input could not be converted to a valid integer. Please input an integer between 1 and 4."
     )

--- a/tests/sorcha/test_sorcha_copy_configs.py
+++ b/tests/sorcha/test_sorcha_copy_configs.py
@@ -63,7 +63,7 @@ def test_parse_file_selection():
     assert e.value.code == "Input could not be converted to a valid integer. Please try again."
 
     with pytest.raises(SystemExit) as e2:
-        test_wrong_integer = parse_file_selection("6")
+        test_wrong_integer = parse_file_selection("4")
 
     assert (
         e2.value.code

--- a/tests/sorcha/test_sorcha_copy_configs.py
+++ b/tests/sorcha/test_sorcha_copy_configs.py
@@ -33,8 +33,7 @@ def test_sorcha_copy_configs(tmp_path):
     with pytest.raises(SystemExit) as e:
         copy_demo_configs(dummy_folder, "all")
 
-    assert e.type == SystemExit
-    assert e.value.code == "ERROR: filepath {} supplied for -f, --filepath argument does not exist.".format(
+    assert e.value.code == "ERROR: filepath {} supplied for filepath argument does not exist.".format(
         dummy_folder
     )
 
@@ -42,8 +41,35 @@ def test_sorcha_copy_configs(tmp_path):
     with pytest.raises(SystemExit) as e2:
         copy_demo_configs(tmp_path, "laphroaig")
 
-    assert e2.type == SystemExit
     assert (
         e2.value.code
         == "String 'laphroaig' not recognised for 'configs' variable. Must be 'rubin', 'demo' or 'all'."
+    )
+
+
+def test_parse_file_selection():
+    from sorcha.utilities.sorcha_copy_configs import parse_file_selection
+
+    # test to make sure the inputs align with the correct options
+    test_rubin = parse_file_selection("1")
+    test_demo = parse_file_selection("2")
+    test_all = parse_file_selection("3")
+
+    assert test_rubin == "rubin"
+    assert test_demo == "demo"
+    assert test_all == "all"
+
+    # test error messages
+
+    with pytest.raises(SystemExit) as e:
+        test_string = parse_file_selection("not_an_integer")
+
+    assert e.value.code == "Input could not be converted to a valid integer. Please try again."
+
+    with pytest.raises(SystemExit) as e2:
+        test_wrong_integer = parse_file_selection("6")
+
+    assert (
+        e2.value.code
+        == "Input could not be converted to a valid integer. Please input an integer between 1 and 3."
     )

--- a/tests/sorcha/test_sorcha_copy_configs.py
+++ b/tests/sorcha/test_sorcha_copy_configs.py
@@ -14,22 +14,15 @@ def test_sorcha_copy_configs(tmp_path):
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
 
-    # test that the demo config is successfully copied
-    copy_demo_configs(tmp_path, "demo")
-
-    assert os.path.isfile(os.path.join(tmp_path, "sorcha_config_demo.ini"))
-
     # remove those files
     os.remove(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
     os.remove(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
-    os.remove(os.path.join(tmp_path, "sorcha_config_demo.ini"))
 
     # test that all the configs are successfully copied
     copy_demo_configs(tmp_path, "all")
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
-    assert os.path.isfile(os.path.join(tmp_path, "sorcha_config_demo.ini"))
 
     # test the error message if user supplies non-existent directory
     dummy_folder = os.path.join(tmp_path, "dummy_folder")
@@ -46,7 +39,7 @@ def test_sorcha_copy_configs(tmp_path):
 
     assert (
         e2.value.code
-        == "String 'laphroaig' not recognised for 'configs' variable. Must be 'rubin', 'demo' or 'all'."
+        == "String 'laphroaig' not recognised for 'configs' variable. Must be 'rubin_circle', 'rubin_footprint' or 'all'."
     )
 
 
@@ -56,12 +49,10 @@ def test_parse_file_selection():
     # test to make sure the inputs align with the correct options
     test_rubin_circle = parse_file_selection("1")
     test_rubin_footprint = parse_file_selection("2")
-    test_demo = parse_file_selection("3")
-    test_all = parse_file_selection("4")
+    test_all = parse_file_selection("3")
 
     assert test_rubin_circle == "rubin_circle"
     assert test_rubin_footprint == "rubin_footprint"
-    assert test_demo == "demo"
     assert test_all == "all"
 
     # test error messages
@@ -76,5 +67,5 @@ def test_parse_file_selection():
 
     assert (
         e2.value.code
-        == "Input could not be converted to a valid integer. Please input an integer between 1 and 4."
+        == "Input could not be converted to a valid integer. Please input an integer between 1 and 3."
     )

--- a/tests/sorcha/test_sorcha_copy_configs.py
+++ b/tests/sorcha/test_sorcha_copy_configs.py
@@ -1,0 +1,49 @@
+import os
+import pytest
+
+
+def test_sorcha_copy_configs(tmp_path):
+    from sorcha.utilities.sorcha_copy_configs import copy_demo_configs
+
+    # test that the Rubin files are successfully copied
+    copy_demo_configs(tmp_path, "rubin")
+
+    assert os.path.isfile(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
+    assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
+
+    # test that the demo config is successfully copied
+    copy_demo_configs(tmp_path, "demo")
+
+    assert os.path.isfile(os.path.join(tmp_path, "sorcha_config_demo.ini"))
+
+    # remove those files
+    os.remove(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
+    os.remove(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
+    os.remove(os.path.join(tmp_path, "sorcha_config_demo.ini"))
+
+    # test that all the configs are successfully copied
+    copy_demo_configs(tmp_path, "all")
+
+    assert os.path.isfile(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
+    assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
+    assert os.path.isfile(os.path.join(tmp_path, "sorcha_config_demo.ini"))
+
+    # test the error message if user supplies non-existent directory
+    dummy_folder = os.path.join(tmp_path, "dummy_folder")
+    with pytest.raises(SystemExit) as e:
+        copy_demo_configs(dummy_folder, "all")
+
+    assert e.type == SystemExit
+    assert e.value.code == "ERROR: filepath {} supplied for -f, --filepath argument does not exist.".format(
+        dummy_folder
+    )
+
+    # test the error message if user supplies unrecognised keyword for which_configs variable
+    with pytest.raises(SystemExit) as e2:
+        copy_demo_configs(tmp_path, "laphroaig")
+
+    assert e2.type == SystemExit
+    assert (
+        e2.value.code
+        == "String 'laphroaig' not recognised for 'configs' variable. Must be 'rubin', 'demo' or 'all'."
+    )

--- a/tests/sorcha/test_sorcha_copy_configs.py
+++ b/tests/sorcha/test_sorcha_copy_configs.py
@@ -6,11 +6,11 @@ def test_sorcha_copy_configs(tmp_path):
     from sorcha.utilities.sorcha_copy_configs import copy_demo_configs
 
     # test that the Rubin files are successfully copied
-    copy_demo_configs(tmp_path, "rubin_circle")
+    copy_demo_configs(tmp_path, "rubin_circle", True)
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
 
-    copy_demo_configs(tmp_path, "rubin_footprint")
+    copy_demo_configs(tmp_path, "rubin_footprint", True)
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
 
@@ -19,7 +19,7 @@ def test_sorcha_copy_configs(tmp_path):
     os.remove(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
 
     # test that all the configs are successfully copied
-    copy_demo_configs(tmp_path, "all")
+    copy_demo_configs(tmp_path, "all", True)
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
@@ -27,7 +27,7 @@ def test_sorcha_copy_configs(tmp_path):
     # test the error message if user supplies non-existent directory
     dummy_folder = os.path.join(tmp_path, "dummy_folder")
     with pytest.raises(SystemExit) as e:
-        copy_demo_configs(dummy_folder, "all")
+        copy_demo_configs(dummy_folder, "all", True)
 
     assert e.value.code == "ERROR: filepath {} supplied for filepath argument does not exist.".format(
         dummy_folder
@@ -35,12 +35,19 @@ def test_sorcha_copy_configs(tmp_path):
 
     # test the error message if user supplies unrecognised keyword for which_configs variable
     with pytest.raises(SystemExit) as e2:
-        copy_demo_configs(tmp_path, "laphroaig")
+        copy_demo_configs(tmp_path, "laphroaig", True)
 
     assert (
         e2.value.code
         == "String 'laphroaig' not recognised for 'configs' variable. Must be 'rubin_circle', 'rubin_footprint' or 'all'."
     )
+
+    # test tthe error message if file exists and overwrite isn't forced
+
+    with pytest.raises(SystemExit) as e3:
+        copy_demo_configs(tmp_path, "rubin_footprint", False)
+
+    assert e3.value.code == "Identical file exists at location. Re-run with -f or --force to force overwrite."
 
 
 def test_parse_file_selection():


### PR DESCRIPTION
Fixes #776 .

There is now a command (`sorcha_copy_configs`) which will copy the example configuration files from where-ever Sorcha is installed on the user's machine to a location of their choosing (or, by default, the current working directory). This will work for pip and Conda installations.

The user can also choose (via command-line flag) whether to copy the Rubin config files, the demo config file, or all of them. Usage:

`sorcha_copy_configs [-h] [-f FILEPATH] [-c [{rubin,demo,all}]]`

Updated pyproject.toml, also wrote a unit test.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
