### PR TITLE
Removing duplicate config file read-in.

### DIFF
--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -101,11 +101,6 @@ def runLSSTSimulation(args, configs):
     # if not, verboselog does absolutely nothing
     verboselog = pplogger.info if args.verbose else lambda *a, **k: None
 
-    verboselog("Reading configuration file...")
-    configs = PPConfigFileParser(args.configfile, args.surveyname)
-
-    verboselog("Configuration file successfully read.")
-
     configs["mainfilter"], configs["othercolours"] = PPGetMainFilterAndColourOffsets(
         args.paramsinput, configs["observing_filters"], configs["aux_format"]
     )
@@ -447,7 +442,9 @@ def main():
 
     # Extract and validate the remaining arguments.
     cmd_args = PPCommandLineParser(args)
+    pplogger.info("Reading configuration file...")
     configs = PPConfigFileParser(cmd_args["configfile"], cmd_args["surveyname"])
+    pplogger.info("Configuration file read.")
 
     if configs["ephemerides_type"] == "external" and cmd_args["oifoutput"] is None:
         pplogger.error("ERROR: A+R simulation not enabled and no ephemerides file provided")


### PR DESCRIPTION
Fixes #831.
- Deleted the duplicate config file read-in in runLSSTSimulation().
- Added a couple of logging statements to the existing config file read-in in main().

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
