### PR TITLE
Removing deprecation warning.

### DIFF
--- a/src/sorcha/modules/PPStats.py
+++ b/src/sorcha/modules/PPStats.py
@@ -26,7 +26,7 @@ def stats(observations, statsfilename, outpath):
 
     statsfilepath = os.path.join(outpath, statsfilename + ".csv")
 
-    group_by = observations.groupby(["ObjID", "optFilter"])
+    group_by = observations.groupby(["ObjID", "optFilter"], observed=False)
 
     mag = (
         group_by["trailedSourceMag"]


### PR DESCRIPTION
Fixes #968.
- Prevents Pandas deprecation warning while maintaining expected behaviour for the call to `groupby()` in `PPStats.stats()`.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
