### PR TITLE
Removing Expert section in example config files.

### DIFF
--- a/benchmarks/test_bench_config.ini
+++ b/benchmarks/test_bench_config.ini
@@ -21,6 +21,10 @@ size_serial_chunk = 5000
 # Options: csv or whitespace
 aux_format = csv
 
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
+
+
 [SIMULATION]
 
 # Configs for running the ASSIST+REBOUND ephemerides generator.
@@ -170,19 +174,3 @@ lc_model = none
 # file must be specified at the command line.
 comet_activity = none
 
-
-[EXPERT]
-
-# WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
-# They may have unexpected results or break the code entirely.
-
-# SQL query for extracting data from the pointing database.
-pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
-
-# SNR limit: drop observations equal to or below this SNR threshold.
-# Cannot be used at the same time as the magnitude threshold. Must be a float.
-#SNR_limit = 2.0
-
-# Magnitude threshold: drop observations equal to or fainter than this magnitude. Omit for no magnitude cut.
-# Cannot be used at the same time as the SNR limit. Must be a float.
-#magnitude_limit = 22.0

--- a/benchmarks/test_bench_config.ini
+++ b/benchmarks/test_bench_config.ini
@@ -26,7 +26,6 @@ pointing_sql_query = SELECT observationId, observationStartMJD as observationSta
 
 
 [SIMULATION]
-
 # Configs for running the ASSIST+REBOUND ephemerides generator.
 
 # the field of view of our search field, in degrees
@@ -101,6 +100,7 @@ camera_model = footprint
 # at which we will not correctly extract an object.
 # footprint_edge_threshold = 0.0001
 
+
 [FADINGFUNCTION]
 
 # Detection efficiency fading function on or off. Uses the fading function as outlined in
@@ -143,6 +143,7 @@ SSP_number_tracklets = 3
 # constitute a complete track/detection.
 SSP_track_window = 15
 
+
 [OUTPUT]
 
 # Output format of the output file[s]
@@ -159,6 +160,7 @@ position_decimals = 7
 # Decimal places to which all magnitudes should be rounded to in output.
 magnitude_decimals = 3
 
+
 [LIGHTCURVE]
 
 # The unique name of the lightcurve model to use. Defined in the ``name_id`` method 
@@ -173,4 +175,3 @@ lc_model = none
 #  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
 # file must be specified at the command line.
 comet_activity = none
-

--- a/demo/PPConfig_test.ini
+++ b/demo/PPConfig_test.ini
@@ -77,6 +77,7 @@ camera_model = footprint
 # at which we will not correctly extract an object.
 # footprint_edge_threshold = 0.0001
 
+
 [FADINGFUNCTION]
 
 # Detection efficiency fading function on or off. Uses the fading function as outlined in
@@ -102,7 +103,6 @@ SSP_detection_efficiency = 0.95
 # required to produce a valid tracklet?
 SSP_number_observations = 2
 
-
 # Minimum separation (in arcsec) between two observations of an object required 
 # for the linking software to distinguish them as separate and therefore as a valid tracklet.
 SSP_separation_threshold = 0.5
@@ -119,8 +119,8 @@ SSP_number_tracklets = 3
 # constitute a complete track/detection.
 SSP_track_window = 15
 
-[SIMULATION]
 
+[SIMULATION]
 # Configs for running the ASSIST+REBOUND ephemerides generator.
 
 # the field of view of our search field, in degrees
@@ -159,3 +159,17 @@ position_decimals = 7
 magnitude_decimals = 3
 
 
+[LIGHTCURVE]
+
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method 
+# of the subclasses of AbstractLightCurve. If not none, the complex physical parameters 
+# file must be specified at the command line.lc_model = none
+lc_model = none
+
+
+[ACTIVITY]
+
+# The unique name of the actvity model to use. Defined in the ``name_id`` method
+#  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
+# file must be specified at the command line.
+comet_activity = none

--- a/demo/PPConfig_test.ini
+++ b/demo/PPConfig_test.ini
@@ -21,6 +21,8 @@ size_serial_chunk = 5000
 # Options: csv or whitespace
 aux_format = whitespace
 
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
 
 [FILTERS]
 
@@ -157,18 +159,3 @@ position_decimals = 7
 magnitude_decimals = 3
 
 
