### PR TITLE
Adding custom output option.

### DIFF
--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -673,10 +673,23 @@ def PPConfigFileParser(configfile, survey_name):
 
     config_dict["output_size"] = PPGetOrExit(
         config, "OUTPUT", "output_size", "ERROR: output size not specified."
-    ).lower()
-    if config_dict["output_size"] not in ["basic", "all"]:
-        pplogger.error("ERROR: output_size not recognised.")
-        sys.exit("ERROR: output_size not recognised.")
+    )
+
+    if (config_dict["output_size"] not in ["basic", "all"]) and ("," not in config_dict["output_size"]):
+        pplogger.error(
+            "ERROR: output_size not recognised. Must be 'basic', 'all', or a comma-separated list of columns."
+        )
+        sys.exit(
+            "ERROR: output_size not recognised. Must be 'basic', 'all', or a comma-separated list of columns."
+        )
+
+    # note: if providing a comma-separated list of column names, this is NOT ERROR-HANDLED
+    # as we have no way of knowing ahead of time of columns that user-generated code or add-ons may add.
+
+    if (
+        "," in config_dict["output_size"]
+    ):  # assume list of column names: turn into a list and strip whitespace
+        config_dict["output_size"] = [colname.strip(" ") for colname in config_dict["output_size"].split(",")]
 
     config_dict["position_decimals"], _ = PPGetValueAndFlag(config, "OUTPUT", "position_decimals", "int")
     config_dict["magnitude_decimals"], _ = PPGetValueAndFlag(config, "OUTPUT", "magnitude_decimals", "int")
@@ -945,4 +958,7 @@ def PPPrintConfigsToLog(configs, cmd_args):
         + str(configs["magnitude_decimals"])
         + " decimal places."
     )
-    pplogger.info("The output size is set to: " + configs["output_size"])
+    if isinstance(configs["output_size"], list):
+        pplogger.info("The output size is set to: " + " ".join(configs["output_size"]))
+    else:
+        pplogger.info("The output size is set to: " + configs["output_size"])

--- a/src/sorcha/modules/PPOutput.py
+++ b/src/sorcha/modules/PPOutput.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import numpy as np
 import os
+import sys
 import sqlite3
 import logging
 
@@ -155,6 +156,16 @@ def PPWriteOutput(cmd_args, configs, observations_in, endChunk=0, verbose=False)
         ]
     elif configs["output_size"] == "all":
         observations = observations_in.copy()
