### PR TITLE
Fixing bug with external ephemeris read-in

### DIFF
--- a/demo/PPConfig_test_chunked.ini
+++ b/demo/PPConfig_test_chunked.ini
@@ -1,0 +1,175 @@
+# Sorcha Configuration File 
+
+
+[INPUT]
+
+# The simulation used for the ephemeris input. 
+# ar=ASSIST+REBOUND interal ephemeris generation 
+# external=providing an external input file from the command line
+# Options: "ar", "external"
+ephemerides_type = external
+
+# Format for ephemeris simulation input file if a file is specified at the command line. 
+# If reading from an existing temporary ephemeris database, this will be ignored.
+# Options: csv, whitespace, hdf5
+eph_format = csv
+
+# Sorcha chunk size: how many objects should be processed at once?
+size_serial_chunk = 5
+
+# Format for the orbit, physical parameters, and complex physical parameters input files.
+# Options: csv or whitespace
+aux_format = whitespace
+
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
+
+[FILTERS]
+
+# Filters of the observations you are interested in, comma-separated.
+# Your physical parameters file must have H calculated in one of these filters
+# and colour offset columns defined relative to that filter.
+observing_filters = r,g,i,z
+
+
+[SATURATION]
+
+# Upper magnitude limit on sources that will overfill the detector pixels/have
+# counts above the non-linearity regime of the pixels where one can’t do 
+# photometry. Objects brighter than this limit (in magnitude) will be cut. 
+# Comment out for no saturation limit.
+# Two formats are accepted:
+# Single float: applies same saturation limit to observations in all filters.
+# Comma-separated list of floats: applies saturation limit per filter, in order as
+# given in observing_filters keyword.
+bright_limit = 16.0
+
+
+[PHASECURVES]
+
+# The phase function used to calculate apparent magnitude. The physical parameters input
+# file must contain the columns needed to calculate the phase function.
+# Options: HG, HG1G2, HG12, linear, none.
+phase_function = HG
+
+
+[FOV]
+
+# Choose between circular or actual camera footprint, including chip gaps.
+# Options: circle, footprint.
+camera_model = footprint
+
+# Path to camera footprint file. Uncomment to provide a path to the desired camera 
+# detector configurationn file if not using the default built-in LSSTCam detector 
+# configuration or not using the circle footprint model.
+# footprint_path= ./data/detectors_corners.csv
+
+# Fraction of detector surface area which contains CCD -- simulates chip gaps
+# for OIF output. Comment out if using camera footprint.
+# Default: 0.9.
+# fill_factor = 0.9
+
+# Radius of the circle for a circular footprint (in degrees). Float.
+# Comment out or do not include if using footprint camera model.
+# circle_radius = 1.75
+
+# The distance from the edge of a detector (in arcseconds on the focal plane)
+# at which we will not correctly extract an object.
+# footprint_edge_threshold = 0.0001
+
+
+[FADINGFUNCTION]
+
+# Detection efficiency fading function on or off. Uses the fading function as outlined in
+# Chelsey and Vereš (2017) to remove observations.
+fading_function_on = False
+
+# Width parameter for fading function. Should be greater than zero and less than 0.5.
+# Suggested value is 0.1 after Chelsey and Vereš (2017).
+#fading_function_width = 0.1
+
+# Peak efficiency for the fading function, called the 'fill factor' in Chelsey and Veres (2017).
+# Suggested value is 1. Do not change this unless you are sure of what you are doing.
+#fading_function_peak_efficiency = 1.
+
+
+[LINKINGFILTER]
+
+# SSP detection efficiency. Which fraction of the objects will
+# the automated Rubin Solar System Processing (SSP) pipeline successfully link? Float. 
+#SSP_detection_efficiency = 0.95
+
+# Length of tracklets. How many observations of an object during one night are
+# required to produce a valid tracklet?
+#SSP_number_observations = 2
+
+# Minimum separation (in arcsec) between two observations of an object required 
+# for the linking software to distinguish them as separate and therefore as a valid tracklet.
+#SSP_separation_threshold = 0.5
+
+# Maximum time separation (in days) between subsequent observations # Maximum time separation (in days) between subsequent observations in a tracklet. 
+# Default is 0.0625 days (90mins). a tracklet. Default is 0.0625 days (90mins).
+#SSP_maximum_time = 0.0625
+
+# Number of tracklets for detection. How many tracklets are required to classify
+# an object as detected? 
+#SSP_number_tracklets = 3
+
+# The number of tracklets defined above must occur in <= this number of days to 
+# constitute a complete track/detection.
+#SSP_track_window = 15
+
+
+[SIMULATION]
+# Configs for running the ASSIST+REBOUND ephemerides generator.
+
+# the field of view of our search field, in degrees
+ar_ang_fov = 1.8
+
+# the buffer zone around the field of view we want to include, in degrees
+ar_fov_buffer = 0.2
+
+# the "picket" is our imprecise discretization of time that allows us to move progress
+# our simulations forward without getting too granular when we don't have to.
+# the unit is number of days.
+ar_picket = 1
+
+# the obscode is the MPC observatory code for the provided telescope.
+ar_obs_code = X05
+
+# the order of healpix which we will use for the healpy portions of the code.
+# the nside is equivalent to 2**ar_healpix_order
+ar_healpix_order = 6
+
+
+[OUTPUT]
+
+# Output format of the output file[s]
+# Options: csv, sqlite3, hdf5
+output_format = csv
+
+# Controls which columns are in the output files.
+# Options are "basic" and "all", which returns all columns.
+output_columns = basic
+
+
+[LIGHTCURVE]
+
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method 
+# of the subclasses of AbstractLightCurve. If not none, the complex physical parameters 
+# file must be specified at the command line.lc_model = none
+lc_model = none
+
+
+[ACTIVITY]
+
+# The unique name of the actvity model to use. Defined in the ``name_id`` method
+#  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
+# file must be specified at the command line.
+comet_activity = none
+
+
+[EXPERT]
+randomization_on = False
+vignetting_on = False
+trailing_losses_on = False