-[EXPERT]
-
-# WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
-# They may have unexpected results or break the code entirely.
-
-# SQL query for extracting data from the pointing database.
-pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
-
-# SNR limit: drop observations equal to or below this SNR threshold.
-# Cannot be used at the same time as the magnitude threshold. Must be a float.
-#SNR_limit = 2.0
-
-# Magnitude threshold: drop observations equal to or fainter than this magnitude. Omit for no magnitude cut.
-# Cannot be used at the same time as the SNR limit. Must be a float.
-#magnitude_limit = 22.0

--- a/demo/config_for_ephemeris_unit_test.ini
+++ b/demo/config_for_ephemeris_unit_test.ini
@@ -21,6 +21,9 @@ size_serial_chunk = 50000
 # Options: csv or whitespace
 aux_format = csv
 
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
+
 [SIMULATION]
 
 # Configs for running the ASSIST+REBOUND ephemerides generator.
@@ -161,19 +164,3 @@ position_decimals = 7
 # Decimal places to which all magnitudes should be rounded to in output.
 magnitude_decimals = 3
 
-
-[EXPERT]
-
-# WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
-# They may have unexpected results or break the code entirely.
-
-# SQL query for extracting data from the pointing database.
-pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
-
-# SNR limit: drop observations equal to or below this SNR threshold.
-# Cannot be used at the same time as the magnitude threshold. Must be a float.
-#SNR_limit = 2.0
-
-# Magnitude threshold: drop observations equal to or fainter than this magnitude. Omit for no magnitude cut.
-# Cannot be used at the same time as the SNR limit. Must be a float.
-#magnitude_limit = 22.0

--- a/demo/config_for_ephemeris_unit_test.ini
+++ b/demo/config_for_ephemeris_unit_test.ini
@@ -24,6 +24,7 @@ aux_format = csv
 # SQL query for extracting data from the pointing database.
 pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
 
+
 [SIMULATION]
 
 # Configs for running the ASSIST+REBOUND ephemerides generator.
@@ -45,14 +46,6 @@ ar_obs_code = X05
 # the order of healpix which we will use for the healpy portions of the code.
 # the nside is equivalent to 2**ar_healpix_order
 ar_healpix_order = 6
-
-
-[ACTIVITY]
-
-# Flag for cometary activity. If not none, a cometary parameters file ust be specified at the command line.
-# Value is expected to be the unique name of the activity model to use.
-# The unique name is defined in the ``name_id`` method of the subclasses of AbstractCometaryActivity
-comet_activity = none
 
 
 [FILTERS]
@@ -108,6 +101,7 @@ camera_model = footprint
 # at which we will not correctly extract an object.
 # footprint_edge_threshold = 0.0001
 
+
 [FADINGFUNCTION]
 
 # Detection efficiency fading function on or off. Uses the fading function as outlined in
@@ -148,6 +142,7 @@ SSP_number_tracklets = 3
 # constitute a complete track/detection.
 SSP_track_window = 15
 
+
 [OUTPUT]
 
 # Output format.
@@ -163,4 +158,22 @@ position_decimals = 7
 
 # Decimal places to which all magnitudes should be rounded to in output.
 magnitude_decimals = 3
+
+
+[LIGHTCURVE]
+
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method 
+# of the subclasses of AbstractLightCurve. If not none, the complex physical parameters 
+# file must be specified at the command line.lc_model = none
+lc_model = none
+
+
+[ACTIVITY]
+
+# The unique name of the actvity model to use. Defined in the ``name_id`` method
+#  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
+# file must be specified at the command line.
+comet_activity = none
+
+
 

--- a/demo/sorcha_config_demo.ini
+++ b/demo/sorcha_config_demo.ini
@@ -26,7 +26,6 @@ pointing_sql_query = SELECT observationId, observationStartMJD as observationSta
 
 
 [SIMULATION]
-
 # Configs for running the ASSIST+REBOUND ephemerides generator.
 
 # the field of view of our search field, in degrees
@@ -101,6 +100,7 @@ camera_model = footprint
 # at which we will not correctly extract an object.
 # footprint_edge_threshold = 0.0001
 
+
 [FADINGFUNCTION]
 
 # Detection efficiency fading function on or off. Uses the fading function as outlined in
@@ -143,6 +143,7 @@ SSP_number_tracklets = 3
 # constitute a complete track/detection.
 SSP_track_window = 15
 
+
 [OUTPUT]
 
 # Output format of the output file[s]
