### PR TITLE
Force-removing stats file with -f

### DIFF
--- a/src/sorcha/modules/PPCommandLineParser.py
+++ b/src/sorcha/modules/PPCommandLineParser.py
@@ -88,6 +88,10 @@ def PPCommandLineParser(args):
     cmd_args_dict["verbose"] = args.v
     cmd_args_dict["stats"] = args.st
 
+    warn_or_remove_file(
+        os.path.join(cmd_args_dict["outpath"], cmd_args_dict["stats"] + ".csv"), args.f, pplogger
+    )
+
     cmd_args_dict["ar_data_path"] = args.ar  # default value for args.ar is `None`.
     if cmd_args_dict["ar_data_path"]:
         PPFindDirectoryOrExit(cmd_args_dict["ar_data_path"], "-ar, --ar_data_path")


### PR DESCRIPTION
Fixes #970.
- The code now stops if it detects an existing stats file with the same filename and `-f` is not set. The stats file is force-overwritten if `-f` is set.
- Oops. Sorry.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
