### PR TITLE
Adding stats file output to demo command.

### DIFF
--- a/src/sorcha/modules/PPStats.py
+++ b/src/sorcha/modules/PPStats.py
@@ -3,7 +3,7 @@ import pandas as pd
 import os
 
 
-def stats(observations, statsfilepath):
+def stats(observations, statsfilename, outpath):
     """
     Write a summary statistics file including whether each object was linked
     or not within miniDifi, their number of observations, min/max phase angles,
@@ -15,14 +15,16 @@ def stats(observations, statsfilepath):
     observations : Pandas dataframe
         Pandas dataframe of observations
 
-    statsfilepath : string
-        Path to write summary stats file to
+    statsfilename : string
+        Stem filename to write summary stats file to
 
     Returns
     -------
     None.
 
     """
+
+    statsfilepath = os.path.join(outpath, statsfilename + ".csv")
 
     group_by = observations.groupby(["ObjID", "optFilter"])
 

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -343,7 +343,7 @@ def runLSSTSimulation(args, configs):
         PPWriteOutput(args, configs, observations, endChunk, verbose=args.verbose, lastchunk=lastChunk)
 
         if args.stats is not None:
-            stats(observations, args.stats, configs["observing_filters"])
+            stats(observations, args.stats, args.outpath)
 
         startChunk = startChunk + configs["size_serial_chunk"]
         loopCounter = loopCounter + 1
@@ -491,7 +491,7 @@ def main():
     optional.add_argument(
         "-st",
         "--stats",
-        help="Output summary statistics table to this filename.",
+        help="Output summary statistics table to this stem filename.",
         type=str,
         dest="st",
         default=None,

--- a/src/sorcha/utilities/sorchaArguments.py
+++ b/src/sorcha/utilities/sorchaArguments.py
@@ -103,6 +103,3 @@ class sorchaArguments:
 
         if self.ar_data_file_path and not path.isdir(self.ar_data_file_path):
             raise ValueError("`ar_data_path` is not a valid directory.")
-
-        if self.stats and not path.isdir(path.dirname(self.stats)):
-            raise ValueError("`stats` is not a valid directory.")

--- a/src/sorcha/utilities/sorcha_demo_command.py
+++ b/src/sorcha/utilities/sorcha_demo_command.py
@@ -14,7 +14,7 @@ def get_demo_command():
         working sorcha demo command
     """
 
-    return "sorcha -c sorcha_config_demo.ini -p sspp_testset_colours.txt -ob sspp_testset_orbits.des -pd baseline_v2.0_1yr.db -o ./ -t testrun_e2e"
+    return "sorcha -c sorcha_config_demo.ini -p sspp_testset_colours.txt -ob sspp_testset_orbits.des -pd baseline_v2.0_1yr.db -o ./ -t testrun_e2e -st testrun_stats"
 
 
 def print_demo_command(printall=True):

--- a/tests/sorcha/test_PPStats.py
+++ b/tests/sorcha/test_PPStats.py
@@ -28,10 +28,10 @@ def test_PPStats(tmp_path):
     }
     test_df = pd.DataFrame(test_dict)
 
-    filepath_stats = os.path.join(tmp_path, "test_stats.csv")
-    stats(test_df, filepath_stats)
+    filename_stats = "test_stats"
+    stats(test_df, filename_stats, tmp_path)
 
-    stats_df = pd.read_csv(filepath_stats)
+    stats_df = pd.read_csv(os.path.join(tmp_path, filename_stats + ".csv"))
 
     # For comparison purposes, change NaNs to Nones
     stats_df.replace({np.nan: None}, inplace=True)

--- a/tests/sorcha/test_demo_command_line.py
+++ b/tests/sorcha/test_demo_command_line.py
@@ -26,6 +26,7 @@ def setup_and_teardown_for_demo_command_line():
     # After running the test, delete the created files...
 
     os.remove("testrun_e2e.csv")
+    os.remove("testrun_stats.csv")
 
     os.remove(glob.glob("*sorcha.err")[0])
     os.remove(glob.glob("*sorcha.log")[0])

--- a/tests/sorcha/test_sorchaArguments.py
+++ b/tests/sorcha/test_sorchaArguments.py
@@ -54,11 +54,3 @@ def test_validate_arguments():
         args.configfile = get_demo_filepath("NOPE.txt")
 
         args.validate_arguments()
-
-    args.configfile = get_demo_filepath("PPConfig_test.ini")
-
-    args.validate_arguments()
-
-    with pytest.raises(ValueError, match="stats"):
-        args.stats = "./imaginary_folder/test.csv"
-        args.validate_arguments()


### PR DESCRIPTION
Fixes #965.
- Added the tally file to the standard demo command.
- Changed the behaviour so that the user supplies a filename stem only on the command line if they wish to output the tally file (`-st <filestem>`). The tally file is thus saved in the same place as all the other outputs (defined with the -o flag).
- Fixed a bug where too many arguments were being supplied to the call to `PPStats.stats() `in sorcha.py.
- Updated unit tests.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