+    elif len(configs["output_size"]) > 1:  # assume a list of column names...
+        try:
+            observations = observations_in.copy()[configs["output_size"]]
+        except KeyError:
+            pplogger.error(
+                "ERROR: at least one of the columns provided in output_size does not seem to exist. Check docs and try again."
+            )
+            sys.exit(
+                "ERROR: at least one of the columns provided in output_size does not seem to exist. Check docs and try again."
+            )
 
     if configs["position_decimals"]:
         for position_col in [

--- a/tests/sorcha/test_PPOutput.py
+++ b/tests/sorcha/test_PPOutput.py
@@ -7,51 +7,16 @@ from numpy.testing import assert_equal
 
 from sorcha.utilities.dataUtilitiesForTests import get_test_filepath
 from sorcha.utilities.sorchaArguments import sorchaArguments
+from sorcha.modules.PPOutput import PPWriteOutput
 
 
-@pytest.fixture
-def setup_and_teardown_for_PPOutWriteCSV():
-    yield
-
-    tmp_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
-
-    os.remove(os.path.join(tmp_path, "test_csv_out.csv"))
+# some global variables used by tests
+observations = pd.read_csv(get_test_filepath("test_input_fullobs.csv"), nrows=1)
+args = sorchaArguments()
 
 
-@pytest.fixture
-def setup_and_teardown_for_PPOutWriteHDF5():
-    yield
-
-    tmp_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
-
-    os.remove(os.path.join(tmp_path, "test_hdf5_out.h5"))
-
-
-@pytest.fixture
-def setup_and_teardown_for_PPOutWriteSqlite3():
-    yield
-
-    tmp_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
-
-    os.remove(os.path.join(tmp_path, "test_sql_out.db"))
-
-
-@pytest.fixture
-def setup_and_teardown_for_PPWriteOutput():
-    yield
-
-    tmp_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
-
-    os.remove(os.path.join(tmp_path, "PPOutput_test_out.csv"))
-    os.remove(os.path.join(tmp_path, "PPOutput_test_out.db"))
-    os.remove(os.path.join(tmp_path, "PPOutput_test_all.csv"))
-
-
-def test_PPOutWriteCSV(setup_and_teardown_for_PPOutWriteCSV):
+def test_PPOutWriteCSV(tmp_path):
     from sorcha.modules.PPOutput import PPOutWriteCSV
-
-    observations = pd.read_csv(get_test_filepath("test_input_fullobs.csv"), nrows=1)
-    tmp_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
 
     PPOutWriteCSV(observations, os.path.join(tmp_path, "test_csv_out.csv"))
 
@@ -59,14 +24,9 @@ def test_PPOutWriteCSV(setup_and_teardown_for_PPOutWriteCSV):
 
     pd.testing.assert_frame_equal(observations, test_in)
 
-    return
 
-
-def test_PPOutWriteSqlite3(setup_and_teardown_for_PPOutWriteSqlite3):
+def test_PPOutWriteSqlite3(tmp_path):
     from sorcha.modules.PPOutput import PPOutWriteSqlite3
-
-    observations = pd.read_csv(get_test_filepath("test_input_fullobs.csv"), nrows=1)
-    tmp_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
 
     PPOutWriteSqlite3(observations, os.path.join(tmp_path, "test_sql_out.db"))
 
@@ -79,14 +39,9 @@ def test_PPOutWriteSqlite3(setup_and_teardown_for_PPOutWriteSqlite3):
 
     pd.testing.assert_frame_equal(observations, test_in)
 
-    return
 
-
-def test_PPOutWriteHDF5(setup_and_teardown_for_PPOutWriteHDF5):
+def test_PPOutWriteHDF5(tmp_path):
     from sorcha.modules.PPOutput import PPOutWriteHDF5
-
-    observations = pd.read_csv(get_test_filepath("test_input_fullobs.csv"), nrows=1)
-    tmp_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
 
     PPOutWriteHDF5(observations, os.path.join(tmp_path, "test_hdf5_out.h5"), "testchunk")
 
@@ -94,16 +49,8 @@ def test_PPOutWriteHDF5(setup_and_teardown_for_PPOutWriteHDF5):
 
     pd.testing.assert_frame_equal(observations, test_in)
 
-    return
 
-
-def test_PPWriteOutput(setup_and_teardown_for_PPWriteOutput):
-    from sorcha.modules.PPOutput import PPWriteOutput
-
-    observations = pd.read_csv(get_test_filepath("test_input_fullobs.csv"), nrows=1)
-    tmp_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
-
-    args = sorchaArguments()
+def test_PPWriteOutput_csv(tmp_path):
     args.outpath = tmp_path
     args.outfilestem = "PPOutput_test_out"
 
@@ -113,17 +60,6 @@ def test_PPWriteOutput(setup_and_teardown_for_PPWriteOutput):
         "magnitude_decimals": 3,
         "output_format": "csv",
     }
