### PR TITLE
Printing/testing demo command.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ createResultsSQLDatabase = "sorcha.utilities.createResultsSQLDatabase:main"
 bootstrap_sorcha_data_files = "sorcha.utilities.retrieve_ephemeris_data_files:main"
 sorcha_copy_configs = "sorcha.utilities.sorcha_copy_configs:main"
 sorcha_copy_demo_files = "sorcha.utilities.sorcha_copy_demo_files:main"
+sorcha_demo_command = "sorcha.utilities.sorcha_demo_command:print_demo_command"
 
 [project.urls]
 "Documentation" = "https://sorcha.readthedocs.io/en/latest/"

--- a/src/sorcha/utilities/sorcha_copy_demo_files.py
+++ b/src/sorcha/utilities/sorcha_copy_demo_files.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 
 from sorcha.modules.PPConfigParser import PPFindDirectoryOrExit
+from sorcha.utilities.sorcha_demo_command import print_demo_command
 
 
 def copy_demo_files(copy_location, force_overwrite):
@@ -48,6 +49,8 @@ def copy_demo_files(copy_location, force_overwrite):
         shutil.copy(demo_path, copy_location)
 
     print("Demo files {} copied to {}.".format(demo_files, copy_location))
+
+    print_demo_command(printall=False)
 
 
 def main():

--- a/src/sorcha/utilities/sorcha_demo_command.py
+++ b/src/sorcha/utilities/sorcha_demo_command.py
@@ -1,0 +1,41 @@
+def print_demo_command(printall=True):
+    """
+    Prints the current working version of the demo command to the terminal, with
+    optional functionality to also tell the user how to copy the demo files.
+
+    Parameters
+    -----------
+    printall : boolean
+        When True, prints the demo command plus the instructions for copying the demo files.
+        When False, prints the demo command only.
+
+    Returns
+    -----------
+    None.
+
+    """
+
+    print("\nThe command to run the Sorcha demo in this version of Sorcha is:\n")
+
+    print(
+        "\033[1;32;40msorcha -c sorcha_config_demo.ini -p sspp_testset_colours.txt -ob sspp_testset_orbits.des -pd baseline_v2.0_1yr.db -o ./ -t testrun_e2e\033[0m\n"
+    )
+
+    print("WARNING: This command assumes that the demo files are in your working directory.\n")
+
+    if printall:
+        print("You can copy the demo files into your working directory by running:\n")
+
+        print("\033[1;32;40msorcha_copy_demo_files\033[0m\n")
+
+        print("Or, to copy them into a directory of your choice, run:\n")
+
+        print("\033[1;32;40msorcha_copy_demo_files -p /path/to/files \033[0m\n")
+
+    print(
+        "If copying into a directory of your choice, you will need to modify the demo command to path to your files.\n"
+    )
+
+
+if __name__ == "__main__":
+    print_demo_command()

--- a/src/sorcha/utilities/sorcha_demo_command.py
+++ b/src/sorcha/utilities/sorcha_demo_command.py
@@ -1,6 +1,25 @@
+def get_demo_command():
+    """
+    Returns the current working version of the Sorcha demo command as a string.
+    If the Sorcha run command changes, updating this function will ensure
+    associated unit tests pass.
+
+    Parameters
+    -----------
+    None.
+
+    Returns
+    -----------
+    None.
+
+    """
+
+    return "sorcha -c sorcha_config_demo.ini -p sspp_testset_colours.txt -ob sspp_testset_orbits.des -pd baseline_v2.0_1yr.db -o ./ -t testrun_e2e"
+
+
 def print_demo_command(printall=True):
     """
-    Prints the current working version of the demo command to the terminal, with
+    Prints the current working version of the Sorcha demo command to the terminal, with
     optional functionality to also tell the user how to copy the demo files.
 
     Parameters
@@ -15,11 +34,11 @@ def print_demo_command(printall=True):
 
     """
 
+    current_demo_command = get_demo_command()
+
     print("\nThe command to run the Sorcha demo in this version of Sorcha is:\n")
 
-    print(
-        "\033[1;32;40msorcha -c sorcha_config_demo.ini -p sspp_testset_colours.txt -ob sspp_testset_orbits.des -pd baseline_v2.0_1yr.db -o ./ -t testrun_e2e\033[0m\n"
-    )
+    print("\033[1;32;40m" + current_demo_command + "\033[0m\n")
 
     print("WARNING: This command assumes that the demo files are in your working directory.\n")
 

--- a/tests/sorcha/test_demo_command_line.py
+++ b/tests/sorcha/test_demo_command_line.py
@@ -45,6 +45,11 @@ def test_demo_command_line(setup_and_teardown_for_demo_command_line):
 
     current_demo_command = get_demo_command()
 
+    # usually the ephemeris files have already been downloaded by the
+    # ephemeris end-to-end test, but we can't rely on test order for this to
+    # work! if the files already exist in the default location this will do nothing.
+    os.system("bootstrap_sorcha_data_files")
+
     os.system(current_demo_command)
 
     assert os.path.exists("testrun_e2e.csv")