@@ -158,6 +159,7 @@ position_decimals = 7
 
 # Decimal places to which all magnitudes should be rounded to in output. Delete for no rounding.
 magnitude_decimals = 3
+
 
 [LIGHTCURVE]
 

--- a/demo/sorcha_config_demo.ini
+++ b/demo/sorcha_config_demo.ini
@@ -21,6 +21,10 @@ size_serial_chunk = 5000
 # Options: csv or whitespace
 aux_format = whitespace
 
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
+
+
 [SIMULATION]
 
 # Configs for running the ASSIST+REBOUND ephemerides generator.
@@ -169,20 +173,3 @@ lc_model = none
 #  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
 # file must be specified at the command line.
 comet_activity = none
-
-
-[EXPERT]
-
-# WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
-# They may have unexpected results or break the code entirely.
-
-# SQL query for extracting data from the pointing database.
-pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
-
-# SNR limit: drop observations equal to or below this SNR threshold.
-# Cannot be used at the same time as the magnitude threshold. Must be a float.
-#SNR_limit = 2.0
-
-# Magnitude threshold: drop observations equal to or fainter than this magnitude. Omit for no magnitude cut.
-# Cannot be used at the same time as the SNR limit. Must be a float.
-#magnitude_limit = 22.0

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -410,6 +410,10 @@ def PPConfigFileParser(configfile, survey_name):
         pplogger.error("ERROR: size_serial_chunk is zero or negative.")
         sys.exit("ERROR: size_serial_chunk is zero or negative.")
 
+    config_dict["pointing_sql_query"] = PPGetOrExit(
+        config, "INPUT", "pointing_sql_query", "ERROR: no pointing database SQLite3 query provided."
+    )
+
     # ACTIVITY
 
     config_dict["comet_activity"] = config.get("ACTIVITY", "comet_activity", fallback=None)
@@ -725,10 +729,6 @@ def PPConfigFileParser(configfile, survey_name):
         sys.exit(
             "ERROR: could not parse value for default_SNR_cut as a boolean. Check formatting and try again."
         )
-
-    config_dict["pointing_sql_query"] = PPGetOrExit(
-        config, "EXPERT", "pointing_sql_query", "ERROR: no pointing database SQLite3 query provided."
-    )
 
     config_dict["lc_model"] = config.get("EXPERT", "lc_model", fallback=None)
     config_dict["lc_model"] = None if config_dict["lc_model"] == "none" else config_dict["lc_model"]

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -730,7 +730,9 @@ def PPConfigFileParser(configfile, survey_name):
             "ERROR: could not parse value for default_SNR_cut as a boolean. Check formatting and try again."
         )
 
-    config_dict["lc_model"] = config.get("EXPERT", "lc_model", fallback=None)
+    # LIGHTCURVEß
+
+    config_dict["lc_model"] = config.get("LIGHTCURVE", "lc_model", fallback=None)
     config_dict["lc_model"] = None if config_dict["lc_model"] == "none" else config_dict["lc_model"]
 
     # If the user defined a lightcurve model, but the model has not been registered, exit the program.

--- a/survey_setups/Rubin_circular_approximation.ini
+++ b/survey_setups/Rubin_circular_approximation.ini
@@ -24,8 +24,8 @@ aux_format = csv
 # SQL query for extracting data from the pointing database.
 pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
 
-[SIMULATION]
 
+[SIMULATION]
 # Configuration for running the ASSIST+REBOUND ephemerides generator.
 
 # the field of view of our search field, in degrees
@@ -45,6 +45,7 @@ ar_obs_code = X05
 # the order of healpix which we will use for the healpy portions of the code.
 # the nside is equivalent to 2**ar_healpix_order
 ar_healpix_order = 6
+
 
 [FILTERS]
 
@@ -74,6 +75,7 @@ bright_limit = 16.0
 # Options: HG, HG1G2, HG12, linear, none.
 phase_function = HG
 
+
 [FOV]
 
 # Choose between circular or actual camera footprint, including chip gaps.
@@ -87,6 +89,7 @@ fill_factor = 0.9
 # Radius of the circle for a circular footprint (in degrees). Float.
 # Comment out or do not include if using footprint camera model.
 circle_radius = 1.75
+
 
 [FADINGFUNCTION]
 
@@ -130,6 +133,7 @@ SSP_number_tracklets = 3
 # constitute a complete track/detection.
 SSP_track_window = 15
 
+
 [OUTPUT]
 
 # Output format of the output file[s]
