### PR TITLE
Making tally file work if linking is off

### DIFF
--- a/src/sorcha/modules/PPStats.py
+++ b/src/sorcha/modules/PPStats.py
@@ -3,7 +3,7 @@ import pandas as pd
 import os
 
 
-def stats(observations, statsfilename, outpath):
+def stats(observations, statsfilename, outpath, linking=True):
     """
     Write a summary statistics file including whether each object was linked
     or not within miniDifi, their number of observations, min/max phase angles,
@@ -39,10 +39,14 @@ def stats(observations, statsfilename, outpath):
         group_by["phase_deg"].agg(["min", "max"]).rename(columns={"min": "min_phase", "max": "max_phase"})
     )
     num_obs = group_by.agg("size").to_frame("number_obs")
-    linked = group_by["object_linked"].agg("all").to_frame("object_linked")
-    date_linked = group_by["date_linked_MJD"].agg("first").to_frame("date_linked_MJD")
 
-    joined_stats = num_obs.join([mag, phase_deg, linked, date_linked])
+    if linking:
+        linked = group_by["object_linked"].agg("all").to_frame("object_linked")
+        date_linked = group_by["date_linked_MJD"].agg("first").to_frame("date_linked_MJD")
+        joined_stats = num_obs.join([mag, phase_deg, linked, date_linked])
+    else:
+        joined_stats = num_obs.join([mag, phase_deg])
+
     joined_stats.to_csv(
         path_or_buf=statsfilepath, mode="a", header=not os.path.exists(statsfilepath), index=True
     )

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -343,7 +343,7 @@ def runLSSTSimulation(args, configs):
         PPWriteOutput(args, configs, observations, endChunk, verbose=args.verbose, lastchunk=lastChunk)
 
         if args.stats is not None:
-            stats(observations, args.stats, args.outpath)
+            stats(observations, args.stats, args.outpath, linking=configs["SSP_linking_on"])
 
         startChunk = startChunk + configs["size_serial_chunk"]
         loopCounter = loopCounter + 1

--- a/tests/sorcha/test_PPStats.py
+++ b/tests/sorcha/test_PPStats.py
@@ -4,10 +4,10 @@ import numpy as np
 from numpy.testing import assert_equal
 import pytest
 
+from sorcha.modules.PPStats import stats
+
 
 def test_PPStats(tmp_path):
-    from sorcha.modules.PPStats import stats
-
     # make some simple test data
     ObjID = (["object_one"] * 10) + (["object_two"] * 5)
     Linked = ([True] * 10) + ([False] * 5)
@@ -72,3 +72,50 @@ def test_PPStats(tmp_path):
     assert_equal(expected_row_one, stats_df.iloc[0].values)
     assert_equal(expected_row_two, stats_df.iloc[1].values)
     assert_equal(expected_row_three, stats_df.iloc[2].values)
+
+
+def test_PPStats_nolinking(tmp_path):
+    ObjID = (["object_one"] * 10) + (["object_two"] * 5)
+    optFilter = (["r"] * 6) + (["g"] * 4) + (["r"] * 5)
+    trailedSourceMag = np.concatenate(
+        (np.linspace(18, 21, 6), np.linspace(19, 22, 4), np.linspace(20, 23, 5))
+    )
+    phase_deg = np.concatenate((np.linspace(3, 10, 6), np.linspace(4, 11, 4), np.linspace(5, 10, 5)))
+
+    test_dict = {
+        "ObjID": ObjID,
+        "optFilter": optFilter,
+        "trailedSourceMag": trailedSourceMag,
+        "phase_deg": phase_deg,
+    }
+
+    test_df = pd.DataFrame(test_dict)
+
+    filename_stats = "test_stats"
+    stats(test_df, filename_stats, tmp_path, linking=False)
+
+    stats_df = pd.read_csv(os.path.join(tmp_path, filename_stats + ".csv"))
+
+    assert len(stats_df) == 3
+
+    expected_columns = np.array(
+        [
+            "ObjID",
+            "optFilter",
+            "number_obs",
+            "min_apparent_mag",
+            "max_apparent_mag",
+            "median_apparent_mag",
+            "min_phase",
+            "max_phase",
+        ],
+        dtype="object",
+    )
+
+    assert_equal(expected_columns, stats_df.columns.values)
+
+    expected_row_one = np.array(["object_one", "g", 4, 19.0, 22.0, 20.5, 4.0, 11.0], dtype=object)
+
+    # the previous test checks all rows so it's fine to just check one here, this test is mostly to make
+    # sure that the stats file works correctly if linking is off
+    assert_equal(expected_row_one, stats_df.iloc[0].values)


### PR DESCRIPTION
Fixes #955.
- `PPStats.stats()` will no longer error out if linking is off but the tally file is requested. Instead it generates the tally file without the linking information.
- Made a new unit test to test this behaviour.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
