### PR TITLE
Move randomisation

### DIFF
--- a/docs/notebooks/demo_UncertaintiesAndRandomization.ipynb
+++ b/docs/notebooks/demo_UncertaintiesAndRandomization.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "from sorcha.modules.PPAddUncertainties import addUncertainties\n",
-    "from sorcha.modules.PPRandomizeMeasurements import randomizeAstrometryandPhotometry, randomizePhotometry\n",
+    "from sorcha.modules.PPRandomizeMeasurements import randomizeAstrometryAndPhotometry, randomizePhotometry\n",
     "from sorcha.modules.PPModuleRNG import PerModuleRNG"
    ]
   },

--- a/docs/notebooks/demo_UncertaintiesAndRandomization.ipynb
+++ b/docs/notebooks/demo_UncertaintiesAndRandomization.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "from sorcha.modules.PPAddUncertainties import addUncertainties\n",
-    "from sorcha.modules.PPRandomizeMeasurements import randomizeAstrometryAndPhotometry, randomizePhotometry\n",
+    "from sorcha.modules.PPRandomizeMeasurements import randomizeAstrometryAndPhotometry, randomizeAstrometry\n",
     "from sorcha.modules.PPModuleRNG import PerModuleRNG"
    ]
   },

--- a/docs/notebooks/demo_UncertaintiesAndRandomization.ipynb
+++ b/docs/notebooks/demo_UncertaintiesAndRandomization.ipynb
@@ -14,7 +14,7 @@
    "outputs": [],
    "source": [
     "from sorcha.modules.PPAddUncertainties import addUncertainties\n",
-    "from sorcha.modules.PPRandomizeMeasurements import randomizeAstrometry\n",
+    "from sorcha.modules.PPRandomizeMeasurements import randomizeAstrometryandPhotometry, randomizePhotometry\n",
     "from sorcha.modules.PPModuleRNG import PerModuleRNG"
    ]
   },
@@ -98,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "configs = {'trailing_losses_on':True, 'default_SNR_cut': False, 'randomization_on':True}\n",
+    "configs = {'trailing_losses_on':True, 'default_SNR_cut': False}\n",
     "rng = PerModuleRNG(2012)"
    ]
   },
