### PR TITLE
Adding more switches to config file.

### DIFF
--- a/demo/sorcha_config_demo.ini
+++ b/demo/sorcha_config_demo.ini
@@ -80,7 +80,7 @@ phase_function = HG
 
 # Choose between circular or actual camera footprint, including chip gaps.
 # Options: circle, footprint.
-camera_model = none
+camera_model = footprint
 
 # Path to camera footprint file. Uncomment to provide a path to the desired camera 
 # detector configurationn file if not using the default built-in LSSTCam detector 
@@ -175,7 +175,3 @@ lc_model = none
 #  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
 # file must be specified at the command line.
 comet_activity = none
-
-[EXPERT]
-randomization_on = False
-vignetting_on = False

--- a/demo/sorcha_config_demo.ini
+++ b/demo/sorcha_config_demo.ini
@@ -80,7 +80,7 @@ phase_function = HG
 
 # Choose between circular or actual camera footprint, including chip gaps.
 # Options: circle, footprint.
-camera_model = footprint
+camera_model = none
 
 # Path to camera footprint file. Uncomment to provide a path to the desired camera 
 # detector configurationn file if not using the default built-in LSSTCam detector 
@@ -175,3 +175,7 @@ lc_model = none
 #  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
 # file must be specified at the command line.
 comet_activity = none
+
+[EXPERT]
+randomization_on = False
+vignetting_on = False

--- a/docs/notebooks/demo_UncertaintiesAndRandomization.ipynb
+++ b/docs/notebooks/demo_UncertaintiesAndRandomization.ipynb
@@ -98,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "configs = {'trailing_losses_on':True, 'default_SNR_cut': False}\n",
+    "configs = {'trailing_losses_on':True, 'default_SNR_cut': False, 'randomization_on':True}\n",
     "rng = PerModuleRNG(2012)"
    ]
   },

--- a/src/sorcha/modules/PPAddUncertainties.py
+++ b/src/sorcha/modules/PPAddUncertainties.py
@@ -115,17 +115,23 @@ def addUncertainties(detDF, configs, module_rngs, verbose=True):
         verboselog("Removing all observations with SNR < 2.0...")
         detDF = PPSNRLimit(detDF.copy(), 2.0)
 
-    verboselog("Randomising photometry...")
-    detDF["trailedSourceMag"] = PPRandomizeMeasurements.randomizePhotometry(
-        detDF, module_rngs, magName="trailedSourceMagTrue", sigName="trailedSourceMagSigma"
-    )
-
-    if configs.get("trailing_losses_on", False):
-        detDF["PSFMag"] = PPRandomizeMeasurements.randomizePhotometry(
-            detDF, module_rngs, magName="PSFMagTrue", sigName="PSFMagSigma"
+    if configs["randomization_on"]:
+        verboselog("Randomising photometry...")
+        detDF["trailedSourceMag"] = PPRandomizeMeasurements.randomizePhotometry(
+            detDF, module_rngs, magName="trailedSourceMagTrue", sigName="trailedSourceMagSigma"
         )
+
+        if configs.get("trailing_losses_on", False):
+            detDF["PSFMag"] = PPRandomizeMeasurements.randomizePhotometry(
+                detDF, module_rngs, magName="PSFMagTrue", sigName="PSFMagSigma"
+            )
+        else:
+            detDF["PSFMag"] = detDF["trailedSourceMag"]
+
     else:
-        detDF["PSFMag"] = detDF["trailedSourceMag"]
+        verboselog("Randomization turned off in config file. No magnitude randomization performed.")
+        detDF["trailedSourceMag"] = detDF["trailedSourceMagTrue"]
+        detDF["PSFMag"] = detDF["PSFMagTrue"]
 
     return detDF
 

--- a/src/sorcha/modules/PPAddUncertainties.py
+++ b/src/sorcha/modules/PPAddUncertainties.py
@@ -130,8 +130,8 @@ def addUncertainties(detDF, configs, module_rngs, verbose=True):
 
     else:
         verboselog("Randomization turned off in config file. No magnitude randomization performed.")
-        detDF["trailedSourceMag"] = detDF["trailedSourceMagTrue"]
-        detDF["PSFMag"] = detDF["PSFMagTrue"]
+        detDF["trailedSourceMag"] = detDF["trailedSourceMagTrue"].copy()
+        detDF["PSFMag"] = detDF["PSFMagTrue"].copy()
 
     return detDF
 

--- a/src/sorcha/modules/PPApplyFOVFilter.py
+++ b/src/sorcha/modules/PPApplyFOVFilter.py
@@ -65,6 +65,9 @@ def PPApplyFOVFilter(observations, configs, module_rngs, footprint=None, verbose
             verboselog("Fill factor is set. Removing random observations to mimic chip gaps.")
             observations = PPSimpleSensorArea(observations, module_rngs, configs["fill_factor"])
 
+    if configs["camera_model"] == "none":
+        verboselog("Camera model set to None in configs. No FOV filter will be applied.")
+
     return observations
 
 

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -470,7 +470,7 @@ def PPConfigFileParser(configfile, survey_name):
         config, "FOV", "camera_model", "ERROR: camera model not defined."
     )
 
-    if config_dict["camera_model"] not in ["circle", "footprint"]:
+    if config_dict["camera_model"] not in ["circle", "footprint", "none"]:
         pplogger.error('ERROR: camera_model should be either "circle" or "footprint".')
         sys.exit('ERROR: camera_model should be either "circle" or "footprint".')
 
@@ -730,6 +730,26 @@ def PPConfigFileParser(configfile, survey_name):
             "ERROR: could not parse value for default_SNR_cut as a boolean. Check formatting and try again."
         )
 
