### PR TITLE
Script to copy Sorcha demo files, read-only mode for pointing DB

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ makeSLURMscript = "sorcha.utilities.makeSLURMscript:main"
 createResultsSQLDatabase = "sorcha.utilities.createResultsSQLDatabase:main"
 bootstrap_sorcha_data_files = "sorcha.utilities.retrieve_ephemeris_data_files:main"
 sorcha_copy_configs = "sorcha.utilities.sorcha_copy_configs:main"
+sorcha_copy_demo_files = "sorcha.utilities.sorcha_copy_demo_files:main"
 
 [project.urls]
 "Documentation" = "https://sorcha.readthedocs.io/en/latest/"

--- a/src/sorcha/modules/PPReadPointingDatabase.py
+++ b/src/sorcha/modules/PPReadPointingDatabase.py
@@ -28,7 +28,7 @@ def PPReadPointingDatabase(bsdbname, observing_filters, dbquery, surveyname):
 
     pplogger = logging.getLogger(__name__)
 
-    con = sqlite3.connect(bsdbname)
+    con = sqlite3.connect("file:" + bsdbname + "?mode=ro", uri=True)
 
     try:
         df = pd.read_sql_query(dbquery, con)

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -33,17 +33,13 @@ def copy_demo_configs(copy_location, which_configs, force_overwrite):
     path_to_file = os.path.abspath(__file__)
 
     path_to_surveys = os.path.join(str(Path(path_to_file).parents[3]), "survey_setups")
-    path_to_demo = os.path.join(str(Path(path_to_file).parents[3]), "demo")
 
     if which_configs == "rubin_circle":
-        config_locations = [os.path.join(path_to_surveys, "Rubin_circular_approximation.ini")]
+        config_locations = ["Rubin_circular_approximation.ini"]
     elif which_configs == "rubin_footprint":
-        config_locations = [os.path.join(path_to_surveys, "Rubin_full_footprint.ini")]
+        config_locations = ["Rubin_full_footprint.ini"]
     elif which_configs == "all":