@@ -108,7 +108,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obs_uncert = addUncertainties(observations, configs, rng)"
+    "obs_uncert_1 = addUncertainties(observations, configs, rng)\n",
+    "obs_uncert = randomizeAstrometryAndPhotometry(obs_uncert_1, configs, rng)"
    ]
   },
   {

--- a/src/sorcha/modules/PPAddUncertainties.py
+++ b/src/sorcha/modules/PPAddUncertainties.py
@@ -108,31 +108,6 @@ def addUncertainties(detDF, configs, module_rngs, verbose=True):
     else:
         detDF["PSFMagSigma"] = detDF["trailedSourceMagSigma"]
 
-    # default SNR cut can be disabled in the config file under EXPERT
-    # at low SNR, high photometric sigma causes randomisation to sometimes
-    # grossly inflate/decrease magnitudes.
-    if configs.get("default_SNR_cut", False):
-        verboselog("Removing all observations with SNR < 2.0...")
-        detDF = PPSNRLimit(detDF.copy(), 2.0)
-
-    if configs["randomization_on"]:
-        verboselog("Randomising photometry...")
-        detDF["trailedSourceMag"] = PPRandomizeMeasurements.randomizePhotometry(
-            detDF, module_rngs, magName="trailedSourceMagTrue", sigName="trailedSourceMagSigma"
-        )
-
-        if configs.get("trailing_losses_on", False):
-            detDF["PSFMag"] = PPRandomizeMeasurements.randomizePhotometry(
-                detDF, module_rngs, magName="PSFMagTrue", sigName="PSFMagSigma"
-            )
-        else:
-            detDF["PSFMag"] = detDF["trailedSourceMag"]
-
-    else:
-        verboselog("Randomization turned off in config file. No magnitude randomization performed.")
-        detDF["trailedSourceMag"] = detDF["trailedSourceMagTrue"].copy()
-        detDF["PSFMag"] = detDF["PSFMagTrue"].copy()
-
     return detDF
 
 

--- a/src/sorcha/modules/PPRandomizeMeasurements.py
+++ b/src/sorcha/modules/PPRandomizeMeasurements.py
@@ -34,7 +34,35 @@ logger = logging.getLogger(__name__)
 def randomizeAstrometryAndPhotometry(observations, configs, module_rngs, verbose=False):
     """
     Wrapper function to perform randomisation of astrometry and photometry around
-    their uncertainties.
+    their uncertainties. Calls randomizePhotometry() and randomizeAstrometry().
+
+    Adds the following columns to the dataframe:
+    - trailedSourceMag
+    - PSFMag
+    - AstRATrue(deg)
+    - AstDecTrue(deg)
+
+    Parameters
+    -----------
+    observations : pandas dataframe
+       Dataframe containing observations.
+
+    configs : dict
+       Dictionary of config file variables.
+
+    module_rngs : PerModuleRNG
+       A collection of random number generators (per module).
+
+    verbose : bool
+       Verbosity on or off. Default False.
+
+    Returns
+    ---------
+    observations : pandas dataframe
+       Original input dataframe with RA and Dec columns and trailedSourceMag and PSFMag
+       columns randomized around astrometric and photometric sigma. Original RA and Dec/magnitudes
+       stored in separate columns.
+
     """
 
     verboselog = logger.info if verbose else lambda *a, **k: None

--- a/src/sorcha/modules/PPRandomizeMeasurements.py
+++ b/src/sorcha/modules/PPRandomizeMeasurements.py
@@ -22,12 +22,48 @@ import numpy as np
 import sys
 import logging
 from sorcha.modules.PPModuleRNG import PerModuleRNG
+from sorcha.modules.PPSNRLimit import PPSNRLimit
 
 import pandas as pd
 
 pd.options.mode.copy_on_write = True
 
 logger = logging.getLogger(__name__)
+
+
+def randomizeAstrometryAndPhotometry(observations, configs, module_rngs, verbose=False):
+    """
+    Wrapper function to perform randomisation of astrometry and photometry around
+    their uncertainties.
+    """
+
+    verboselog = logger.info if verbose else lambda *a, **k: None
+
+    # default SNR cut can be disabled in the config file under EXPERT
+    # at low SNR, high photometric sigma causes randomisation to sometimes
+    # grossly inflate/decrease magnitudes.
+    if configs.get("default_SNR_cut", False):
+        verboselog("Removing all observations with SNR < 2.0...")
+        observations = PPSNRLimit(observations.copy(), 2.0)
+
+    verboselog("Randomising photometry...")
+    observations["trailedSourceMag"] = randomizePhotometry(
+        observations, module_rngs, magName="trailedSourceMagTrue", sigName="trailedSourceMagSigma"
+    )
+
+    if configs.get("trailing_losses_on", False):
+        observations["PSFMag"] = randomizePhotometry(
+            observations, module_rngs, magName="PSFMagTrue", sigName="PSFMagSigma"
+        )
+    else:
+        observations["PSFMag"] = observations["trailedSourceMag"]
+
+    verboselog("Randomizing astrometry...")
+    observations = randomizeAstrometry(
+        observations, module_rngs, sigName="astrometricSigma_deg", sigUnits="deg"
+    )
+
+    return observations
 
 
 def randomizeAstrometry(

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -236,8 +236,6 @@ def runLSSTSimulation(args, configs):
         # These are the columns that should be used moving forward for filters etc.
         # Do NOT use trailedSourceMagTrue or PSFMagTrue, these are the unrandomised magnitudes.
         verboselog("Calculating astrometric and photometric uncertainties...")
-        if configs["randomization_on"]:
-            verboselog("Values are then used to randomize the photometry....")
         verboselog(
             "Number of rows BEFORE caclulating astrometric and photometric uncertainties : "
             + str(len(observations.index))
@@ -252,17 +250,24 @@ def runLSSTSimulation(args, configs):
         )
 
         if configs["randomization_on"]:
-            verboselog("Randomizing astrometry...")
-            observations = PPRandomizeMeasurements.randomizeAstrometry(
-                observations, args._rngs, sigName="astrometricSigma_deg", sigUnits="deg"
+            observations = PPRandomizeMeasurements.randomizeAstrometryAndPhotometry(
+                observations, configs, args._rngs, verbose=args.verbose
             )
+
         else:
-            verboselog("Randomization turned off in config file. No astrometric randomization performed.")
+            verboselog(
+                "Randomization turned off in config file. No astrometric or photometric randomization performed."
+            )
             verboselog(
                 "NOTE: new columns RATrue_deg and DecTrue_deg are EQUAL to columns RA_deg and Dec_deg."
             )
+            verboselog(
+                "NOTE: columns trailedSourceMagTrue and PSFMagTrue are EQUAL to columns trailedSourceMag and PSFMag."
+            )
             observations["RATrue_deg"] = observations["RA_deg"].copy()
             observations["DecTrue_deg"] = observations["Dec_deg"].copy()
+            observations["trailedSourceMag"] = observations["trailedSourceMagTrue"].copy()
+            observations["PSFMag"] = observations["PSFMagTrue"].copy()
 
         verboselog("Applying field-of-view filters...")
         verboselog("Number of rows BEFORE applying FOV filters: " + str(len(observations.index)))

--- a/tests/sorcha/test_PPAddUncertainty.py
+++ b/tests/sorcha/test_PPAddUncertainty.py
@@ -104,7 +104,7 @@ def test_addUncertainties():
         }
     )
 
-    configs = {"trailing_losses_on": True, "default_SNR_cut": False, "randomization_on": True}
+    configs = {"trailing_losses_on": True, "default_SNR_cut": False}
 
     rng = PerModuleRNG(2021)
 
@@ -123,32 +123,6 @@ def test_addUncertainties():
         decimal=6,
     )
     assert_almost_equal(obs_uncert["SNR"], [24.941285, 10.303786, 4.166240, 0.000168], decimal=6)
