### PR TITLE
miniDifi: bugfix for discovery options past discovery window

### DIFF
--- a/src/sorcha/modules/PPMiniDifi.py
+++ b/src/sorcha/modules/PPMiniDifi.py
@@ -134,7 +134,7 @@ def discoveryOpportunities(nights, nightHasTracklets, window, nlink, p, rng):
         #    then subtracting the shifted array -- basic integration)
         #    And then find nights where the # of tracklets >= nlink
         #
-        n0, n1 = nights.min(), nights.max()
+        n0, n1 = nights.min(), nights.max() + window
         nlen = n1 - n0 + 1
         arr = np.zeros(nlen, dtype="i8")
         arr[nights - n0] = nightHasTracklets


### PR DESCRIPTION
Say our discovery window is 10, and the object has tracklets at nights:

    2 4 6 8

This should generate the following discovery opportunities:

    2 4 6
    2 4 6 8
      4 6 8

The code before this bugfix would stop looking for discovery opportunities after the final night was reached, so it didn't "see" the last one combination.

Fixes # .

Describe your changes.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