--- a/tests/sorcha/test_demo_command_line.py
+++ b/tests/sorcha/test_demo_command_line.py
@@ -1,0 +1,55 @@
+# This test file checks to see if Sorcha runs correctly and produces output
+# using the current demo command.
+# It does not check the output for correctness. This is covered by test_demo_end2end.py.
+
+import os
+import pytest
+import glob
+from pathlib import Path
+
+
+@pytest.fixture
+def setup_and_teardown_for_demo_command_line():
+    # Record initial working directory
+    initial_wd = os.getcwd()
+
+    # Find where the demo files are installed on this machine
+    path_to_file = os.path.abspath(__file__)
+    path_to_demo = os.path.join(str(Path(path_to_file).parents[2]), "demo")
+
+    # Move to the demo directory
+    os.chdir(path_to_demo)
+
+    # Yield to pytest to run the test
+    yield
+
+    # After running the test, delete the created files...
+
+    os.remove("testrun_e2e.csv")
+
+    os.remove(glob.glob("*sorcha.err")[0])
+    os.remove(glob.glob("*sorcha.log")[0])
+
+    # And move back to initial working directory.
+    os.chdir(initial_wd)
+
+
+def test_demo_command_line(setup_and_teardown_for_demo_command_line):
+    """This checks to see if the current demo command-line command for Sorcha
+    results in a successful run, i.e.: it runs without error and produces output.
+    It does not check the actual output for correctness. This is done by
+    test_demo_end2end.py.
+    """
+
+    from sorcha.utilities.sorcha_demo_command import get_demo_command
+
+    current_demo_command = get_demo_command()
+
+    os.system(current_demo_command)
+
+    assert os.path.exists("testrun_e2e.csv")
+
+    # also check to make sure the error log is empty :)
+    error_log = glob.glob("*sorcha.err")[0]
+
+    assert os.stat(error_log).st_size == 0

--- a/tests/sorcha/test_sorcha_demo_command.py
+++ b/tests/sorcha/test_sorcha_demo_command.py
@@ -1,13 +1,16 @@
 def test_copy_demo_command(capsys):
-    from sorcha.utilities.sorcha_demo_command import print_demo_command
+    from sorcha.utilities.sorcha_demo_command import print_demo_command, get_demo_command
 
     print_demo_command(printall=True)
+    current_demo_command = get_demo_command()
 
     captured = capsys.readouterr()
 
     expected = (
         "\nThe command to run the Sorcha demo in this version of Sorcha is:\n\n"
-        + "\033[1;32;40msorcha -c sorcha_config_demo.ini -p sspp_testset_colours.txt -ob sspp_testset_orbits.des -pd baseline_v2.0_1yr.db -o ./ -t testrun_e2e\033[0m\n\n"
+        + "\033[1;32;40m"
+        + current_demo_command
+        + "\033[0m\n\n"
         + "WARNING: This command assumes that the demo files are in your working directory.\n\n"
         + "You can copy the demo files into your working directory by running:\n\n"
         + "\033[1;32;40msorcha_copy_demo_files\033[0m\n\n"

--- a/tests/sorcha/test_sorcha_demo_command.py
+++ b/tests/sorcha/test_sorcha_demo_command.py
@@ -1,0 +1,19 @@
+def test_copy_demo_command(capsys):
+    from sorcha.utilities.sorcha_demo_command import print_demo_command
+
+    print_demo_command(printall=True)
+
+    captured = capsys.readouterr()
+
+    expected = (
+        "\nThe command to run the Sorcha demo in this version of Sorcha is:\n\n"
+        + "\033[1;32;40msorcha -c sorcha_config_demo.ini -p sspp_testset_colours.txt -ob sspp_testset_orbits.des -pd baseline_v2.0_1yr.db -o ./ -t testrun_e2e\033[0m\n\n"
+        + "WARNING: This command assumes that the demo files are in your working directory.\n\n"
+        + "You can copy the demo files into your working directory by running:\n\n"
+        + "\033[1;32;40msorcha_copy_demo_files\033[0m\n\n"
+        + "Or, to copy them into a directory of your choice, run:\n\n"
+        + "\033[1;32;40msorcha_copy_demo_files -p /path/to/files \033[0m\n\n"
+        + "If copying into a directory of your choice, you will need to modify the demo command to path to your files.\n\n"
+    )
+
+    assert captured.out == expected


### PR DESCRIPTION
Fixes #692 .

- There is now a demo command that spits out the command which runs Sorcha from the demo files. It can be run by running `sorcha_demo_command`.
- This command also tells the user how to run `sorcha_copy_demo_files` to get the demo files.
- I'm not sure there's much point in a unit test for this function, as it only outputs text to the terminal, but I wrote one anyway so CodeCov stays happy.
- `sorcha_copy_demo_files` now also prints the demo command to the terminal.
- There is a function in sorcha_demo_command.py called `get_demo_command()` which will simply return the demo command as a string. If the demo command ever changes, this is the only place in the code that needs to be updated.

Fixes #815 (I think).

- There is now a test that obtains the current version's working demo command and runs it on the command line to ensure that it both produces output and has an empty error log.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
