### PR TITLE
Adding version checker, better error messages

### DIFF
--- a/src/sorcha/utilities/sorchaArguments.py
+++ b/src/sorcha/utilities/sorchaArguments.py
@@ -87,19 +87,19 @@ class sorchaArguments:
 
     def validate_arguments(self):
         if not path.isfile(self.paramsinput):
-            raise ValueError("`paramsinput` is not a valid file path.")
+            raise ValueError("File does not exist at path supplied for -p/--params argument.")
 
         if not path.isfile(self.orbinfile):
-            raise ValueError("`orbinfile` is not a valid file path.")
+            raise ValueError("File does not exist at path supplied for -ob/--orbit argument.")
 
         if self.oifoutput and not path.isfile(self.oifoutput):
-            raise ValueError("`oifoutput` is not a valid file path.")
+            raise ValueError("File does not exist at path supplied for -er/--ephem_read argument.")
 
         if not path.isfile(self.configfile):
-            raise ValueError("`configfile` is not a valid file path.")
+            raise ValueError("File does not exist at path supplied for -c/--config argument.")
 
         if not path.isfile(self.pointing_database):
-            raise ValueError("`pointing_database` is not a valid file path.")
+            raise ValueError("File does not exist at path supplied for -pd/--pointing_database argument.")
 
         if self.ar_data_file_path and not path.isdir(self.ar_data_file_path):
-            raise ValueError("`ar_data_path` is not a valid directory.")
+            raise ValueError("Directory does not exist at path supplied for -ar/--ar_data_path argument.")

--- a/src/sorcha_cmdline/main.py
+++ b/src/sorcha_cmdline/main.py
@@ -46,11 +46,27 @@ def main():
     parser = argparse.ArgumentParser(
         description=description, epilog=epilog_text, formatter_class=argparse.RawDescriptionHelpFormatter
     )
-
-    parser.add_argument("verb", choices=available_verbs, help="Verb to execute")
+    parser.add_argument(
+        "--version",
+        help="Print version information",
+        dest="version",
+        action="store_true",
+    )
+    parser.add_argument("verb", nargs="?", choices=available_verbs, help="Verb to execute")
     parser.add_argument("args", nargs=argparse.REMAINDER, help="Arguments for the verb")
 
     args = parser.parse_args()
+
+    if args.version:
+        import sorcha
+
+        print(sorcha.__version__)
+        return
+
+    # Ensure a verb is provided if not just checking the version
+    if not args.verb:
+        parser.print_help()
+        sys.exit(1)
 
     # Construct the full command name
     utility = f"sorcha-{args.verb}"

--- a/tests/sorcha/test_sorchaArguments.py
+++ b/tests/sorcha/test_sorchaArguments.py
@@ -29,28 +29,28 @@ def test_validate_arguments():
 
     args = sorchaArguments(cmd_args_dict)
 
-    with pytest.raises(ValueError, match="paramsinput"):
+    with pytest.raises(ValueError):
         args.paramsinput = get_demo_filepath("sspp_testset_colors.txt")
 
         args.validate_arguments()
 
     args.paramsinput = get_demo_filepath("sspp_testset_colours.txt")
 
-    with pytest.raises(ValueError, match="orbinfile"):
+    with pytest.raises(ValueError):
         args.orbinfile = get_demo_filepath("sspp_testset_orbitz.des")
 
         args.validate_arguments()
 
     args.orbinfile = get_demo_filepath("sspp_testset_orbits.des")
 
-    with pytest.raises(ValueError, match="oifoutput"):
+    with pytest.raises(ValueError):
         args.oifoutput = get_demo_filepath("example_oif_output.txtttttt")
 
         args.validate_arguments()
 
     args.oifoutput = get_demo_filepath("example_oif_output.txt")
 
-    with pytest.raises(ValueError, match="configfile"):
+    with pytest.raises(ValueError):
         args.configfile = get_demo_filepath("NOPE.txt")
 
         args.validate_arguments()


### PR DESCRIPTION
Fixes #983.
- Error messages in the sorchaArguments dataclass are now more informative and refer to the relevant command-line argument.
- Updated the unit test.

Fixes #981.
- Added back in Mario's code for a --version command line argument.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