--- a/demo/PPConfig_test_unchunked.ini
+++ b/demo/PPConfig_test_unchunked.ini
@@ -1,0 +1,175 @@
+# Sorcha Configuration File 
+
+
+[INPUT]
+
+# The simulation used for the ephemeris input. 
+# ar=ASSIST+REBOUND interal ephemeris generation 
+# external=providing an external input file from the command line
+# Options: "ar", "external"
+ephemerides_type = external
+
+# Format for ephemeris simulation input file if a file is specified at the command line. 
+# If reading from an existing temporary ephemeris database, this will be ignored.
+# Options: csv, whitespace, hdf5
+eph_format = csv
+
+# Sorcha chunk size: how many objects should be processed at once?
+size_serial_chunk = 500000
+
+# Format for the orbit, physical parameters, and complex physical parameters input files.
+# Options: csv or whitespace
+aux_format = whitespace
+
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
+
+[FILTERS]
+
+# Filters of the observations you are interested in, comma-separated.
+# Your physical parameters file must have H calculated in one of these filters
+# and colour offset columns defined relative to that filter.
+observing_filters = r,g,i,z
+
+
+[SATURATION]
+
+# Upper magnitude limit on sources that will overfill the detector pixels/have
+# counts above the non-linearity regime of the pixels where one can’t do 
+# photometry. Objects brighter than this limit (in magnitude) will be cut. 
+# Comment out for no saturation limit.
+# Two formats are accepted:
+# Single float: applies same saturation limit to observations in all filters.
+# Comma-separated list of floats: applies saturation limit per filter, in order as
+# given in observing_filters keyword.
+bright_limit = 16.0
+
+
+[PHASECURVES]
+
+# The phase function used to calculate apparent magnitude. The physical parameters input
+# file must contain the columns needed to calculate the phase function.
+# Options: HG, HG1G2, HG12, linear, none.
+phase_function = HG
+
+
+[FOV]
+
+# Choose between circular or actual camera footprint, including chip gaps.
+# Options: circle, footprint.
+camera_model = footprint
+
+# Path to camera footprint file. Uncomment to provide a path to the desired camera 
+# detector configurationn file if not using the default built-in LSSTCam detector 
+# configuration or not using the circle footprint model.
+# footprint_path= ./data/detectors_corners.csv
+
+# Fraction of detector surface area which contains CCD -- simulates chip gaps
+# for OIF output. Comment out if using camera footprint.
+# Default: 0.9.
+# fill_factor = 0.9
+
+# Radius of the circle for a circular footprint (in degrees). Float.
+# Comment out or do not include if using footprint camera model.
+# circle_radius = 1.75
+
+# The distance from the edge of a detector (in arcseconds on the focal plane)
+# at which we will not correctly extract an object.
+# footprint_edge_threshold = 0.0001
+
+
+[FADINGFUNCTION]
+
+# Detection efficiency fading function on or off. Uses the fading function as outlined in
+# Chelsey and Vereš (2017) to remove observations.
+fading_function_on = False
+
+# Width parameter for fading function. Should be greater than zero and less than 0.5.
+# Suggested value is 0.1 after Chelsey and Vereš (2017).
+#fading_function_width = 0.1
+
+# Peak efficiency for the fading function, called the 'fill factor' in Chelsey and Veres (2017).
+# Suggested value is 1. Do not change this unless you are sure of what you are doing.
+#fading_function_peak_efficiency = 1.
+
+
+[LINKINGFILTER]
+
+# SSP detection efficiency. Which fraction of the objects will
+# the automated Rubin Solar System Processing (SSP) pipeline successfully link? Float. 
+#SSP_detection_efficiency = 0.95
+
+# Length of tracklets. How many observations of an object during one night are
+# required to produce a valid tracklet?
+#SSP_number_observations = 2
+
+# Minimum separation (in arcsec) between two observations of an object required 
+# for the linking software to distinguish them as separate and therefore as a valid tracklet.
+#SSP_separation_threshold = 0.5
+
+# Maximum time separation (in days) between subsequent observations # Maximum time separation (in days) between subsequent observations in a tracklet. 
+# Default is 0.0625 days (90mins). a tracklet. Default is 0.0625 days (90mins).
+#SSP_maximum_time = 0.0625
+
+# Number of tracklets for detection. How many tracklets are required to classify
+# an object as detected? 
+#SSP_number_tracklets = 3
+
+# The number of tracklets defined above must occur in <= this number of days to 
+# constitute a complete track/detection.
+#SSP_track_window = 15
+
+
+[SIMULATION]
+# Configs for running the ASSIST+REBOUND ephemerides generator.
+
+# the field of view of our search field, in degrees
+ar_ang_fov = 1.8
+
+# the buffer zone around the field of view we want to include, in degrees
+ar_fov_buffer = 0.2
+
+# the "picket" is our imprecise discretization of time that allows us to move progress
+# our simulations forward without getting too granular when we don't have to.
+# the unit is number of days.
+ar_picket = 1
+
+# the obscode is the MPC observatory code for the provided telescope.
+ar_obs_code = X05
+
+# the order of healpix which we will use for the healpy portions of the code.
+# the nside is equivalent to 2**ar_healpix_order
+ar_healpix_order = 6
+
+
+[OUTPUT]
+
+# Output format of the output file[s]
+# Options: csv, sqlite3, hdf5
+output_format = csv
+
+# Controls which columns are in the output files.
+# Options are "basic" and "all", which returns all columns.
+output_columns = basic
+
+
+[LIGHTCURVE]
+
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method 
+# of the subclasses of AbstractLightCurve. If not none, the complex physical parameters 
+# file must be specified at the command line.lc_model = none
+lc_model = none
+
+
+[ACTIVITY]
+
+# The unique name of the actvity model to use. Defined in the ``name_id`` method
+#  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
+# file must be specified at the command line.
+comet_activity = none
+
+
+[EXPERT]
+randomization_on = False
+vignetting_on = False
+trailing_losses_on = False

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -138,8 +138,6 @@ def runLSSTSimulation(args, configs):
     # Set up the data readers.
     ephem_type = configs["ephemerides_type"]
     ephem_primary = False