+    try:
+        config_dict["randomization_on"] = config.getboolean("EXPERT", "randomization_on", fallback=True)
+    except ValueError:
+        pplogger.error(
+            "ERROR: could not parse value for randomization_on as a boolean. Check formatting and try again."
+        )
+        sys.exit(
+            "ERROR: could not parse value for randomization_on as a boolean. Check formatting and try again."
+        )
+
+    try:
+        config_dict["vignetting_on"] = config.getboolean("EXPERT", "vignetting_on", fallback=True)
+    except ValueError:
+        pplogger.error(
+            "ERROR: could not parse value for vignetting_on as a boolean. Check formatting and try again."
+        )
+        sys.exit(
+            "ERROR: could not parse value for vignetting_on as a boolean. Check formatting and try again."
+        )
+
     # LIGHTCURVEß
 
     config_dict["lc_model"] = config.get("LIGHTCURVE", "lc_model", fallback=None)
@@ -805,13 +825,23 @@ def PPPrintConfigsToLog(configs, cmd_args):
     else:
         pplogger.info("Computation of trailing losses is switched OFF.")
 
+    if configs["randomization_on"]:
+        pplogger.info("Randomization of position and magnitude around uncertainties is switched ON.")
+    else:
+        pplogger.info("Randomization of position and magnitude around uncertainties is switched OFF.")
+
+    if configs["vignetting_on"]:
+        pplogger.info("Vignetting is switched ON.")
+    else:
+        pplogger.info("Vignetting is switched OFF.")
+
     if configs["camera_model"] == "footprint":
         pplogger.info("Footprint is modelled after the actual camera footprint.")
         if configs["footprint_path"]:
             pplogger.info("Loading camera footprint from " + configs["footprint_path"])
         else:
             pplogger.info("Loading default LSST footprint LSST_detector_corners_100123.csv")
-    else:
+    elif configs["camera_model"] == "circle":
         pplogger.info("Footprint is circular.")
         if configs["fill_factor"]:
             pplogger.info(
@@ -821,6 +851,8 @@ def PPPrintConfigsToLog(configs, cmd_args):
             pplogger.info(
                 "A circular footprint will be applied with radius: " + str(configs["circle_radius"])
             )
+    else:
+        pplogger.info("Camera footprint is turned OFF.")
 
     if configs["bright_limit_on"]:
         pplogger.info("The upper saturation limit(s) is/are: " + str(configs["bright_limit"]))

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -261,8 +261,8 @@ def runLSSTSimulation(args, configs):
             verboselog(
                 "NOTE: new columns RATrue_deg and DecTrue_deg are EQUAL to columns RA_deg and Dec_deg."
             )
-            observations["RATrue_deg"] = observations["RA_deg"]
-            observations["DecTrue_deg"] = observations["Dec_deg"]
+            observations["RATrue_deg"] = observations["RA_deg"].copy()
+            observations["DecTrue_deg"] = observations["Dec_deg"].copy()
 
         verboselog("Applying field-of-view filters...")
         verboselog("Number of rows BEFORE applying FOV filters: " + str(len(observations.index)))

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -258,6 +258,11 @@ def runLSSTSimulation(args, configs):
             )
         else:
             verboselog("Randomization turned off in config file. No astrometric randomization performed.")
+            verboselog(
+                "NOTE: new columns RATrue_deg and DecTrue_deg are EQUAL to columns RA_deg and Dec_deg."
+            )
+            observations["RATrue_deg"] = observations["RA_deg"]
+            observations["DecTrue_deg"] = observations["Dec_deg"]
 
         verboselog("Applying field-of-view filters...")
         verboselog("Number of rows BEFORE applying FOV filters: " + str(len(observations.index)))

