### PR TITLE
Fixing coverage to omit the untestable.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,8 @@
 [run]
 omit = src/sorcha/utilities/citation_text.py
+
+[report]
+exclude_also =
+    # pragma: no cover
+
+omit = src/sorcha/utilities/citation_text.py

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -43,7 +43,7 @@ from sorcha.utilities.sorchaArguments import sorchaArguments
 from sorcha.utilities.citation_text import cite_sorcha
 
 
-def cite():
+def cite():  # pragma: no cover
     """Providing the bibtex, AAS Journals software latex command, and acknowledgement
     statements for Sorcha and the associated packages that power it.
 

--- a/src/sorcha/utilities/createResultsSQLDatabase.py
+++ b/src/sorcha/utilities/createResultsSQLDatabase.py
@@ -183,7 +183,7 @@ def get_column_names(filename, table_name="pp_results"):
     return col_names
 
 
-def main():
+def main():  # pragma: no cover
     """
     Creates a SQLite database with tables of SSPP results and all orbit/physical
     parameters/comet files. Assumes orbit/physical parameters/comet files are all
@@ -256,5 +256,5 @@ def main():
     create_results_database(args)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/sorcha/utilities/generateGoldens.py
+++ b/src/sorcha/utilities/generateGoldens.py
@@ -7,7 +7,7 @@ from shutil import copyfile
 from sorcha.utilities.diffTestUtils import override_seed_and_run
 from sorcha.utilities.dataUtilitiesForTests import get_demo_filepath
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     """
     Generates "golden" output for sorcha runs for testing. This should only b
     be run sparingly when confident all changes have been confirmed and tested with

--- a/src/sorcha/utilities/retrieve_ephemeris_data_files.py
+++ b/src/sorcha/utilities/retrieve_ephemeris_data_files.py
@@ -12,7 +12,7 @@ from sorcha.ephemeris.simulation_data_files import (
 from sorcha.utilities.generate_meta_kernel import build_meta_kernel_file
 
 
-def _decompress(fname, action, pup):
+def _decompress(fname, action, pup):  # pragma: no cover
     """Override the functionality of Pooch's `Decompress` class so that the resulting
     decompressed file uses the original file name without the compression extension.
     For instance `filename.json.bz` will be decompressed and saved as `filename.json`.
@@ -35,7 +35,7 @@ def _decompress(fname, action, pup):
         pooch.Decompress(method="auto", name=os.path.splitext(fname)[0]).__call__(fname, action, pup)
 
 
-def _remove_files(retriever: pooch.Pooch) -> None:
+def _remove_files(retriever: pooch.Pooch) -> None:  # pragma: no cover
     """Utility to remove all the files tracked by the pooch retriever. This includes
     the decompressed ObservatoryCodes.json file as well as the META_KERNEL file
     that are created after downloading the files in the DATA_FILES_TO_DOWNLOAD
@@ -53,7 +53,7 @@ def _remove_files(retriever: pooch.Pooch) -> None:
         os.remove(file_path)
 
 
-def _check_for_existing_files(retriever: pooch.Pooch, file_list: list[str]) -> bool:
+def _check_for_existing_files(retriever: pooch.Pooch, file_list: list[str]) -> bool:  # pragma: no cover
     """Will check for existing local files, any file not found will be printed
     to the terminal.
 
@@ -89,7 +89,7 @@ def _check_for_existing_files(retriever: pooch.Pooch, file_list: list[str]) -> b
     return found_all_files
 
 
-def main():
+def main():  # pragma: no cover
     # parse the input arguments
     parser = argparse.ArgumentParser(
         description="Fetch the NAIF high precision EOP kernel file store its checksum."
@@ -134,5 +134,5 @@ def main():
         _check_for_existing_files(retriever, DATA_FILE_LIST)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -91,7 +91,7 @@ def parse_file_selection(file_select):
     return which_configs
 
 
-def main():
+def main():  # pragma: no cover
     """
     Copies example configuration files for Sorcha from the installation location
     to a user-specified location. Filepath to copy files to is specified by command-line
@@ -146,5 +146,5 @@ def main():
     copy_demo_configs(copy_location, which_configs, args.force)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/sorcha/utilities/sorcha_copy_demo_files.py
+++ b/src/sorcha/utilities/sorcha_copy_demo_files.py
@@ -53,7 +53,7 @@ def copy_demo_files(copy_location, force_overwrite):
     print_demo_command(printall=False)
 
 
-def main():
+def main():  # pragma: no cover
     """
     Copies demo files for Sorcha from the installation location
     to a user-specified location. Filepath to copy files to is specified by command-line
@@ -100,5 +100,5 @@ def main():
     copy_demo_files(copy_location, args.force)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/sorcha/utilities/sorcha_demo_command.py
+++ b/src/sorcha/utilities/sorcha_demo_command.py
@@ -56,5 +56,5 @@ def print_demo_command(printall=True):
     )
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     print_demo_command()


### PR DESCRIPTION
Fixes #834 .

I have made some changes to .coveragerc that should hopefully convince coverage to ignore citation_text.py once and for all.

I have also used the `# pragma: no cover` comment to exclude a lot of the main() functions on utility scripts, plus some utility scripts that will never be unit-tested (generateGoldens and retrieve_ephemeris_data_files).

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