-    if ephem_type.casefold() == "external":
-        ephem_primary = True
     reader = CombinedDataReader(ephem_primary=ephem_primary, verbose=True)
 
     # TODO: Once more ephemerides_types are added this should be wrapped in a EphemerisDataReader

--- a/src/sorcha/utilities/diffTestUtils.py
+++ b/src/sorcha/utilities/diffTestUtils.py
@@ -69,6 +69,30 @@ WITH_EPHEMERIS_ARGS = {
     "stats": None,
 }
 
+CHUNKED_ARGS = {
+    "paramsinput": get_demo_filepath("sspp_testset_colours.txt"),
+    "orbinfile": get_demo_filepath("sspp_testset_orbits.des"),
+    "oifoutput": get_demo_filepath("example_oif_output.txt"),
+    "configfile": get_demo_filepath("PPConfig_test_chunked.ini"),
+    "pointing_database": get_demo_filepath("baseline_v2.0_1yr.db"),
+    "surveyname": "rubin_sim",
+    "outfilestem": f"out_end2end_chunked",
+    "verbose": False,
+    "stats": None,
+}
+
+UNCHUNKED_ARGS = {
+    "paramsinput": get_demo_filepath("sspp_testset_colours.txt"),
+    "orbinfile": get_demo_filepath("sspp_testset_orbits.des"),
+    "oifoutput": get_demo_filepath("example_oif_output.txt"),
+    "configfile": get_demo_filepath("PPConfig_test_unchunked.ini"),
+    "pointing_database": get_demo_filepath("baseline_v2.0_1yr.db"),
+    "surveyname": "rubin_sim",
+    "outfilestem": f"out_end2end_unchunked",
+    "verbose": False,
+    "stats": None,
+}
+
 
 VERIFICATION_TRUTH = {
     "paramsinput": get_demo_filepath("verification_colors.txt"),
@@ -105,6 +129,10 @@ def override_seed_and_run(outpath, arg_set="baseline"):
         cmd_args_dict = BASELINE_ARGS
     elif arg_set == "with_ephemeris":
         cmd_args_dict = WITH_EPHEMERIS_ARGS
+    elif arg_set == "chunked":
+        cmd_args_dict = CHUNKED_ARGS
+    elif arg_set == "unchunked":
+        cmd_args_dict = UNCHUNKED_ARGS
     elif arg_set == "truth":
         cmd_args_dict = VERIFICATION_TRUTH
     else:

--- a/tests/sorcha/test_demo_chunking.py
+++ b/tests/sorcha/test_demo_chunking.py
@@ -1,0 +1,32 @@
+import os
+import tempfile
+import pandas as pd
+
+from sorcha.utilities.dataUtilitiesForTests import get_demo_filepath
+from sorcha.utilities.diffTestUtils import override_seed_and_run
+
+
+def test_demo_chunking():
+    """This tests chunked vs. unchunked Sorcha. It is a full end-to-end test
+    with all randomised elements turned off to enable a one-to-one comparison
+    between the chunked and unchunked results.
+    """
+
+    with tempfile.TemporaryDirectory() as dir_name:
+        override_seed_and_run(dir_name, arg_set="chunked")
+        override_seed_and_run(dir_name, arg_set="unchunked")
+        res_file_chunked = os.path.join(dir_name, "out_end2end_chunked.csv")
+        res_file_unchunked = os.path.join(dir_name, "out_end2end_unchunked.csv")
+        assert os.path.isfile(res_file_chunked)
+        assert os.path.isfile(res_file_unchunked)
+
+        chunked_data = pd.read_csv(res_file_chunked)
+        unchunked_data = pd.read_csv(res_file_unchunked)
+
+        if chunked_data.shape != unchunked_data.shape:
+            return False
+
+        chunked_sorted = chunked_data.sort_values(["ObjID", "fieldMJD_TAI"]).reset_index(drop=True)
+        unchunked_sorted = unchunked_data.sort_values(["ObjID", "fieldMJD_TAI"]).reset_index(drop=True)
+
+        pd.testing.assert_frame_equal(chunked_sorted, unchunked_sorted)


### PR DESCRIPTION
Fixes #988.
- Changed behaviour of `CombinedDataReader.read_block()` when reading from an external ephemeris file by setting `ephem_primary=False`. This results in the intended behaviour. See the linked issue for more details.
- Wrote an end-to-end test to compare chunked to unchunked Sorcha results. This would have caught this bug, which only manifests when chunk size is smaller than the input ephemeris file.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