--- a/tests/data/test_PPPrintConfigsToLog.txt
+++ b/tests/data/test_PPPrintConfigsToLog.txt
@@ -15,6 +15,8 @@ sorcha.modules.PPConfigParser INFO     The filters included in the post-processi
 sorcha.modules.PPConfigParser INFO     Thus, the colour indices included in the simulation are g-r i-r z-r 
 sorcha.modules.PPConfigParser INFO     The apparent brightness is calculated using the following phase function model: HG 
 sorcha.modules.PPConfigParser INFO     Computation of trailing losses is switched ON. 
+sorcha.modules.PPConfigParser INFO     Randomization of position and magnitude around uncertainties is switched ON. 
+sorcha.modules.PPConfigParser INFO     Vignetting is switched ON. 
 sorcha.modules.PPConfigParser INFO     Footprint is modelled after the actual camera footprint. 
 sorcha.modules.PPConfigParser INFO     Loading camera footprint from ./detectors_corners.csv 
 sorcha.modules.PPConfigParser INFO     The upper saturation limit(s) is/are: 16.0 

--- a/tests/sorcha/test_PPAddUncertainty.py
+++ b/tests/sorcha/test_PPAddUncertainty.py
@@ -104,7 +104,7 @@ def test_addUncertainties():
         }
     )
 
-    configs = {"trailing_losses_on": True, "default_SNR_cut": False}
+    configs = {"trailing_losses_on": True, "default_SNR_cut": False, "randomization_on": True}
 
     rng = PerModuleRNG(2021)
 
@@ -130,7 +130,7 @@ def test_addUncertainties():
     )
     assert_almost_equal(obs_uncert["PSFMag"], [21.239301, 22.050202, 23.006519, 37.514547], decimal=6)
 
-    configs_notrail = {"trailing_losses_on": False, "default_SNR_cut": False}
+    configs_notrail = {"trailing_losses_on": False, "default_SNR_cut": False, "randomization_on": True}
 
     obs_notrail = addUncertainties(test_data, configs_notrail, rng)
 
@@ -139,11 +139,16 @@ def test_addUncertainties():
         obs_notrail["trailedSourceMagSigma"].values,
     )
 
-    configs_SNRcut = {"trailing_losses_on": False, "default_SNR_cut": True}
+    configs_SNRcut = {"trailing_losses_on": False, "default_SNR_cut": True, "randomization_on": True}
 
     obs_SNRcut = addUncertainties(test_data, configs_SNRcut, rng)
 
     assert_equal(obs_SNRcut["ObjID"].values, ["a21", "b22", "c23"])
+
+    configs_norand = {"trailing_losses_on": False, "default_SNR_cut": False, "randomization_on": False}
+    obs_norand = addUncertainties(test_data, configs_norand, rng)
+
+    assert_almost_equal(obs_norand["PSFMag"], [21.2, 22.2, 23.2, 34.2])
 
     return
 
@@ -165,7 +170,7 @@ def test_uncertainties():
         }
     )
 
-    configs = {"trailing_losses_on": False}
+    configs = {"trailing_losses_on": False, "randomization_on": True}
 
     ast_sig_deg, photo_sig, SNR = uncertainties(observations, configs)
 

--- a/tests/sorcha/test_PPApplyFOVFilter.py
+++ b/tests/sorcha/test_PPApplyFOVFilter.py
@@ -92,7 +92,7 @@ def test_PPApplyFOVFilters():
     configs = {
         "camera_model": "footprint",
         "footprint_path": get_test_filepath("detectors_corners.csv"),
-        "footprint_edge_threshold": 0.0,
+        "footprint_edge_threshold": 10.0,
     }
     footprint = Footprint(configs["footprint_path"])
     new_obs = PPApplyFOVFilter(observations, configs, rng, footprint=footprint)
@@ -101,7 +101,6 @@ def test_PPApplyFOVFilters():
         894838,
         897478,
         897521,
-        901987,
         902035,
         907363,
         907416,
@@ -109,7 +108,6 @@ def test_PPApplyFOVFilters():
         909426,
         909452,
         910850,
-        910872,
         915246,
         915268,
         922013,
@@ -121,4 +119,6 @@ def test_PPApplyFOVFilters():
 
     assert_equal(new_obs["FieldID"].values, expected)
 
-    return
+    configs = {"camera_model": "none"}
+    new_obs = PPApplyFOVFilter(observations, configs, rng)
+    assert len(new_obs) == 20

--- a/tests/sorcha/test_PPApplyFOVFilter.py
+++ b/tests/sorcha/test_PPApplyFOVFilter.py
@@ -9,24 +9,11 @@ from sorcha.utilities.dataUtilitiesForTests import get_test_filepath
 def test_PPSimpleSensorArea():
     from sorcha.modules.PPApplyFOVFilter import PPSimpleSensorArea
 
-    test_data = pd.read_csv(get_test_filepath("test_input_fullobs.csv"), nrows=15)
+    test_data = pd.read_csv(get_test_filepath("test_input_fullobs.csv"), nrows=10)
 
