### PR TITLE
switch survey name to rubin_sim

### DIFF
--- a/benchmarks/bench_cProfile.py
+++ b/benchmarks/bench_cProfile.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":  # pragma: no cover
         "outpath": os.path.join(path_to_sorcha, "tests/out"),
         "outfilestem": os.path.join(path_to_sorcha, f"out_{args.object_type}"),
         "verbose": False,
-        "surveyname": "lsst",
+        "surveyname": "rubin_sim",
     }
 
     args_obj = sorchaArguments(cmd_args_dict)

--- a/docs/example_files/help_output.txt
+++ b/docs/example_files/help_output.txt
@@ -24,6 +24,6 @@ Optional arguments:
   -cp CP, --complex_physical_parameters CP
                         Complex physical parameters file name (default: None)
   -f, --force           Force deletion/overwrite of existing output file(s). Default False. (default: False)
-  -s S, --survey S      Survey to simulate (default: LSST)
+  -s S, --survey S      Survey to simulate (default: rubin_sim)
   -t T, --stem T        Output file name stem. (default: SSPPOutput)
   -v, --verbose         Verbosity. Default currently true; include to turn off verbosity. (default: True)

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -325,7 +325,7 @@ def PPCheckFiltersForSurvey(survey_name, observing_filters):
 
     pplogger = logging.getLogger(__name__)
 
-    if survey_name in ["LSST", "lsst"]:
+    if survey_name in ["rubin_sim", "RUBIN_SIM"]:
         lsst_filters = ["u", "g", "r", "i", "z", "y"]
         filters_ok = all(elem in lsst_filters for elem in observing_filters)
 
@@ -476,7 +476,7 @@ def PPConfigFileParser(configfile, survey_name):
         )
         if external_file:
             PPFindFileOrExit(config_dict["footprint_path"], "footprint_path")
-        elif survey_name.lower() != "lsst":
+        elif survey_name.lower() not in ["lsst", "rubin_sim"]:
             log_error_and_exit(
                 "a default detector footprint is currently only provided for LSST; please provide your own footprint file."
             )

--- a/src/sorcha/modules/PPLinkingFilter.py
+++ b/src/sorcha/modules/PPLinkingFilter.py
@@ -10,7 +10,7 @@ def PPLinkingFilter(
     tracklet_interval,
     minimum_separation,
     maximum_time,
-    survey_name="lsst",
+    survey_name="rubin_sim",
 ):
     """
     A function which mimics the effects of the SSP linking process by looking
@@ -38,7 +38,7 @@ def PPLinkingFilter(
     rng (numpy Generator object): numpy random number generator object.
 
     survey_name (str): a string with the survey name. used for time-zone purposes.
-    Currently only accepts "lsst", "LSST".
+    Currently only accepts "rubin_sim", "RUBIN_SIM", "lsst", "LSST".
 
     Returns:
     -----------

--- a/src/sorcha/modules/PPReadPointingDatabase.py
+++ b/src/sorcha/modules/PPReadPointingDatabase.py
@@ -52,7 +52,7 @@ def PPReadPointingDatabase(bsdbname, observing_filters, dbquery, surveyname):
     # once we have the actual pointings this check could be changed to, eg,
     # lsst_sim for the RubinSim pointings, and 'lsst' would produce different
     # behaviour.
-    if surveyname in ["lsst", "LSST"]:
+    if surveyname in ["rubin_sim", "RUBIN_SIM"]:
         dfo["observationMidpointMJD_TAI"] = dfo["observationStartMJD_TAI"] + (
             (dfo["visitTime"] / 2.0) / 86400.0
         )

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -441,7 +441,9 @@ def main():
         action="store_true",
         default=False,
     )
-    optional.add_argument("-s", "--survey", help="Survey to simulate", type=str, dest="s", default="rubin_sim")
+    optional.add_argument(
+        "-s", "--survey", help="Survey to simulate", type=str, dest="s", default="rubin_sim"
+    )
     optional.add_argument(
         "-t", "--stem", help="Output file name stem.", type=str, dest="t", default="SSPPOutput"
     )
@@ -498,17 +500,25 @@ def main():
         runLSSTSimulation(args, configs)
     elif cmd_args["surveyname"] in ["LSST", "lsst"]:
         pplogger.error(
-            "ERROR: The LSST has not started yet Current allowed surveys are: {}".format(["rubin_sim", "RUBIN_SIM"])
+            "ERROR: The LSST has not started yet Current allowed surveys are: {}".format(
+                ["rubin_sim", "RUBIN_SIM"]
+            )
         )
         sys.exit(
-            "ERROR: The LSST has not started. Current allowed surveys are: {}".format(["rubin_sim", "RUBIN_SIM"])
+            "ERROR: The LSST has not started. Current allowed surveys are: {}".format(
+                ["rubin_sim", "RUBIN_SIM"]
+            )
         )
     else:
         pplogger.error(
-            "ERROR: Survey name not recognised. Current allowed surveys are: {}".format(["rubin_sim", "RUBIN_SIM"])
+            "ERROR: Survey name not recognised. Current allowed surveys are: {}".format(
+                ["rubin_sim", "RUBIN_SIM"]
+            )
         )
         sys.exit(
-            "ERROR: Survey name not recognised. Current allowed surveys are: {}".format(["rubin_sim", "RUBIN_SIM"])
+            "ERROR: Survey name not recognised. Current allowed surveys are: {}".format(
+                ["rubin_sim", "RUBIN_SIM"]
+            )
         )
 
 

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -351,7 +351,7 @@ def main():
         -cp CP, --complex_physical_parameters CP
                         Complex physical parameters file name (default: None)
         -f, --force           Force deletion/overwrite of existing output file(s). Default False. (default: False)
-        -s S, --survey S      Survey to simulate (default: LSST)
+        -s S, --survey S      Survey to simulate (default: rubin_sim)
         -t T, --stem T        Output file name stem. (default: SSPPOutput)
         -v, --verbose         Verbosity. Default currently true; include to turn off verbosity. (default: True)
     """
