### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "numpy",
+    "numpy<2.0",
     "pandas>=2.0",
     "astropy",
     "matplotlib",
@@ -68,7 +68,7 @@ dev = [
     "ipython", # Also used in building notebooks into Sphinx
     "ipykernel",
     "matplotlib", # Used in sample notebook intro_notebook.ipynb
-    "numpy", # Used in sample notebook intro_notebook.ipynb
+    "numpy<2.0", # Used in sample notebook intro_notebook.ipynb
 ]
 
 test = [


### PR DESCRIPTION
pinning numpy to < 2.0 temporarily

Fixes #962 

Pinning numpy to less than 2.0 to see if we can get unit tests working again