### PR TITLE
New config file

### DIFF
--- a/docs/configfiles.rst
+++ b/docs/configfiles.rst
@@ -18,7 +18,7 @@ Rubin Full Footprint
 This configuration file is appropriate for running ``sorcha`` using the Rubin
 full detector footprint.
 
-.. literalinclude:: ../survey_setups/Rubin_full_footprint.ini
+.. literalinclude:: ../src/sorcha/data/survey_setups/Rubin_full_footprint.ini
    :language: text
    :linenos:
 
@@ -28,7 +28,7 @@ Rubin Circular Approximation
 This configuration file is appropriate for running ``sorcha`` using a circular 
 approximation of the Rubin detector.
 
-.. literalinclude:: ../survey_setups/Rubin_circular_approximation.ini
+.. literalinclude:: ../src/sorcha/data/survey_setups/Rubin_circular_approximation.ini
     :language: text
     :linenos:
 
@@ -42,6 +42,6 @@ and where known objects will appear in Rubin observations.
 .. warning::
    As this configuration file turns off most of Sorcha's features, we strongly recommend you do not use it unless you are certain you know what you are doing.
 
-.. literalinclude:: ../survey_setups/Rubin_known_object_prediction.ini
+.. literalinclude:: ../src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
     :language: text
     :linenos:

--- a/docs/configfiles.rst
+++ b/docs/configfiles.rst
@@ -32,4 +32,16 @@ approximation of the Rubin detector.
     :language: text
     :linenos:
 
+Rubin Known Object Prediction
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This configuration file is appropriate for running ``sorcha`` using the full camera footprint but with randomization,
+fading function, vignetting, SSP linking, saturation limit and trailing losses off. This will output all detections
+which lie on the CCD with unadulterated apparent magnitudes. This could thus be used to predict when 
+and where known objects will appear in Rubin observations.
 
+.. warning::
+   As this configuration file turns off most of Sorcha's features, we strongly recommend you do not use it unless you are certain you know what you are doing.
+
+.. literalinclude:: ../survey_setups/Rubin_known_object_prediction.ini
+    :language: text
+    :linenos:

--- a/src/sorcha/data/survey_setups/README
+++ b/src/sorcha/data/survey_setups/README
@@ -15,3 +15,9 @@ Rubin_circular_approximation.ini -- The configuration file for the Vera C. Rubin
 Legacy Survey of Space and Time (LSST) using the circular footprint approximation
 where the circular footprint matches 90% of the detector surface area.
 
+Rubin_known_object_prediction.ini -- The configuration file for the Vera C. Rubin Observatory's
+Legacy Survey of Space and Time (LSST) using the full camera footprint but with randomization,
+fading function, vignetting, SSP linking, saturation limit and trailing losses off. This will output all detections
+which lie on the CCD with unadulterated apparent magnitudes. This could thus be used to predict when 
+and where known objects will appear in Rubin observations.
+

--- a/src/sorcha/data/survey_setups/README.md
+++ b/src/sorcha/data/survey_setups/README.md
@@ -1,4 +1,4 @@
-README file for survey_setups folder
+## README file for survey_setups folder
 
 This directory contains configuration files that simulate Solar System surveys.
 
@@ -8,14 +8,14 @@ a deeper understanding of different parameters.
 Currently, the directory contains the following files:
 
 
-Rubin_full_footprint.ini -- The configuration file for the Vera C. Rubin Observatory's
+**Rubin_full_footprint.ini** -- The configuration file for the Vera C. Rubin Observatory's
 Legacy Survey of Space and Time (LSST) using the full camera footprint.
 
-Rubin_circular_approximation.ini -- The configuration file for the Vera C. Rubin Observatory's
+**Rubin_circular_approximation.ini** -- The configuration file for the Vera C. Rubin Observatory's
 Legacy Survey of Space and Time (LSST) using the circular footprint approximation
 where the circular footprint matches 90% of the detector surface area.
 
-Rubin_known_object_prediction.ini -- The configuration file for the Vera C. Rubin Observatory's
+**Rubin_known_object_prediction.ini** -- The configuration file for the Vera C. Rubin Observatory's
 Legacy Survey of Space and Time (LSST) using the full camera footprint but with randomization,
 fading function, vignetting, SSP linking, saturation limit and trailing losses off. This will output all detections
 which lie on the CCD with unadulterated apparent magnitudes. This could thus be used to predict when 