-
-    PPWriteOutput(args, configs, observations, 10)
-    csv_test_in = pd.read_csv(os.path.join(tmp_path, "PPOutput_test_out.csv"))
-
-    configs["output_format"] = "sqlite3"
-    PPWriteOutput(args, configs, observations, 10)
-    cnx = sqlite3.connect(os.path.join(tmp_path, "PPOutput_test_out.db"))
-    cur = cnx.cursor()
-    cur.execute("select * from sorcha_results")
-    col_names = list(map(lambda x: x[0], cur.description))
-    sql_test_in = pd.DataFrame(cur.fetchall(), columns=col_names)
 
     expected = np.array(
         [
@@ -146,9 +82,56 @@ def test_PPWriteOutput(setup_and_teardown_for_PPWriteOutput):
         dtype=object,
     )
 
+    # test basic CSV
+
+    PPWriteOutput(args, configs, observations, 10)
+    csv_test_in = pd.read_csv(os.path.join(tmp_path, "PPOutput_test_out.csv"))
     assert_equal(csv_test_in.loc[0, :].values, expected)
+
+
+def test_PPWriteOutput_sql(tmp_path):
+    args.outpath = tmp_path
+    args.outfilestem = "PPOutput_test_out"
+
+    configs = {
+        "output_size": "basic",
+        "position_decimals": 7,
+        "magnitude_decimals": 3,
+        "output_format": "sqlite3",
+    }
+
+    expected = np.array(
+        [
+            "S1000000a",
+            61769.320619,
+            163.8754209,
+            -18.8432714,
+            164.037713,
+            -17.582575,
+            3e-06,
+            "r",
+            19.648,
+            0.007,
+            23.839,
+            18.341701,
+            393817194.335,
+            -22.515,
+            453089476.3503012,
+        ],
+        dtype=object,
+    )
+
+    PPWriteOutput(args, configs, observations, 10)
+    cnx = sqlite3.connect(os.path.join(tmp_path, "PPOutput_test_out.db"))
+    cur = cnx.cursor()
+    cur.execute("select * from sorcha_results")
+    col_names = list(map(lambda x: x[0], cur.description))
+    sql_test_in = pd.DataFrame(cur.fetchall(), columns=col_names)
+
     assert_equal(sql_test_in.loc[0, :].values, expected)
 
+
+def test_PPWriteOutput_all(tmp_path):
     # additional test to ensure that "all" output option and no rounding works
 
     configs = {
@@ -158,6 +141,7 @@ def test_PPWriteOutput(setup_and_teardown_for_PPWriteOutput):
         "output_format": "csv",
     }
 
+    args.outpath = tmp_path
     args.outfilestem = "PPOutput_test_all"
 
     PPWriteOutput(args, configs, observations, 10)
@@ -230,4 +214,34 @@ def test_PPWriteOutput(setup_and_teardown_for_PPWriteOutput):
 
     assert_equal(all_test_in.loc[0, :].values, expected_all)
 
-    return
+
+def test_PPWriteOutput_custom(tmp_path):
+    configs = {
+        "output_size": ["ObjID", "fieldMJD_TAI"],
+        "position_decimals": 7,
+        "magnitude_decimals": 3,
+        "output_format": "csv",
+    }
+
+    args.outpath = tmp_path
+    args.outfilestem = "PPOutput_test_multi"
+
+    PPWriteOutput(args, configs, observations, 10)
+
+    multi_test_in = pd.read_csv(os.path.join(tmp_path, "PPOutput_test_multi.csv"))
+
+    expected_multi = np.array(["S1000000a", 61769.320619], dtype=object)
+
+    assert_equal(multi_test_in.loc[0, :].values, expected_multi)
+
+    # and now we test the error message
+
+    configs["output_size"] = ["ObjID", "fieldMJD_TAI", "dummy_column"]
+
+    with pytest.raises(SystemExit) as e:
+        PPWriteOutput(args, configs, observations, 10)
+
+    assert (
+        e.value.code
+        == "ERROR: at least one of the columns provided in output_size does not seem to exist. Check docs and try again."
+    )


### PR DESCRIPTION
Fixes #828.
- Supplying a comma-separated list of column names for the output_size keyword in the configuration file will limit your output to just those columns.
- If the user supplies a column name that doesn't exist, the code will fail ON OUTPUT - there is no error-handling beforehand as we don't necessarily know ahead of time what columns will be in the dataframe. (Users may, for example, write their own modules or add-ons which add new columns.) Users should test their config file works before they do large runs.
- Wrote a unit test to cover custom column output.
- Cleaned up the unit tests for PPOutput while I was in there.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
