### PR TITLE
Add more checks and debugging strings into file readers

### DIFF
--- a/benchmarks/bench_cProfile.py
+++ b/benchmarks/bench_cProfile.py
@@ -31,9 +31,9 @@ if __name__ == "__main__":  # pragma: no cover
         "outpath": os.path.join(path_to_sorcha, "tests/out"),
         "outfilestem": os.path.join(path_to_sorcha, f"out_{args.object_type}"),
         "verbose": False,
-        "surveyname": "lsst"
+        "surveyname": "lsst",
     }
-    
+
     args_obj = sorchaArguments(cmd_args_dict)
 
     configs = PPConfigFileParser(os.path.join(path_to_sorcha, "benchmarks/test_bench_config.ini"), "LSST")

--- a/src/sorcha/readers/ObjectDataReader.py
+++ b/src/sorcha/readers/ObjectDataReader.py
@@ -185,6 +185,18 @@ class ObjectDataReader(abc.ABC):
             if True then checks the data for  NaNs or nulls.
 
         """
+        pplogger = logging.getLogger(__name__)
+
+        # Check that the table has more than one column.
+        if len(input_table.columns) <= 1:
+            outstr = (
+                f"ERROR: While reading table {self.filename}. Only one column found. "
+                "Check that you specified the correct format."
+            )
+            pplogger.error(outstr)
+            sys.exit(outstr)
+
+        # Check that "ObjID" is a column and is a string.
         input_table = self._validate_object_id_column(input_table)
 
         # Check for NaNs or nulls.
@@ -193,8 +205,6 @@ class ObjectDataReader(abc.ABC):
                 pdt = input_table[input_table.isna().any(axis=1)]
                 inds = str(pdt["ObjID"].values)
                 outstr = f"ERROR: While reading table {self.filename} found uninitialised values ObjID: {str(inds)}."
-
-                pplogger = logging.getLogger(__name__)
                 pplogger.error(outstr)
                 sys.exit(outstr)
         return input_table

--- a/tests/readers/test_CSVReader.py
+++ b/tests/readers/test_CSVReader.py
@@ -166,6 +166,15 @@ def test_CSVDataReader_oif_header():
     oif_data2 = csv_reader2.read_rows()
     assert len(oif_data2) == 9
 
+    # Check that we fail if we provide the wrong header line number (skip the true header)
+    with pytest.raises(SystemExit) as e1:
+        _ = CSVDataReader(get_test_filepath("oiftestoutput_comment.csv"), "csv", header=4)
+    assert e1.type == SystemExit
+
+    with pytest.raises(SystemExit) as e1:
+        _ = CSVDataReader(get_test_filepath("oiftestoutput_comment.csv"), "csv", header=1)
+    assert e1.type == SystemExit
+
 
 @pytest.mark.parametrize("use_cache", [True, False])
 def test_CSVDataReader_specific_oif(use_cache):
@@ -358,16 +367,28 @@ def test_CSVDataReader_comets():
     expected = pd.DataFrame({"ObjID": ["67P/Churyumov-Gerasimenko"], "afrho1": [1552], "k": [-3.35]})
     assert_frame_equal(observations, expected)
 
+    # Check reading with a bad format specification.
+    with pytest.raises(SystemExit) as e1:
+        reader = CSVDataReader(get_test_filepath("testcomet.txt"), "csv")
+        _ = reader.read_rows(0, 1)
+    assert e1.type == SystemExit
+
 
 def test_CSVDataReader_delims():
-    """Test that we check the delimiter during reader creation."""
-    for delim in ["whitespace", "csv"]:
-        _ = CSVDataReader(get_test_filepath("testcolour.txt"), delim)
+    """Test that we check and match the delimiter during reader creation."""
+    _ = CSVDataReader(get_test_filepath("testcolour.txt"), "whitespace")
 
+    # Wrong delim type.
+    with pytest.raises(SystemExit) as e1:
+        _ = CSVDataReader(get_test_filepath("testcolour.txt"), "csv")
+    assert e1.type == SystemExit
+
+    # Invalid delim type.
     with pytest.raises(SystemExit) as e1:
         _ = CSVDataReader(get_test_filepath("testcolour.txt"), "many_commas")
     assert e1.type == SystemExit
 
+    # Empty delim type.
     with pytest.raises(SystemExit) as e2:
         _ = CSVDataReader(get_test_filepath("testcolour.txt"), "")
     assert e2.type == SystemExit

--- a/tests/readers/test_HDF5Reader.py
+++ b/tests/readers/test_HDF5Reader.py
@@ -156,3 +156,10 @@ def test_HDF5DataReader_read_objects(use_cache):
     oif_data2 = reader.read_objects(["S000021"])
     assert len(oif_data2) == 1
     assert_equal(oif_data2.iloc[0].values[0], "S000021")
+
+
+def test_bad_format():
+    """Test that we fail if we try to read a non-HDF5 file."""
+    reader = HDF5DataReader(get_test_filepath("testcolour.txt"))
+    with pytest.raises(RuntimeError):
+        _ = reader.read_rows()

--- a/tests/readers/test_OIFReader.py
+++ b/tests/readers/test_OIFReader.py
@@ -90,7 +90,9 @@ def test_OIFDataReader():
         "oiftestoutput.csv"
     )
 
-    # Check a mismatched file.
+
+def test_OIFDataReader_wrong_data():
+    """Test that we fail if we read an OIF data with the wrong type of data"""
     with pytest.raises(SystemExit) as e:
         reader_ws2 = OIFDataReader(get_test_filepath("testcolour.txt"), inputformat="whitespace")
         _ = reader_ws2.read_rows()
@@ -100,7 +102,19 @@ def test_OIFDataReader():
         == "ERROR: OIFDataReader: column headings do not match expected OIF column headings. Check format of file."
     )
 
+
+def test_OIFDataReader_wrong_format():
+    """Test that we fail if we read an OIF data with the wrong type of data"""
     # Check an invalid file type.
     with pytest.raises(SystemExit) as e:
-        reader_ws2 = OIFDataReader(get_test_filepath("testcolour.txt"), inputformat="invalid")
+        _ = OIFDataReader(get_test_filepath("testcolour.txt"), inputformat="invalid")
+    assert e.type == SystemExit
+
+    # Check mismatched file types.
+    with pytest.raises(SystemExit) as e:
+        _ = OIFDataReader(get_test_filepath("oiftestoutput.txt"), inputformat="csv")
+    assert e.type == SystemExit
+
+    with pytest.raises(SystemExit) as e:
+        _ = OIFDataReader(get_test_filepath("oiftestoutput.csv"), inputformat="whitespace")
     assert e.type == SystemExit

--- a/tests/readers/test_OrbitAuxReader.py
+++ b/tests/readers/test_OrbitAuxReader.py
@@ -295,3 +295,14 @@ def test_orbit_reader_extra_columns():
     with pytest.raises(SystemExit) as err:
         _ = csv_reader.read_rows()
     assert "only provide the required columns" in str(err.value)
+
+
+def test_orbit_reader_wrong_delim():
+    """If the wrong columns for the format defined in the orbit file, raise
+    exception.
+    """
+    with pytest.raises(SystemExit) as err:
+        _ = OrbitAuxReader(get_test_filepath("orbit_test_files/orbit_com_wrong_cols.csv"), "whitespace")
+
+    with pytest.raises(SystemExit) as err:
+        _ = OrbitAuxReader(get_test_filepath("testorb.des"), "csv")

--- a/tests/sorcha/test_PPAddUncertainty.py
+++ b/tests/sorcha/test_PPAddUncertainty.py
@@ -124,9 +124,7 @@ def test_addUncertainties():
         [0.036035, 0.084703, 0.198012, 9.239406],
         decimal=6,
     )
-    assert_almost_equal(
-        obs_uncert["SNR"], [24.941285, 10.303786, 4.166240, 0.000168], decimal=6
-    )
+    assert_almost_equal(obs_uncert["SNR"], [24.941285, 10.303786, 4.166240, 0.000168], decimal=6)
     assert_almost_equal(
         obs_uncert["observedTrailedSourceMag"],
         [21.0419, 22.0064, 23.1822, 37.3978],


### PR DESCRIPTION
Fixes #854 

Adds more (and earlier) checks that a file is being read in with the correct format and delimiter. Produces more meaningful error messages when a mismatch is seen, including outputting the header line to the info logs.

The automatic formatting run picked up a few additional small changes that I included.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [X] Have you written a unit test for any new functions?
- [X] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [X] Have you used black on the files you have updated to confirm python programming style guide enforcement?
