### PR TITLE
Seed the random number generator with urandom

### DIFF
--- a/src/sorcha/utilities/sorchaArguments.py
+++ b/src/sorcha/utilities/sorchaArguments.py
@@ -1,7 +1,7 @@
 import numpy as np
 from dataclasses import dataclass
 import time
-from os import path
+from os import path, urandom
 import logging
 
 from sorcha.modules.PPModuleRNG import PerModuleRNG
@@ -78,7 +78,7 @@ class sorchaArguments:
         # WARNING: Take care if manually setting the seed. Re-using seeds between
         # simulations may result in hard-to-detect correlations in simulation
         # outputs.
-        seed = args.get("seed", int(time.time()))
+        seed = args.get("seed", int.from_bytes(urandom(4), "big"))
         self._rngs = PerModuleRNG(seed, self.pplogger)
 
     def validate_arguments(self):


### PR DESCRIPTION
Fixes #779 779

Use urandom to seed the random number generator instead of time so as to provide better randomization during parallel runs.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [X] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [X] Have you used black on the files you have updated to confirm python programming style guide enforcement?
