### PR TITLE
Extra checks for empty dataframes

### DIFF
--- a/src/sorcha/modules/PPApplyFOVFilter.py
+++ b/src/sorcha/modules/PPApplyFOVFilter.py
@@ -65,9 +65,6 @@ def PPApplyFOVFilter(observations, configs, module_rngs, footprint=None, verbose
             verboselog("Fill factor is set. Removing random observations to mimic chip gaps.")
             observations = PPSimpleSensorArea(observations, module_rngs, configs["fill_factor"])
 
-    if configs["camera_model"] == "none":
-        verboselog("Camera model set to None in configs. No FOV filter will be applied.")
-
     return observations
 
 

--- a/src/sorcha/modules/PPFadingFunctionFilter.py
+++ b/src/sorcha/modules/PPFadingFunctionFilter.py
@@ -40,17 +40,9 @@ def PPFadingFunctionFilter(observations, fillfactor, width, module_rngs, verbose
         observations, fillFactor=fillfactor, w=width
     )
 
-    verboselog(
-        "Number of rows BEFORE applying detection probability threshold: " + str(len(observations.index))
-    )
-
     verboselog("Dropping observations below detection threshold...")
     observations = PPDropObservations(observations, module_rngs, "detection_probability")
     observations_drop = observations.drop("detection_probability", axis=1)
     observations_drop.reset_index(drop=True, inplace=True)
-
-    verboselog(
-        "Number of rows AFTER applying detection probability threshold: " + str(len(observations_drop.index))
-    )
 
     return observations_drop

--- a/src/sorcha/modules/PPOutput.py
+++ b/src/sorcha/modules/PPOutput.py
@@ -79,6 +79,9 @@ def PPOutWriteSqlite3(pp_results, outf, tablename="sorcha_results"):
     outf : string
         Location to which file should be written.
 
+    tablename: string
+        String of the table within the database to be indexed.
+
     Returns
     -----------
     None.
@@ -103,6 +106,13 @@ def PPIndexSQLDatabase(outf, tablename="sorcha_results"):
     -----------
     outf : string
         Location of SQLite database to be indexed.
+
+    tablename: string
+        String of the table within the database to be indexed.
+
+    Returns
+    -----------
+    None.
 
     """
 

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -334,12 +334,14 @@ def runLSSTSimulation(args, configs):
         else:
             verboselog("No observations left in chunk. No output will be written for this chunk.")
 
-        if endChunk >= lenf and configs["output_format"] == "sqlite3":
-            pplogger.info("Last chunk detected. Indexing output SQLite database...")
-            PPIndexSQLDatabase(os.path.join(args.outpath, args.outfilestem + ".db"))
-
         startChunk = startChunk + configs["size_serial_chunk"]
         loopCounter = loopCounter + 1
         # end for
+
+    if configs["output_format"] == "sqlite3" and os.path.isfile(
+        os.path.join(args.outpath, args.outfilestem + ".db")
+    ):
+        pplogger.info("Indexing output SQLite database...")
+        PPIndexSQLDatabase(os.path.join(args.outpath, args.outfilestem + ".db"))
 
     pplogger.info("Sorcha process is completed.")

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -335,6 +335,7 @@ def runLSSTSimulation(args, configs):
             verboselog("No observations left in chunk. No output will be written for this chunk.")
 
         if endChunk >= lenf and configs["output_format"] == "sqlite3":
+            pplogger.info("Last chunk detected. Indexing output SQLite database...")
             PPIndexSQLDatabase(os.path.join(args.outpath, args.outfilestem + ".db"))
 
         startChunk = startChunk + configs["size_serial_chunk"]

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -156,7 +156,7 @@ def runLSSTSimulation(args, configs):
         reader.add_aux_data_reader(CSVDataReader(args.complex_parameters, configs["aux_format"]))
 
     # In case of a large input file, the data is read in chunks. The
-    # "sizeSerialChunk" parameter in PPConfig.ini assigns the chunk.
+    # "sizeSerialChunk" parameter in the config file assigns the chunk.
     startChunk = 0
     endChunk = 0
     loopCounter = 0
@@ -197,7 +197,7 @@ def runLSSTSimulation(args, configs):
 
         # If the ephemeris file doesn't have any observations for the objects in the chunk
         # PPReadAllInput will return an empty dataframe. We thus log a warning.
-        if len(observations) == 0:
+        if len(observations.index) == 0:
             pplogger.info(
                 "WARNING: no ephemeris observations found for these objects. Skipping to next chunk..."
             )
@@ -239,24 +239,20 @@ def runLSSTSimulation(args, configs):
         # These are the columns that should be used moving forward for filters etc.
         # Do NOT use trailedSourceMagTrue or PSFMagTrue, these are the unrandomised magnitudes.
         verboselog("Calculating astrometric and photometric uncertainties...")
-        verboselog(
-            "Number of rows BEFORE caclulating astrometric and photometric uncertainties : "
-            + str(len(observations.index))
-        )
-
         observations = PPAddUncertainties.addUncertainties(
             observations, configs, args._rngs, verbose=args.verbose
         )
-        verboselog(
-            "Number of rows AFTER caclulating astrometric and photometric uncertainties : "
-            + str(len(observations.index))
-        )
 
         if configs["randomization_on"]:
+            verboselog(
+                "Number of rows BEFORE randomizing astrometry and photometry: " + str(len(observations.index))
+            )
             observations = PPRandomizeMeasurements.randomizeAstrometryAndPhotometry(
                 observations, configs, args._rngs, verbose=args.verbose
             )
-
+            verboselog(
+                "Number of rows AFTER randomizing astrometry and photometry: " + str(len(observations.index))
+            )
         else:
             verboselog(
                 "Randomization turned off in config file. No astrometric or photometric randomization performed."
@@ -272,14 +268,15 @@ def runLSSTSimulation(args, configs):
             observations["trailedSourceMag"] = observations["trailedSourceMagTrue"].copy()
             observations["PSFMag"] = observations["PSFMagTrue"].copy()
 
-        verboselog("Applying field-of-view filters...")
-        verboselog("Number of rows BEFORE applying FOV filters: " + str(len(observations.index)))
-        observations = PPApplyFOVFilter(
-            observations, configs, args._rngs, footprint=footprint, verbose=args.verbose
-        )
-        verboselog("Number of rows AFTER applying FOV filters: " + str(len(observations.index)))
+        if configs["camera_model"] != "none" and len(observations.index) > 0:
+            verboselog("Applying field-of-view filters...")
+            verboselog("Number of rows BEFORE applying FOV filters: " + str(len(observations.index)))
+            observations = PPApplyFOVFilter(
+                observations, configs, args._rngs, footprint=footprint, verbose=args.verbose
+            )
+            verboselog("Number of rows AFTER applying FOV filters: " + str(len(observations.index)))
 
-        if configs["SNR_limit_on"]:
+        if configs["SNR_limit_on"] and len(observations.index) > 0:
             verboselog(
                 "Dropping observations with signal to noise ratio less than {}...".format(
                     configs["SNR_limit"]
@@ -289,14 +286,15 @@ def runLSSTSimulation(args, configs):
             observations = PPSNRLimit(observations, configs["SNR_limit"])
             verboselog("Number of rows AFTER applying SNR limit filter: " + str(len(observations.index)))
 
-        if configs["mag_limit_on"]:
+        if configs["mag_limit_on"] and len(observations.index) > 0:
             verboselog("Dropping detections fainter than user-defined magnitude limit... ")
             verboselog("Number of rows BEFORE applying mag limit filter: " + str(len(observations.index)))
             observations = PPMagnitudeLimit(observations, configs["mag_limit"])
             verboselog("Number of rows AFTER applying mag limit filter: " + str(len(observations.index)))
 
-        if configs["fading_function_on"]:
+        if configs["fading_function_on"] and len(observations.index) > 0:
             verboselog("Applying detection efficiency fading function...")
+            verboselog("Number of rows BEFORE applying fading function: " + str(len(observations.index)))
             observations = PPFadingFunctionFilter(
                 observations,
                 configs["fading_function_peak_efficiency"],
@@ -304,19 +302,15 @@ def runLSSTSimulation(args, configs):
                 args._rngs,
                 verbose=args.verbose,
             )
+            verboselog("Number of rows AFTER applying fading function: " + str(len(observations.index)))
 
-        if configs["bright_limit_on"]:
+        if configs["bright_limit_on"] and len(observations.index) > 0:
             verboselog("Dropping observations that are too bright...")
             verboselog("Number of rows BEFORE applying bright limit filter " + str(len(observations.index)))
             observations = PPBrightLimit(observations, configs["observing_filters"], configs["bright_limit"])
             verboselog("Number of rows AFTER applying bright limit filter " + str(len(observations.index)))
 
-        if len(observations) == 0:
-            verboselog("No observations left in chunk. Skipping to next chunk...")
-            startChunk = startChunk + configs["size_serial_chunk"]
-            continue
-
-        if configs["SSP_linking_on"]:
+        if configs["SSP_linking_on"] and len(observations.index) > 0:
             verboselog("Applying SSP linking filter...")
             verboselog("Number of rows BEFORE applying SSP linking filter: " + str(len(observations.index)))
             observations = PPLinkingFilter(
@@ -332,16 +326,15 @@ def runLSSTSimulation(args, configs):
             observations.reset_index(drop=True, inplace=True)
             verboselog("Number of rows AFTER applying SSP linking filter: " + str(len(observations.index)))
 
-        pplogger.info("Post processing completed for this chunk")
-
-        pplogger.info("Output results for this chunk")
-
-        # write output
-
-        PPWriteOutput(args, configs, observations, endChunk, verbose=args.verbose, lastchunk=lastChunk)
-
-        if args.stats is not None:
-            stats(observations, args.stats, args.outpath, linking=configs["SSP_linking_on"])
+        # write output if chunk not empty
+        if len(observations.index) > 0:
+            pplogger.info("Post processing completed for this chunk")
+            pplogger.info("Outputting results for this chunk")
+            PPWriteOutput(args, configs, observations, endChunk, verbose=args.verbose, lastchunk=lastChunk)
+            if args.stats is not None:
+                stats(observations, args.stats, args.outpath, linking=configs["SSP_linking_on"])
+        else:
+            verboselog("No observations left in chunk. No output will be written for this chunk.")
 
         startChunk = startChunk + configs["size_serial_chunk"]
         loopCounter = loopCounter + 1

--- a/tests/sorcha/test_PPOutput.py
+++ b/tests/sorcha/test_PPOutput.py
@@ -90,6 +90,8 @@ def test_PPWriteOutput_csv(tmp_path):
 
 
 def test_PPWriteOutput_sql(tmp_path):
+    from sorcha.modules.PPOutput import PPIndexSQLDatabase
+
     args.outpath = tmp_path
     args.outfilestem = "PPOutput_test_out"
 
@@ -121,7 +123,9 @@ def test_PPWriteOutput_sql(tmp_path):
         dtype=object,
     )
 
-    PPWriteOutput(args, configs, observations, 10, lastchunk=True)
+    PPWriteOutput(args, configs, observations, 10)
+    PPIndexSQLDatabase(os.path.join(tmp_path, "PPOutput_test_out.db"))
+
     cnx = sqlite3.connect(os.path.join(tmp_path, "PPOutput_test_out.db"))
     cur = cnx.cursor()
     cur.execute("select * from sorcha_results")


### PR DESCRIPTION
Fixes #986.
- Behaviour in sorcha.py regarding empty dataframes is now consistent.
- Each filter checks to make sure the dataframe is not empty before running.
- The code also no longer tries to write output if the dataframe is empty.
- Moved check for `configs["camera_model"] == "none"` out of PPApplyFOVFilter and into sorcha.py, for consistency
- Moved log messages for number of lines left in dataframe away from PPAddUncertainties (which does not remove rows) to PPRandomizeAstrometryAndPhotometry (which does).
- Made sure the loop counter updates in the case where there are no observations in the ephemeris file for the chunk so the chunk is skipped.
- Separated the indexing of SQL output into its own function which is always performed on the last chunk.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
