### PR TITLE
Removing duplicate column.

### DIFF
--- a/src/sorcha/modules/PPMatchPointingToObservations.py
+++ b/src/sorcha/modules/PPMatchPointingToObservations.py
@@ -69,6 +69,6 @@ def PPMatchPointingToObservations(padain, pointfildb):
             "ERROR:: PPMatchPointingToObservations: mismatch in pointing database and pointing output times."
         )
 
-    resdf = resdf.drop(columns=["observationStartMJD_TAI", "observationId_"])
+    resdf = resdf.drop(columns=["observationStartMJD_TAI", "observationId_", "observationMidpointMJD_TAI"])
 
     return resdf

--- a/tests/sorcha/test_PPMatchPointingToObservations.py
+++ b/tests/sorcha/test_PPMatchPointingToObservations.py
@@ -135,7 +135,6 @@ def test_PPMatchPointingToObservations():
             "fieldRA": [10.286608210708128, 10.286608210708128],
             "fieldDec": [-2.177840811640851, -2.177840811640851],
             "rotSkyPos": [298.5944886818567, 302.40143247632597],
-            "observationMidpointMJD_TAI": [60229.284567, 60229.308459],
         }
     )
     expected_df["optFilter"] = expected_df["optFilter"].astype("category")

--- a/tests/sorcha/test_combined_data_reading.py
+++ b/tests/sorcha/test_combined_data_reading.py
@@ -90,7 +90,6 @@ def test_PPReadAllInput():
             11.104605793427162,
             -1.2000819393055593,
             273.9055664032884,
-            60225.290312576966,
         ],
         dtype=object,
     )
@@ -143,7 +142,6 @@ def test_PPReadAllInput():
             "fieldRA",
             "fieldDec",
             "rotSkyPos",
-            "observationMidpointMJD_TAI",
         ],
         dtype=object,
     )


### PR DESCRIPTION
Fixes #839.
- Changed PPMatchPointingToObservations() so that the "observationMidpointMJD_TAI" column is deleted on merge. This solves the problem of duplicate information.
- Edited unit tests to reflect this change.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