@@ -441,7 +441,7 @@ def main():
         action="store_true",
         default=False,
     )
-    optional.add_argument("-s", "--survey", help="Survey to simulate", type=str, dest="s", default="LSST")
+    optional.add_argument("-s", "--survey", help="Survey to simulate", type=str, dest="s", default="rubin_sim")
     optional.add_argument(
         "-t", "--stem", help="Output file name stem.", type=str, dest="t", default="SSPPOutput"
     )
@@ -484,7 +484,7 @@ def main():
         cmd_args["seed"] = int(os.environ["SORCHA_SEED"])
         pplogger.info(f"Random seed overridden via environmental variable, SORCHA_SEED={cmd_args['seed']}")
 
-    if cmd_args["surveyname"] in ["LSST", "lsst"]:
+    if cmd_args["surveyname"] in ["rubin_sim", "RUBIN_SIM"]:
         try:
             args = sorchaArguments(cmd_args)
         except Exception as err:
@@ -496,12 +496,19 @@ def main():
             pplogger.error(err)
             sys.exit(err)
         runLSSTSimulation(args, configs)
-    else:
+    elif cmd_args["surveyname"] in ["LSST", "lsst"]:
         pplogger.error(
-            "ERROR: Survey name not recognised. Current allowed surveys are: {}".format(["LSST", "lsst"])
+            "ERROR: The LSST has not started yet Current allowed surveys are: {}".format(["rubin_sim", "RUBIN_SIM"])
         )
         sys.exit(
-            "ERROR: Survey name not recognised. Current allowed surveys are: {}".format(["LSST", "lsst"])
+            "ERROR: The LSST has not started. Current allowed surveys are: {}".format(["rubin_sim", "RUBIN_SIM"])
+        )
+    else:
+        pplogger.error(
+            "ERROR: Survey name not recognised. Current allowed surveys are: {}".format(["rubin_sim", "RUBIN_SIM"])
+        )
+        sys.exit(
+            "ERROR: Survey name not recognised. Current allowed surveys are: {}".format(["rubin_sim", "RUBIN_SIM"])
         )
 
 

--- a/src/sorcha/utilities/diffTestUtils.py
+++ b/src/sorcha/utilities/diffTestUtils.py
@@ -51,7 +51,7 @@ BASELINE_ARGS = {
     "oifoutput": get_demo_filepath("example_oif_output.txt"),
     "configfile": get_demo_filepath("PPConfig_test.ini"),
     "pointing_database": get_demo_filepath("baseline_v2.0_1yr.db"),
-    "surveyname": "LSST",
+    "surveyname": "rubin_sim",
     "outfilestem": f"out_end2end",
     "verbose": False,
 }
@@ -62,7 +62,7 @@ WITH_EPHEMERIS_ARGS = {
     "configfile": get_demo_filepath("config_for_ephemeris_unit_test.ini"),
     "pointing_database": get_demo_filepath("baseline_v2.0_1yr.db"),
     "output_ephemeris_file": "sorcha_ephemeris.csv",
-    "surveyname": "LSST",
+    "surveyname": "rubin_sim",
     "outfilestem": f"out_end2end_with_ephemeris_generation",
     "verbose": False,
 }

