### PR TITLE
use different config file for cprofiler

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,3 @@
+Usage: in the main sorcha repository directory run:
+
+python benchmarks/bench_cProfile.py

--- a/benchmarks/bench_cProfile.py
+++ b/benchmarks/bench_cProfile.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":  # pragma: no cover
     
     args_obj = sorchaArguments(cmd_args_dict)
 
-    configs = PPConfigFileParser(os.path.join(path_to_sorcha, "demo/sorcha_config_demo.ini"), "LSST")
+    configs = PPConfigFileParser(os.path.join(path_to_sorcha, "benchmarks/test_bench_config.ini"), "LSST")
 
     cProfile.run("runLSSTSimulation(args_obj, configs)", os.path.join(path_to_sorcha, "tests/out/restats"))
 


### PR DESCRIPTION
If I don't make this change, I get an error about the format of the input files and the profiler does not actually run.

Fixes #856 