### PR TITLE
Add a check for the delimiter in the colour offsets file.

### DIFF
--- a/src/sorcha/modules/PPGetMainFilterAndColourOffsets.py
+++ b/src/sorcha/modules/PPGetMainFilterAndColourOffsets.py
@@ -79,21 +79,29 @@ def PPGetMainFilterAndColourOffsets(filename, observing_filters, filesep):
         )
 
     # check that the columns match up with the othercolours calculated from observing_filters config variable
-
     if filesep == "whitespace":
-        sep = " "
+        split_line = first_line[:-1].split()
     elif filesep == "comma" or filesep == "csv":
-        sep = ","
+        split_line = first_line[:-1].split(",")
     else:
-        pplogger.error(
-            "ERROR: PPGetMainFilterAndColourOffsets: unexpected valye for auxFormat keyword in configs."
-        )
-        sys.exit("ERROR: PPGetMainFilterAndColourOffsets: unexpected valye for auxFormat keyword in configs.")
+        err_str = f"ERROR: PPGetMainFilterAndColourOffsets: unexpected value for auxFormat keyword in configs: {filesep}"
+        pplogger.error(err_str)
+        sys.exit(err_str)
 
-    if colour_offsets and not all(colour in first_line[:-1].split(sep) for colour in colour_offsets):
+    # Check that the delimiter split things into at least 2 columns
+    if len(split_line) <= 1:
+        err_str = (
+            "ERROR: PPGetMainFilterAndColourOffsets: Too few colour columns found. "
+            "Confirm you are using the correct 'aux_format' configuration parameter."
+        )
+        pplogger.error(err_str)
+        sys.exit(err_str)
+
+    if colour_offsets and not all(colour in split_line for colour in colour_offsets):
         pplogger.error(
             "ERROR: PPGetMainFilterAndColourOffsets: colour offset columns in physical parameters file do not match with observing filters specified in config file."
         )
+        pplogger.error(f"Expected {colour_offsets}")
         sys.exit(
             "ERROR: PPGetMainFilterAndColourOffsets: colour offset columns in physical parameters file do not match with observing filters specified in config file."
         )

--- a/tests/sorcha/test_PPGetMainFilterAndColourOffsets.py
+++ b/tests/sorcha/test_PPGetMainFilterAndColourOffsets.py
@@ -22,12 +22,22 @@ def test_PPGetMainFilterAndColourOffsets():
         == "ERROR: PPGetMainFilterAndColourOffsets: H is given as r, but r is not listed as a requested observation filter in config file."
     )
 
+    # Test incorrect (but valid) separator.
+    with pytest.raises(SystemExit) as err:
+        _, _ = PPGetMainFilterAndColourOffsets(colour_fn, observing_filters, "csv")
+    assert (
+        err.value.args[0] == (
+            "ERROR: PPGetMainFilterAndColourOffsets: Too few colour columns found. "
+            "Confirm you are using the correct 'aux_format' configuration parameter."
+        )
+    )
+
     # Test invalid separator
     with pytest.raises(SystemExit) as err:
         _, _ = PPGetMainFilterAndColourOffsets(colour_fn, observing_filters, "pipe")
     assert (
         err.value.args[0]
-        == "ERROR: PPGetMainFilterAndColourOffsets: unexpected valye for auxFormat keyword in configs."
+        == "ERROR: PPGetMainFilterAndColourOffsets: unexpected value for auxFormat keyword in configs: pipe"
     )
 
     # Test missing colour


### PR DESCRIPTION
Fixes #854

Add a check for the delimiter in the colour offsets file. This does not use one of the readers since it is only loading the header string. This adds a similar number of columns check.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [X] Have you written a unit test for any new functions?
- [X] Do all the units tests run successfully?
- [X] Does Sorcha run successfully on a test set of input files/databases?
- [X] Have you used black on the files you have updated to confirm python programming style guide enforcement?
