### PR TITLE
Adding indexes to SQL outputs.

### DIFF
--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -161,6 +161,7 @@ def runLSSTSimulation(args, configs):
     startChunk = 0
     endChunk = 0
     loopCounter = 0
+    lastChunk = False
 
     ii = -1
     with open(args.orbinfile) as f:
@@ -177,6 +178,9 @@ def runLSSTSimulation(args, configs):
         verboselog("Starting main Sorcha processing loop round {}".format(loopCounter))
         endChunk = startChunk + configs["size_serial_chunk"]
         verboselog("Working on objects {}-{}".format(startChunk, endChunk))
+
+        if endChunk >= lenf:
+            lastChunk = True
 
         # Processing begins, all processing is done for chunks
         if configs["ephemerides_type"].casefold() == "external":
@@ -334,7 +338,7 @@ def runLSSTSimulation(args, configs):
         pplogger.info("Output results for this chunk")
 
         # write output
-        PPWriteOutput(args, configs, observations, endChunk, verbose=args.verbose)
+        PPWriteOutput(args, configs, observations, endChunk, verbose=args.verbose, lastchunk=lastChunk)
 
         startChunk = startChunk + configs["size_serial_chunk"]
         loopCounter = loopCounter + 1

--- a/tests/sorcha/test_PPOutput.py
+++ b/tests/sorcha/test_PPOutput.py
@@ -121,7 +121,7 @@ def test_PPWriteOutput_sql(tmp_path):
         dtype=object,
     )
 
-    PPWriteOutput(args, configs, observations, 10)
+    PPWriteOutput(args, configs, observations, 10, lastchunk=True)
     cnx = sqlite3.connect(os.path.join(tmp_path, "PPOutput_test_out.db"))
     cur = cnx.cursor()
     cur.execute("select * from sorcha_results")
@@ -129,6 +129,13 @@ def test_PPWriteOutput_sql(tmp_path):
     sql_test_in = pd.DataFrame(cur.fetchall(), columns=col_names)
 
     assert_equal(sql_test_in.loc[0, :].values, expected)
+
+    # check indexes were properly created
+    cur.execute("PRAGMA index_list('sorcha_results')")
+    indexes = cur.fetchall()
+
+    index_list = [indexes[i][1] for i in range(0, 3)]
+    assert index_list == ["optFilter", "fieldMJD_TAI", "ObjID"]
 
 
 def test_PPWriteOutput_all(tmp_path):


### PR DESCRIPTION
Fixes #930.
- Added single-column indexes for the ObjID, optFilter and fieldMJD_TAI columns for SQL output. It is trivial to add other indexes if required.
- I did not add a composite index because I was not sure how helpful it would be or what order would be best, but this could be very simply added.
- The code does not index the table until the very last chunk. This is because recreating the index every time rows are added is apparently slow.
- Added a variable to sorcha.py that triggers if the code is on the last chunk.
- Added a `tablename` variable to `PPOutWriteSqlite3()` to prepare for writing ephemeris data to SQLite as well.
- Added to the unit test to check that the indexes are correctly created.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