--- a/src/sorcha/utilities/sorchaArguments.py
+++ b/src/sorcha/utilities/sorchaArguments.py
@@ -29,7 +29,7 @@ class sorchaArguments:
     """logger verbosity"""
 
     surveyname: str = ""
-    """name of the survey (`lsst` is only one implemented currently)"""
+    """name of the survey (`rubin_sim` is only one implemented currently)"""
 
     complex_parameters: str = ""
     """optional, extra complex physical parameter input files"""

--- a/tests/data/test_PPPrintConfigsToLog.txt
+++ b/tests/data/test_PPPrintConfigsToLog.txt
@@ -3,7 +3,7 @@ sorcha.modules.PPConfigParser INFO     The config file used is located at test_P
 sorcha.modules.PPConfigParser INFO     The physical parameters file used is located at testcolour.txt 
 sorcha.modules.PPConfigParser INFO     The orbits file used is located at testorb.des 
 sorcha.modules.PPConfigParser INFO     The ephemerides file used is located at oiftestoutput.txt 
-sorcha.modules.PPConfigParser INFO     The survey selected is: lsst 
+sorcha.modules.PPConfigParser INFO     The survey selected is: rubin_sim 
 sorcha.modules.PPConfigParser INFO     No cometary activity selected. 
 sorcha.modules.PPConfigParser INFO     Format of ephemerides file is: csv 
 sorcha.modules.PPConfigParser INFO     Format of auxiliary files is: whitespace 

--- a/tests/ephemeris/test_ephemeris_generation.py
+++ b/tests/ephemeris/test_ephemeris_generation.py
@@ -49,7 +49,7 @@ def test_ephemeris_end2end(single_synthetic_pointing, tmp_path):
         "configfile": get_test_filepath("test_ephem_config.ini"),
         "pointing_database": get_demo_filepath("baseline_v2.0_1yr.db"),
         "outpath": tmp_path,
-        "surveyname": "LSST",
+        "surveyname": "rubin_sim",
         "outfilestem": f"out_400k",
         "verbose": False,
     }
@@ -64,7 +64,7 @@ def test_ephemeris_end2end(single_synthetic_pointing, tmp_path):
     configs["seed"] = 24601
 
     filterpointing = PPReadPointingDatabase(
-        args.pointing_database, configs["observing_filters"], configs["pointing_sql_query"], "lsst"
+        args.pointing_database, configs["observing_filters"], configs["pointing_sql_query"], "rubin_sim"
     )
 
     filterpointing = precompute_pointing_information(filterpointing, args, configs)

--- a/tests/sorcha/test_PPCommandLineParser.py
+++ b/tests/sorcha/test_PPCommandLineParser.py
@@ -14,7 +14,7 @@ class args:
         self.pd = get_test_filepath("baseline_10klines_2.0.db")
         self.o = o
         self.cp = cp
-        self.s = "lsst"
+        self.s = "rubin_sim"
         self.t = t
         self.v = True
         self.f = f
@@ -34,7 +34,7 @@ def test_PPCommandLineParser():
         "configfile": get_test_filepath("test_PPConfig.ini"),
         "pointing_database": get_test_filepath("baseline_10klines_2.0.db"),
         "outpath": "./",
-        "surveyname": "lsst",
+        "surveyname": "rubin_sim",
         "outfilestem": "testout",
         "verbose": True,
         "ar_data_path": None,
@@ -50,7 +50,7 @@ def test_PPCommandLineParser():
         "pointing_database": get_test_filepath("baseline_10klines_2.0.db"),
         "outpath": "./",
         "complex_physical_parameters": get_test_filepath("testcomet.txt"),
-        "surveyname": "lsst",
+        "surveyname": "rubin_sim",
         "outfilestem": "testout",
         "verbose": True,
         "ar_data_path": None,

--- a/tests/sorcha/test_PPConfigParser.py
+++ b/tests/sorcha/test_PPConfigParser.py
@@ -31,7 +31,7 @@ def setup_and_teardown_for_PPConfigFileParser(tmp_path):
 def test_PPConfigFileParser(setup_and_teardown_for_PPConfigFileParser):
     from sorcha.modules.PPConfigParser import PPConfigFileParser
 
