### PR TITLE
Updating docs regarding disordered output

### DIFF
--- a/docs/ephemerisgen.rst
+++ b/docs/ephemerisgen.rst
@@ -115,7 +115,11 @@ If you want to use the same input orbits across multiple Sorcha runs, you can sa
 
 .. attention::
    Currently the Sorcha-generated ephemeris is outputted in CSV, whitespace or HDF5 file format only.
+   
 
+.. attention::
+   Users should note that output produced by reading in a previously-generated ephemeris file will be in a different order than the output produced when running the ephemeris generator within Sorcha.
+   This is simply a side-effect of how Sorcha reads in ephemeris files and does not affect the actual content of the output.
 
 
 Providing Your Own Ephemerides 


### PR DESCRIPTION
Quick fix to documentation to add a note that when using a pre-generated ephemeris file, Sorcha's output will be in a different order than the output produced when generating the ephemeris within Sorcha, but the output IS otherwise identical.