-    test_out = PPSimpleSensorArea(test_data, PerModuleRNG(2022), fillfactor=0.9)
+    test_out = PPSimpleSensorArea(test_data, PerModuleRNG(2021), fillfactor=0.9)
 
-    expected = [
-        894816,
-        894838,
-        897478,
-        901987,
-        902035,
-        907363,
-        907416,
-        907470,
-        909426,
-        909452,
-        910850,
-        910872,
-    ]
+    expected = [894816, 894838, 897478, 897521, 901987, 902035, 907363, 907416, 907470, 909426]
 
     assert_equal(expected, test_out["FieldID"].values)
 
@@ -61,7 +48,7 @@ def test_PPApplyFOVFilters():
     from sorcha.modules.PPApplyFOVFilter import PPApplyFOVFilter
     from sorcha.modules.PPFootprintFilter import Footprint
 
-    observations = pd.read_csv(get_test_filepath("test_input_fullobs.csv"), nrows=20)
+    observations = pd.read_csv(get_test_filepath("test_input_fullobs.csv"), nrows=10)
 
     rng = PerModuleRNG(2021)
 
@@ -73,52 +60,45 @@ def test_PPApplyFOVFilters():
     }
 
     new_obs = PPApplyFOVFilter(observations, configs, rng)
-    expected = [897478, 897521, 901987, 902035, 907363, 907416, 907470, 910850, 910872]
+    expected = [897478, 897521, 901987, 902035, 907363, 907416, 907470]
 
     assert_equal(new_obs["FieldID"].values, expected)
 
     configs = {
         "camera_model": "circle",
-        "fill_factor": 0.5,
+        "fill_factor": 0.9,
         "circle_radius": None,
         "footprint_edge_threshold": None,
     }
 
     new_obs = PPApplyFOVFilter(observations, configs, rng)
-    expected = [894816, 894838, 897478, 897521, 901987, 907416, 907470, 910850, 922034, 922035, 926281]
+    expected = [894816, 894838, 897478, 897521, 901987, 902035, 907363, 907416, 907470, 909426]
 
     assert_equal(new_obs["FieldID"].values, expected)
 
     configs = {
         "camera_model": "footprint",
         "footprint_path": get_test_filepath("detectors_corners.csv"),
-        "footprint_edge_threshold": 10.0,
+        "footprint_edge_threshold": None,
     }
     footprint = Footprint(configs["footprint_path"])
     new_obs = PPApplyFOVFilter(observations, configs, rng, footprint=footprint)
-    expected = [
-        894816,
-        894838,
-        897478,
-        897521,
-        902035,
-        907363,
-        907416,
-        907470,
-        909426,
-        909452,
-        910850,
-        915246,
-        915268,
-        922013,
-        922034,
-        922035,
-        926281,
-        926288,
+
+    expected_ids = [
+        35.0,
+        35.0,
+        60.0,
+        88.0,
+        100.0,
+        106.0,
+        114.0,
+        127.0,
+        130.0,
+        130.0,
     ]
 
-    assert_equal(new_obs["FieldID"].values, expected)
+    assert set(new_obs["detectorID"].values) == set(expected_ids)
 
     configs = {"camera_model": "none"}
     new_obs = PPApplyFOVFilter(observations, configs, rng)
-    assert len(new_obs) == 20
+    assert len(new_obs) == 10

--- a/tests/sorcha/test_PPConfigParser.py
+++ b/tests/sorcha/test_PPConfigParser.py
@@ -73,6 +73,8 @@ def test_PPConfigFileParser(setup_and_teardown_for_PPConfigFileParser):
         "magnitude_decimals": 3,
         "size_serial_chunk": 10,
         "lc_model": None,
+        "randomization_on": True,
+        "vignetting_on": True,
     }
 
     assert configs == test_configs
@@ -292,6 +294,8 @@ def test_PPPrintConfigsToLog(tmp_path):
         "mainfilter": "r",
         "othercolours": ["g-r", "i-r", "z-r"],
         "lc_model": None,
+        "randomization_on": True,
+        "vignetting_on": True,
     }
 
     PPPrintConfigsToLog(configs, args)


### PR DESCRIPTION
Fixes #901.
- There is now a hidden config key in the [EXPERT] section, "vignetting_on", which can be used to turn vignetting on and off. By default if the key is not included, this will be set to True.

Fixes #899.
- Setting "camera_model" to "none" in the config file results in no camera model being applied.

Fixes #897.
- There is now a hidden config variable in the [EXPERT] section, "randomization_on", which can be used to turn randomization on and off. By default if the key is not included, this will be set to True.

For all of the above:
- Relevant messages are printed to the log to let the user know what is happening.
- Unit tests have been updated, including testing the expected behaviour when randomisation and camera model are turned off.
- A notebook has also been updated.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