--- a/src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
+++ b/src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
@@ -1,0 +1,129 @@
+# Sorcha Configuration File 
+
+
+[INPUT]
+
+# The simulation used for the ephemeris input.
+# ar=ASSIST+REBOUND interal ephemeris generation
+# external=providing an external input file from the command line
+# Options: "ar", "external"
+ephemerides_type = ar
+
+# Format for ephemeris simulation input file if a file is specified at the command line. 
+# This is also the format to which ephemeris files will be written out, if specified.
+# Options: csv, whitespace, hdf5
+eph_format = csv
+
+# Sorcha chunk size: how many objects should be processed at once?
+size_serial_chunk = 20000
+
+# Format for the orbit, physical parameters, and complex physical parameters input files.
+# Options: csv or whitespace
+aux_format = csv
+
+# SQL query for extracting data from the pointing database.
+pointing_sql_query = SELECT observationId, observationStartMJD as observationStartMJD_TAI, visitTime, visitExposureTime, filter, seeingFwhmGeom as seeingFwhmGeom_arcsec, seeingFwhmEff as seeingFwhmEff_arcsec, fiveSigmaDepth as fieldFiveSigmaDepth_mag , fieldRA as fieldRA_deg, fieldDec as fieldDec_deg, rotSkyPos as fieldRotSkyPos_deg FROM observations order by observationId
+
+
+[SIMULATION]
+# Configs for running the ASSIST+REBOUND ephemerides generator.
+
+# the field of view of our search field, in degrees
+ar_ang_fov = 2.06
+
+# the buffer zone around the field of view we want to include, in degrees
+ar_fov_buffer = 0.2
+
+# the "picket" is our imprecise discretization of time that allows us to move progress
+# our simulations forward without getting too granular when we don't have to.
+# the unit is number of days.
+ar_picket = 1
+
+# the obscode is the MPC observatory code for the provided telescope.
+ar_obs_code = X05
+
+# the order of healpix which we will use for the healpy portions of the code.
+# the nside is equivalent to 2**ar_healpix_order
+ar_healpix_order = 6
+
+
+[FILTERS]
+
+# Filters of the observations you are interested in, comma-separated.
+# Your physical parameters file must have H calculated in one of these filters
+# and colour offset columns defined relative to that filter.
+observing_filters = r,g,i,z,u,y
+
+
+[PHASECURVES]
+
+# The phase function used to calculate apparent magnitude. The physical parameters input
+# file must contain the columns needed to calculate the phase function.
+# Options: HG, HG1G2, HG12, linear, none.
+phase_function = HG
+
+
+[FOV]
+
+# Choose between circular or actual camera footprint, including chip gaps.
+# Options: circle, footprint.
+camera_model = footprint
+
+# Path to camera footprint file. Uncomment to provide a path to the desired camera 
+# detector configurationn file if not using the default built-in LSSTCam detector 
+# configuration or not using the circle footprint model.
+# footprint_path= ./data/detectors_corners.csv
+
+# Fraction of detector surface area which contains CCD -- simulates chip gaps
+# for OIF output. Comment out if using camera footprint.
+# Default: 0.9.
+# fill_factor = 0.9
+
+# Radius of the circle for a circular footprint (in degrees). Float.
+# Comment out or do not include if using footprint camera model.
+# circle_radius = 1.75
+
+# The distance from the edge of a detector (in arcseconds on the focal plane)
+# at which we will not correctly extract an object.
+# footprint_edge_threshold = 0.0001
+
+
+[FADINGFUNCTION]
+
+# Detection efficiency fading function on or off. Uses the fading function as outlined in
+# Chelsey and Vereš (2017) to remove observations.
+fading_function_on = False
+
+
+[OUTPUT]
+
+# Output format of the output file[s]
+# Options: csv, sqlite3, hdf5
+output_format = sqlite3
+
+# Controls which columns are in the output files.
+# Options are "basic" and "all", which returns all columns.
+output_columns = basic
+
+
+[LIGHTCURVE]
+
+# The unique name of the lightcurve model to use. Defined in the ``name_id`` method 
+# of the subclasses of AbstractLightCurve. If not none, the complex physical parameters 
+# file must be specified at the command line.lc_model = none
+lc_model = none
+
+
+[ACTIVITY]
+
+# The unique name of the actvity model to use. Defined in the ``name_id`` method
+#  of the subclasses of AbstractCometaryActivity.  If not none, a complex physical parameters 
+# file must be specified at the command line.
+comet_activity = none
+
+
+[EXPERT]
+# Turning off all randomization and vignetting.
+randomization_on = False
+vignetting_on = False
+trailing_losses_on = False

--- a/src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
+++ b/src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
@@ -123,7 +123,7 @@ comet_activity = none
 
 
 [EXPERT]
-# Turning off all randomization and vignetting.
+# Turning off all randomization, vignetting and trailing losses.
 randomization_on = False
 vignetting_on = False
 trailing_losses_on = False

--- a/src/sorcha/utilities/sorcha_copy_configs.py
+++ b/src/sorcha/utilities/sorcha_copy_configs.py
@@ -36,6 +36,7 @@ def copy_demo_configs(copy_location, which_configs, force_overwrite):
     configs = {
         "rubin_circle": ["Rubin_circular_approximation.ini"],
         "rubin_footprint": ["Rubin_full_footprint.ini"],
+        "rubin_known": ["Rubin_known_object_prediction.ini"],
     }
 
     if which_configs in configs:
@@ -44,7 +45,7 @@ def copy_demo_configs(copy_location, which_configs, force_overwrite):
         config_locations = [fn for fns in configs.values() for fn in fns]
     else:
         sys.exit(
-            "String '{}' not recognised for 'configs' variable. Must be 'rubin_circle', 'rubin_footprint' or 'all'.".format(
+            "String '{}' not recognised for 'configs' variable. Must be 'rubin_circle', 'rubin_footprint', 'rubin_known' or 'all'.".format(
                 which_configs
             )
         )

--- a/src/sorcha_cmdline/init.py
+++ b/src/sorcha_cmdline/init.py
@@ -27,10 +27,10 @@ def parse_file_selection(file_select):
     except ValueError:
         sys.exit("Input could not be converted to a valid integer. Please try again.")
 
-    if file_select not in [1, 2, 3]:
-        sys.exit("Input could not be converted to a valid integer. Please input an integer between 1 and 3.")
+    if file_select not in [1, 2, 3, 4]:
+        sys.exit("Input could not be converted to a valid integer. Please input an integer between 1 and 4.")
 
-    selection_dict = {1: "rubin_circle", 2: "rubin_footprint", 3: "all"}
+    selection_dict = {1: "rubin_circle", 2: "rubin_footprint", 3: "rubin_known", 4: "all"}
 
     which_configs = selection_dict[file_select]
 
@@ -41,7 +41,10 @@ def execute(args):  # pragma: no cover
     print("\nWhich configuration file(s) would you like to copy?:\n")
     print("1. Rubin-specific configuration file using circular approximation of camera footprint (faster).\n")
     print("2. Rubin-specific configuration file using full camera footprint (slower, but more accurate).\n")
-    print("3. All.\n")
+    print(
+        "3. Rubin-specific configuration file using full camera footprint but with all filters turned off, for known object detection. WARNING: do not use this unless you are sure you know what you are doing!\n"
+    )
+    print("4. All.\n")
     file_select = input("Please enter a number and hit Return/Enter.\n")
 
     which_configs = parse_file_selection(file_select)

--- a/tests/sorcha/test_sorcha_copy_configs.py
+++ b/tests/sorcha/test_sorcha_copy_configs.py
@@ -14,15 +14,20 @@ def test_sorcha_copy_configs(tmp_path):
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
 
+    copy_demo_configs(tmp_path, "rubin_known", False)
+    assert os.path.isfile(os.path.join(tmp_path, "Rubin_known_object_prediction.ini"))
+
     # remove those files
     os.remove(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
     os.remove(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
+    os.remove(os.path.join(tmp_path, "Rubin_known_object_prediction.ini"))
 
     # test that all the configs are successfully copied
     copy_demo_configs(tmp_path, "all", False)
 
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_circular_approximation.ini"))
     assert os.path.isfile(os.path.join(tmp_path, "Rubin_full_footprint.ini"))
+    assert os.path.isfile(os.path.join(tmp_path, "Rubin_known_object_prediction.ini"))
 
     # test that files are successfully overwritten if -f flag used
     copy_demo_configs(tmp_path, "all", True)
@@ -42,10 +47,10 @@ def test_sorcha_copy_configs(tmp_path):
 
     assert (
         e2.value.code
-        == "String 'laphroaig' not recognised for 'configs' variable. Must be 'rubin_circle', 'rubin_footprint' or 'all'."
+        == "String 'laphroaig' not recognised for 'configs' variable. Must be 'rubin_circle', 'rubin_footprint', 'rubin_known' or 'all'."
     )
 
-    # test tthe error message if file exists and overwrite isn't forced
+    # test the error message if file exists and overwrite isn't forced
 
     with pytest.raises(SystemExit) as e3:
         copy_demo_configs(tmp_path, "rubin_footprint", False)
@@ -62,10 +67,12 @@ def test_parse_file_selection():
     # test to make sure the inputs align with the correct options
     test_rubin_circle = parse_file_selection("1")
     test_rubin_footprint = parse_file_selection("2")
-    test_all = parse_file_selection("3")
+    test_rubin_known = parse_file_selection("3")
+    test_all = parse_file_selection("4")
 
     assert test_rubin_circle == "rubin_circle"
     assert test_rubin_footprint == "rubin_footprint"
+    assert test_rubin_known == "rubin_known"
     assert test_all == "all"
 
     # test error messages
@@ -76,9 +83,9 @@ def test_parse_file_selection():
     assert e.value.code == "Input could not be converted to a valid integer. Please try again."
 
     with pytest.raises(SystemExit) as e2:
-        test_wrong_integer = parse_file_selection("4")
+        test_wrong_integer = parse_file_selection("500")
 
     assert (
         e2.value.code
-        == "Input could not be converted to a valid integer. Please input an integer between 1 and 3."
+        == "Input could not be converted to a valid integer. Please input an integer between 1 and 4."
     )


### PR DESCRIPTION
Fixes #993.
- Added a new example config file, Rubin_known_object_prediction.ini, which uses the full footprint filter but turns pretty much everything else off.
- Added this config file to the files which can be copied by the sorcha init command.
- Edited unit test for copying config files.
- Edited readme in survey_setups folder.
- Edited configs page in docs.
- Fixed filepaths in docs pointing to old location of survey_setups folder.

Please do let me know if the config file is what you wanted, happy to make any edits!

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