-    assert_almost_equal(
-        obs_uncert["trailedSourceMag"],
-        [21.0419, 22.0064, 23.1822, 37.3978],
-        decimal=4,
-    )
-    assert_almost_equal(obs_uncert["PSFMag"], [21.239301, 22.050202, 23.006519, 37.514547], decimal=6)
-
-    configs_notrail = {"trailing_losses_on": False, "default_SNR_cut": False, "randomization_on": True}
-
-    obs_notrail = addUncertainties(test_data, configs_notrail, rng)
-
-    assert_equal(
-        obs_notrail["PSFMagSigma"].values,
-        obs_notrail["trailedSourceMagSigma"].values,
-    )
-
-    configs_SNRcut = {"trailing_losses_on": False, "default_SNR_cut": True, "randomization_on": True}
-
-    obs_SNRcut = addUncertainties(test_data, configs_SNRcut, rng)
-
-    assert_equal(obs_SNRcut["ObjID"].values, ["a21", "b22", "c23"])
-
-    configs_norand = {"trailing_losses_on": False, "default_SNR_cut": False, "randomization_on": False}
-    obs_norand = addUncertainties(test_data, configs_norand, rng)
-
-    assert_almost_equal(obs_norand["PSFMag"], [21.2, 22.2, 23.2, 34.2])
 
     return
 
@@ -170,7 +144,7 @@ def test_uncertainties():
         }
     )
 
-    configs = {"trailing_losses_on": False, "randomization_on": True}
+    configs = {"trailing_losses_on": False}
 
     ast_sig_deg, photo_sig, SNR = uncertainties(observations, configs)
 

--- a/tests/sorcha/test_PPRandomizeMeasurements.py
+++ b/tests/sorcha/test_PPRandomizeMeasurements.py
@@ -93,3 +93,37 @@ def test_flux_mag_conversion():
     assert_almost_equal(observations["trailedSourceMag"][0], mag_test.values[0])
 
     return
+
+
+def test_randomizeAstrometryAndPhotometry():
+    from sorcha.modules.PPRandomizeMeasurements import randomizeAstrometryAndPhotometry
+
+    data_in = {
+        "RA_deg": 164.037713,
+        "Dec_deg": -17.582575,
+        "trailedSourceMagTrue": 19.655346,
+        "trailedSourceMagSigma": 0.006756,
+        "PSFMagTrue": 19.659713,
+        "PSFMagSigma": 0.006776,
+        "astrometricSigma_deg": 0.000003,
+        "SNR": 159.741315,
+    }
+
+    observations = pd.DataFrame(data_in, index=[0])
+
+    configs = {"default_SNR_cut": True, "trailing_losses_on": True}
+
+    obs_out = randomizeAstrometryAndPhotometry(observations, configs, PerModuleRNG(2021))
+
+    assert_almost_equal(obs_out["trailedSourceMag"][0], 19.663194, decimal=6)
+    assert_almost_equal(obs_out["PSFMag"][0], 19.660227, decimal=6)
+    assert_almost_equal(obs_out["RA_deg"][0], 164.037711, decimal=6)
+    assert_almost_equal(obs_out["Dec_deg"][0], -17.582573, decimal=6)
+
+    assert obs_out["RATrue_deg"][0] == data_in["RA_deg"]
+    assert obs_out["DecTrue_deg"][0] == data_in["Dec_deg"]
+
+    configs["trailing_losses_on"] = False
+
+    obs_out_noloss = randomizeAstrometryAndPhotometry(observations, configs, PerModuleRNG(2021))
+    assert obs_out_noloss["PSFMag"][0] == obs_out_noloss["trailedSourceMag"][0]


### PR DESCRIPTION
Fixes #922.
- Moved photometric randomisation out of PPAddUncertainties and put it along with astrometric randomisation into its own wrapper function, `PPRandomizeMeasurements.randomizeAstrometryAndPhotometry()`. This tidies some more logic out of sorcha.py.
- Edited the unit test for `PPAddUncertainties.addUncertainties()` to remove testing of randomisation.
- Made a new unit test for `PPRandomizeMeasurements.randomizeAstrometryAndPhotometry()`.
- Edited the relevant notebook so it still works.
- Spelled it "randomization" with the z in the code despite every instinct in my body screaming in protest.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
