### PR TITLE
changes to try and use M1 macs

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,10 +12,10 @@ on:
 jobs:
   build:
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         os: ['macos-14','ubuntu-latest']
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        os: ['macos-latest','ubuntu-latest']
+        os: ['macos-14','ubuntu-latest']
         python-version: ['3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -12,10 +12,10 @@ on:
 jobs:
   build:
     strategy:
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         os: ['macos-14','ubuntu-latest']
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: [ '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        os: ['macos-latest','ubuntu-latest']
+        os: ['macos-14','ubuntu-latest']
         python-version: ['3.9', '3.10', '3.11']
 
     runs-on: ${{ matrix.os }}
@@ -34,4 +34,4 @@ jobs:
       run: |
         python -m pytest --cov=sorcha --cov-report=xml
     - name: Upload coverage report to codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pooch",
     "tqdm",
     "numba",
+    "h5py",
 ]
 
 [project.scripts]


### PR DESCRIPTION
changes to try and use M1 macs and also trying to fix the codecoverage node warning 

"Today, GitHub is excited to announce the launch of a new M1 macOS runner! This runner is available for all plans, free in public repositories, and eligible to consume included free plan minutes in private repositories. The new runner executes Actions workflows with a 3 vCPU, 7 GB RAM, and 14 GB of storage VM, which provides the latest Mac hardware Actions has to offer. The new runner operates exclusively on macOS 14 and to use it, simply update the runs-on key in your YAML workflow file to macos-14."

https://github.blog/changelog/