-    configs = PPConfigFileParser(get_test_filepath("test_PPConfig.ini"), "lsst")
+    configs = PPConfigFileParser(get_test_filepath("test_PPConfig.ini"), "rubin_sim")
 
     test_configs = {
         "eph_format": "csv",
@@ -219,10 +219,10 @@ def test_PPFindDirectoryOrExit():
 def test_PPCheckFiltersForSurvey():
     from sorcha.modules.PPConfigParser import PPCheckFiltersForSurvey
 
-    PPCheckFiltersForSurvey("lsst", ["u", "g", "r", "i", "z", "y"])
+    PPCheckFiltersForSurvey("rubin_sim", ["u", "g", "r", "i", "z", "y"])
 
     with pytest.raises(SystemExit) as e:
-        PPCheckFiltersForSurvey("lsst", ["j"])
+        PPCheckFiltersForSurvey("rubin_sim", ["j"])
 
     assert e.type == SystemExit
 
@@ -242,7 +242,7 @@ def test_PPPrintConfigsToLog(tmp_path):
         "configfile": "test_PPConfig.ini",
         "pointing_database": "./baseline_10klines_2.0.db",
         "outpath": "./",
-        "surveyname": "lsst",
+        "surveyname": "rubin_sim",
         "outfilestem": "testout",
         "verbose": True,
         "seed": 24601,

--- a/tests/sorcha/test_PPMatchPointingToObservations.py
+++ b/tests/sorcha/test_PPMatchPointingToObservations.py
@@ -75,7 +75,7 @@ def test_PPMatchPointingToObservations():
     dbq = "SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId"
 
     pointing_db = PPReadPointingDatabase(
-        get_test_filepath("baseline_10klines_2.0.db"), ["g", "r", "i"], dbq, "lsst"
+        get_test_filepath("baseline_10klines_2.0.db"), ["g", "r", "i"], dbq, "rubin_sim"
     )
 
     # simulate adding extra columns to the pointing db for the precomputed values

--- a/tests/sorcha/test_PPReadPointingDatabase.py
+++ b/tests/sorcha/test_PPReadPointingDatabase.py
@@ -12,7 +12,7 @@ def test_PPReadPointingDatabase():
     filter_list = ["u", "g", "r", "i", "z", "y"]
 
     pointing_db = PPReadPointingDatabase(
-        get_test_filepath("baseline_10klines_2.0.db"), filter_list, sql_query, "lsst"
+        get_test_filepath("baseline_10klines_2.0.db"), filter_list, sql_query, "rubin_sim"
     )
 
     expected_first_line = np.array(
@@ -59,7 +59,7 @@ def test_PPReadPointingDatabase():
 
     with pytest.raises(SystemExit) as e:
         pointing_db = PPReadPointingDatabase(
-            get_test_filepath("baseline_10klines_2.0.db"), filter_list, bad_query, "lsst"
+            get_test_filepath("baseline_10klines_2.0.db"), filter_list, bad_query, "rubin_sim"
         )
 
     assert e.type == SystemExit

--- a/tests/sorcha/test_combined_data_reading.py
+++ b/tests/sorcha/test_combined_data_reading.py
@@ -31,7 +31,7 @@ def test_PPReadAllInput():
     }
 
     filterpointing = PPReadPointingDatabase(
-        cmd_args["pointing_database"], configs["observing_filters"], configs["pointing_sql_query"], "lsst"
+        cmd_args["pointing_database"], configs["observing_filters"], configs["pointing_sql_query"], "rubin_sim"
     )
 
     reader = CombinedDataReader(verbose=True)

--- a/tests/sorcha/test_sorchaArguments.py
+++ b/tests/sorcha/test_sorchaArguments.py
@@ -9,7 +9,7 @@ cmd_args_dict = {
     "oifoutput": get_demo_filepath("example_oif_output.txt"),
     "configfile": get_demo_filepath("PPConfig_test.ini"),
     "outpath": "./tests/out",
-    "surveyname": "LSST",
+    "surveyname": "RUBIN_SIM",
     "outfilestem": f"out_end2end",
     "verbose": False,
     "pointing_database": get_demo_filepath("baseline_v2.0_1yr.db"),
@@ -20,7 +20,7 @@ def test_sorchaArguments():
     """make sure that valid args can be parsed"""
     args = sorchaArguments(cmd_args_dict)
 
-    assert args.surveyname == "LSST"
+    assert args.surveyname == "RUBIN_SIM"
 
 
 def test_validate_arguments():


### PR DESCRIPTION
switch survey name to rubin_sim so that it's clear this is running on rubin_sim simulated pointing databases. This way we can start to develop the version that will use the real rubin pointing data as "lsst"

Fixes #886 .

Describe your changes.

## Review Checklist for Source Code Changes

- [X] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [X] Do all the units tests run successfully?
- [X] Does Sorcha run successfully on a test set of input files/databases?
- [X] Have you used black on the files you have updated to confirm python programming style guide enforcement?