@@ -161,4 +165,3 @@ lc_model = none
 #  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
 # file must be specified at the command line.
 comet_activity = none
-

--- a/survey_setups/Rubin_circular_approximation.ini
+++ b/survey_setups/Rubin_circular_approximation.ini
@@ -21,6 +21,9 @@ size_serial_chunk = 20000
 # Options: csv or whitespace
 aux_format = csv
 
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
+
 [SIMULATION]
 
 # Configuration for running the ASSIST+REBOUND ephemerides generator.
@@ -158,13 +161,4 @@ lc_model = none
 #  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
 # file must be specified at the command line.
 comet_activity = none
-
-
-[EXPERT]
-
-# WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
-# They may have unexpected results or break the code entirely.
-
-# SQL query for extracting data from the pointing database.
-pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
 

--- a/survey_setups/Rubin_full_footprint.ini
+++ b/survey_setups/Rubin_full_footprint.ini
@@ -24,8 +24,8 @@ aux_format = csv
 # SQL query for extracting data from the pointing database.
 pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
 
-[SIMULATION]
 
+[SIMULATION]
 # Configuration for running the ASSIST+REBOUND ephemerides generator.
 
 # the field of view of our search field, in degrees
@@ -45,6 +45,7 @@ ar_obs_code = X05
 # the order of healpix which we will use for the healpy portions of the code.
 # the nside is equivalent to 2**ar_healpix_order
 ar_healpix_order = 6
+
 
 [FILTERS]
 
@@ -74,6 +75,7 @@ bright_limit = 16.0
 # Options: HG, HG1G2, HG12, linear, none.
 phase_function = HG
 
+
 [FOV]
 
 # Choose between circular or actual camera footprint, including chip gaps.
@@ -88,6 +90,7 @@ camera_model = footprint
 # detector configurationn file if not using the default built-in LSSTCam detector 
 # configuration or not using the circle footprint model.
 # footprint_path= ./data/detectors_corners.csv
+
 
 [FADINGFUNCTION]
 
@@ -130,6 +133,7 @@ SSP_number_tracklets = 3
 # constitute a complete track/detection.
 SSP_track_window = 15
 
+
 [OUTPUT]
 
 # Output format of the output file[s]
@@ -161,7 +165,5 @@ lc_model = none
 #  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
 # file must be specified at the command line.
 comet_activity = none
-
-
 
 

--- a/survey_setups/Rubin_full_footprint.ini
+++ b/survey_setups/Rubin_full_footprint.ini
@@ -21,6 +21,9 @@ size_serial_chunk = 20000
 # Options: csv or whitespace
 aux_format = csv
 
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
+
 [SIMULATION]
 
 # Configuration for running the ASSIST+REBOUND ephemerides generator.
@@ -160,11 +163,5 @@ lc_model = none
 comet_activity = none
 
 
-[EXPERT]
 
-# WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
-# They may have unexpected results or break the code entirely.
-
-# SQL query for extracting data from the pointing database.
-pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
 

--- a/tests/data/test_PPConfig.ini
+++ b/tests/data/test_PPConfig.ini
@@ -23,14 +23,6 @@ aux_format = whitespace
 pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId
 
 
-[ACTIVITY]
-
-# Flag for cometary activity. If not none, a cometary parameters file must be specified at the command line.
-# Value is expected to be the unique name of the activity model to use.
-# The unique name is defined in the ``name_id`` method of the subclasses of AbstractCometaryActivity
-comet_activity = none
-
-
 [FILTERS]
 
 # Filters of the observations you are interested in, comma-separated.
@@ -123,8 +115,8 @@ SSP_number_tracklets = 3
 # constitute a complete track/detection.
 SSP_track_window = 15
 
-[SIMULATION]
 
+[SIMULATION]
 # Configs for running the ASSIST+REBOUND ephemerides generator.
 
 # the field of view of our search field, in degrees
@@ -161,3 +153,19 @@ position_decimals = 7
 
 # Decimal places to which all magnitudes should be rounded to in output.
 magnitude_decimals = 3
+
+
+[LIGHTCURVE]
+
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method 
+# of the subclasses of AbstractLightCurve. If not none, the complex physical parameters 
+# file must be specified at the command line.lc_model = none
+lc_model = none
+
+
+[ACTIVITY]
+
+# The unique name of the actvity model to use. Defined in the ``name_id`` method
+#  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
+# file must be specified at the command line.
+comet_activity = none

