### PR TITLE
Unpinning numpy version, addressing warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "numpy<2.0",
+    "numpy",
     "pandas>=2.0",
     "astropy",
     "matplotlib",
@@ -68,7 +68,7 @@ dev = [
     "ipython", # Also used in building notebooks into Sphinx
     "ipykernel",
     "matplotlib", # Used in sample notebook intro_notebook.ipynb
-    "numpy<2.0", # Used in sample notebook intro_notebook.ipynb
+    "numpy", # Used in sample notebook intro_notebook.ipynb
 ]
 
 test = [

--- a/src/sorcha/modules/PPLinkingFilter.py
+++ b/src/sorcha/modules/PPLinkingFilter.py
@@ -66,7 +66,7 @@ def PPLinkingFilter(
     nameLen = obsv["ssObjectId"].str.len().max()
     obsv = obsv.to_records(
         index=False,
-        column_dtypes=dict(ssObjectId=f"a{nameLen}", diaSourceId="u8", midPointTai="f8", ra="f8", decl="f8"),
+        column_dtypes=dict(ssObjectId=f"S{nameLen}", diaSourceId="u8", midPointTai="f8", ra="f8", decl="f8"),
     )
 
     # link

--- a/src/sorcha/modules/PPMiniDifi.py
+++ b/src/sorcha/modules/PPMiniDifi.py
@@ -346,7 +346,7 @@ if __name__ == "__main__":
     obsv = np.asarray(
         df.to_records(
             index=False,
-            column_dtypes=dict(_name=f"a{nameLen}", diaSourceId="u8", midPointTai="f8", ra="f8", decl="f8"),
+            column_dtypes=dict(_name=f"S{nameLen}", diaSourceId="u8", midPointTai="f8", ra="f8", decl="f8"),
         )
     )
     del df

--- a/tests/sorcha/test_PPLinkingFilter.py
+++ b/tests/sorcha/test_PPLinkingFilter.py
@@ -101,7 +101,7 @@ def test_PPLinkingFilter_discoveryChances():
     nameLen = obsv["ssObjectId"].str.len().max()
     obsv = obsv.to_records(
         index=False,
-        column_dtypes=dict(ssObjectId=f"a{nameLen}", diaSourceId="u8", midPointTai="f8", ra="f8", decl="f8"),
+        column_dtypes=dict(ssObjectId=f"S{nameLen}", diaSourceId="u8", midPointTai="f8", ra="f8", decl="f8"),
     )
 
     # link
@@ -147,7 +147,7 @@ def test_PPLinkingFilter_nlink1():
     nameLen = obsv["ssObjectId"].str.len().max()
     obsv = obsv.to_records(
         index=False,
-        column_dtypes=dict(ssObjectId=f"a{nameLen}", diaSourceId="u8", midPointTai="f8", ra="f8", decl="f8"),
+        column_dtypes=dict(ssObjectId=f"S{nameLen}", diaSourceId="u8", midPointTai="f8", ra="f8", decl="f8"),
     )
 
     # link


### PR DESCRIPTION
Fixes #964.
- Unpinned Numpy version.
- Modified code to remove new warning for Numpy 2.0 (see below).
- Ensured fix also worked for older Numpy versions.

All tests ran successfully using Numpy v.2.0.1. However, the following new warning occurred:

```
tests/sorcha/test_PPLinkingFilter.py: 9 warnings
tests/sorcha/test_demo_end2end.py: 3 warnings
  /opt/miniconda3/envs/sorcha-numpy/lib/python3.10/site-packages/numpy/_core/records.py:634: DeprecationWarning: Data type alias 'a' was deprecated in NumPy 2.0. Use the 'S' alias instead.
    descr = sb.dtype(dtype)
```

This was a simple fix. MiniDifi uses Numpy record arrays in which the ssObjectID column was being typed as `ssObjectId=f"a{nameLen}"`. Changed this to `ssObjectId=f"S{nameLen}"` in all places. This fix is backwards-compatible at least as far back as Numpy version 1.26.4 so it shouldn't break anyone's existing environments.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