-        config_locations = [
-            os.path.join(path_to_surveys, "Rubin_circular_approximation.ini"),
-            os.path.join(path_to_surveys, "Rubin_full_footprint.ini"),
-        ]
+        config_locations = ["Rubin_circular_approximation.ini", "Rubin_full_footprint.ini"]
     else:
         sys.exit(
             "String '{}' not recognised for 'configs' variable. Must be 'rubin_circle', 'rubin_footprint' or 'all'.".format(
@@ -52,10 +48,14 @@ def copy_demo_configs(copy_location, which_configs, force_overwrite):
         )
 
     for config in config_locations:
-        if not force_overwrite and os.path.isfile(config):
-            sys.exit("Identical file exists at location. Re-run with -f or --force to force overwrite.")
+        config_path = os.path.join(path_to_surveys, config)
 
-        shutil.copy(config, copy_location)
+        if not force_overwrite and os.path.isfile(os.path.join(copy_location, config)):
+            sys.exit(
+                "Identically named file exists at location. Re-run with -f or --force to force overwrite."
+            )
+
+        shutil.copy(config_path, copy_location)
 
     print("Example configuration files {} copied to {}.".format(config_locations, copy_location))
 

--- a/src/sorcha/utilities/sorcha_copy_demo_files.py
+++ b/src/sorcha/utilities/sorcha_copy_demo_files.py
@@ -1,0 +1,101 @@
+import os
+import argparse
+from pathlib import Path
+import shutil
+import sys
+
+from sorcha.modules.PPConfigParser import PPFindDirectoryOrExit
+
+
+def copy_demo_files(copy_location, force_overwrite):
+    """
+    Copies the files needed to run the Sorcha demo to a user-specified location.
+
+    Parameters
+    -----------
+    copy_location : string
+        String containing the filepath of the location to which the configuration files should be copied.
+
+    force_overwrite: boolean
+        Flag for determining whether existing files should be overwritten.
+
+    Returns
+    -----------
+    None
+
+    """
+
+    _ = PPFindDirectoryOrExit(copy_location, "filepath")
+
+    path_to_file = os.path.abspath(__file__)
+
+    path_to_demo = os.path.join(str(Path(path_to_file).parents[3]), "demo")
+
+    demo_files = [
+        "sorcha_config_demo.ini",
+        "sspp_testset_colours.txt",
+        "sspp_testset_orbits.des",
+        "baseline_v2.0_1yr.db",
+    ]
+
+    for filename in demo_files:
+        if not force_overwrite and os.path.isfile(os.path.join(copy_location, filename)):
+            sys.exit(
+                "Identically named file exists at location. Re-run with -f or --force to force overwrite."
+            )
+
+        demo_path = os.path.join(path_to_demo, filename)
+        shutil.copy(demo_path, copy_location)
+
+    print("Demo files {} copied to {}.".format(demo_files, copy_location))
+
+
+def main():
+    """
+    Copies demo files for Sorcha from the installation location
+    to a user-specified location. Filepath to copy files to is specified by command-line
+    flag.
+
+    usage: sorcha_copy_demo_files [-h] [-p PATH]
+        arguments:
+          -h, --help                                  Show this help message and exit.
+          [-p PATH, --path PATH]          Filepath where you want to copy the demo files. Default is current working directory.
+
+    Parameters
+    -----------
+    None
+
+    Returns
+    -----------
+    None
+
+    """
+
+    parser = argparse.ArgumentParser(
+        description="Copies files for demo Sorcha run to a user-specified location."
+    )
+
+    parser.add_argument(
+        "-p",
+        "--path",
+        help="Filepath where you want to copy the demo files. Default is current working directory.",
+        type=str,
+        default="./",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--force",
+        help="Force deletion/overwrite of existing demo file(s). Default False.",
+        action="store_true",
+        default=False,
+    )
+
+    args = parser.parse_args()
+
+    copy_location = os.path.abspath(args.path)
+    copy_demo_files(copy_location, args.force)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sorcha/test_sorcha_copy_configs.py
+++ b/tests/sorcha/test_sorcha_copy_configs.py
@@ -6,11 +6,11 @@ def test_sorcha_copy_configs(tmp_path):
     from sorcha.utilities.sorcha_copy_configs import copy_demo_configs
 
     # test that the Rubin files are successfully copied
-    copy_demo_configs(tmp_path, "rubin_circle", True)
+    copy_demo_configs(tmp_path, "rubin_circle", False)
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
 
-    copy_demo_configs(tmp_path, "rubin_footprint", True)
+    copy_demo_configs(tmp_path, "rubin_footprint", False)
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
 
@@ -19,15 +19,18 @@ def test_sorcha_copy_configs(tmp_path):
     os.remove(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
 
     # test that all the configs are successfully copied
-    copy_demo_configs(tmp_path, "all", True)
+    copy_demo_configs(tmp_path, "all", False)
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
 
+    # test that files are successfully overwritten if -f flag used
+    copy_demo_configs(tmp_path, "all", True)
+
     # test the error message if user supplies non-existent directory
     dummy_folder = os.path.join(tmp_path, "dummy_folder")
     with pytest.raises(SystemExit) as e:
-        copy_demo_configs(dummy_folder, "all", True)
+        copy_demo_configs(dummy_folder, "all", False)
 
     assert e.value.code == "ERROR: filepath {} supplied for filepath argument does not exist.".format(
         dummy_folder
@@ -47,7 +50,10 @@ def test_sorcha_copy_configs(tmp_path):
     with pytest.raises(SystemExit) as e3:
         copy_demo_configs(tmp_path, "rubin_footprint", False)
 
-    assert e3.value.code == "Identical file exists at location. Re-run with -f or --force to force overwrite."
+    assert (
+        e3.value.code
+        == "Identically named file exists at location. Re-run with -f or --force to force overwrite."
+    )
 
 
 def test_parse_file_selection():

--- a/tests/sorcha/test_sorcha_copy_demo_files.py
+++ b/tests/sorcha/test_sorcha_copy_demo_files.py
@@ -1,0 +1,41 @@
+import os
+import pytest
+
+
+def test_sorcha_copy_demo_files(tmp_path):
+    from sorcha.utilities.sorcha_copy_demo_files import copy_demo_files
+
+    copy_demo_files(tmp_path, False)
+
+    demo_files = [
+        "sorcha_config_demo.ini",
+        "sspp_testset_colours.txt",
+        "sspp_testset_orbits.des",
+        "baseline_v2.0_1yr.db",
+    ]
+
+    # test that the files are created
+    for filename in demo_files:
+        assert os.path.isfile(os.path.join(tmp_path, filename))
+
+    # test that files are successfully overwritten if -f flag used
+    copy_demo_files(tmp_path, True)
+
+    # test that the correct error is triggered if force overwrite not used
+    with pytest.raises(SystemExit) as e:
+        copy_demo_files(tmp_path, False)
+
+    assert (
+        e.value.code
+        == "Identically named file exists at location. Re-run with -f or --force to force overwrite."
+    )
+
+    # test the error message if user supplies non-existent directory
+    dummy_folder = os.path.join(tmp_path, "dummy_folder")
+
+    with pytest.raises(SystemExit) as e2:
+        copy_demo_files(dummy_folder, True)
+
+    assert e2.value.code == "ERROR: filepath {} supplied for filepath argument does not exist.".format(
+        dummy_folder
+    )


### PR DESCRIPTION
Fixes #691.

- Added a script to copy the files needed for the test command in the docs to a user-specified location.
- Wrote the unit test for the above.
- Found an error in the script for copying config files where the -f flag wasn't working properly: fixed that.
- Changed the unit test for that script to catch that error.

Fixes #772.
- The pointing database is now opened in read-only mode.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