--- a/tests/data/test_PPConfig.ini
+++ b/tests/data/test_PPConfig.ini
@@ -19,6 +19,9 @@ size_serial_chunk = 10
 # Options: comma, csv or whitespace
 aux_format = whitespace
 
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId
+
 
 [ACTIVITY]
 
@@ -158,23 +161,3 @@ position_decimals = 7
 
 # Decimal places to which all magnitudes should be rounded to in output.
 magnitude_decimals = 3
-
-
-[EXPERT]
-
-# WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
-# They may have unexpected results or break the code entirely.
-
-# SQL query for extracting data from the pointing database.
-pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom, seeingFwhmEff, fiveSigmaDepth, fieldRA, fieldDec, rotSkyPos FROM observations order by observationId
-
-# SNR limit: drop observations below this SNR threshold.
-# Cannot be used at the same time as the magnitude threshold. Must be a float.
-#SNR_limit = 2.0
-
-# Magnitude threshold: drop observations fainter than this magnitude. Omit for no magnitude cut.
-# Cannot be used at the same time as the SNR limit. Must be a float.
-#magnitude_limit = 22.0
-
-# The unique name of the lightcurve model to use. Defined in the ``name_id`` method of the subclasses of AbstractLightCurve
-lc_model = none

--- a/tests/data/test_ephem_config.ini
+++ b/tests/data/test_ephem_config.ini
@@ -23,14 +23,6 @@ aux_format = whitespace
 pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId limit 1000
 
 
-[ACTIVITY]
-
-# Flag for cometary activity. If not none, a cometary parameters file must be specified at the command line.
-# Value is expected to be the unique name of the activity model to use.
-# The unique name is defined in the ``name_id`` method of the subclasses of AbstractCometaryActivity
-comet_activity = none
-
-
 [FILTERS]
 
 # Filters of the observations you are interested in, comma-separated.
@@ -120,8 +112,8 @@ SSP_number_tracklets = 3
 # constitute a complete track/detection.
 SSP_track_window = 15
 
-[SIMULATION]
 
+[SIMULATION]
 # Configs for running the ASSIST+REBOUND ephemerides generator.
 
 # the field of view of our search field, in degrees
@@ -158,3 +150,19 @@ position_decimals = 7
 
 # Decimal places to which all magnitudes should be rounded to in output.
 magnitude_decimals = 3
+
+
+[LIGHTCURVE]
+
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method 
+# of the subclasses of AbstractLightCurve. If not none, the complex physical parameters 
+# file must be specified at the command line.lc_model = none
+lc_model = none
+
+
+[ACTIVITY]
+
+# The unique name of the actvity model to use. Defined in the ``name_id`` method
+#  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
+# file must be specified at the command line.
+comet_activity = none

--- a/tests/data/test_ephem_config.ini
+++ b/tests/data/test_ephem_config.ini
@@ -19,6 +19,9 @@ size_serial_chunk = 10
 # Options: comma, csv or whitespace
 aux_format = whitespace
 
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId limit 1000
+
 
 [ACTIVITY]
 
@@ -155,23 +158,3 @@ position_decimals = 7
 
 # Decimal places to which all magnitudes should be rounded to in output.
 magnitude_decimals = 3
-
-
-[EXPERT]
-
-# WARNING: DO NOT CHANGE THESE PARAMETERS UNLESS YOU ARE VERY SURE OF WHAT YOU ARE DOING!
-# They may have unexpected results or break the code entirely.
-
-# SQL query for extracting data from the pointing database.
-pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId limit 1000
-
-# SNR limit: drop observations below this SNR threshold.
-# Cannot be used at the same time as the magnitude threshold. Must be a float.
-#SNR_limit = 2.0
-
-# Magnitude threshold: drop observations fainter than this magnitude. Omit for no magnitude cut.
-# Cannot be used at the same time as the SNR limit. Must be a float.
-#magnitude_limit = 22.0
-
-# The unique name of the lightcurve model to use. Defined in the ``name_id`` method of the subclasses of AbstractLightCurve
-lc_model = none


### PR DESCRIPTION
Fixes #910.
- The config file variable pointing_sql_query has been moved to the [INPUT] section of the config file.
- The unit test has been updated.
- All demo, example and test configuration files have been updated to reflect the change.
- The [EXPERT] section has been deleted from all example and demo config files, though it still exists in the code. It's a _secret_.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
