### PR TITLE
bugfix: remove code left by accident

### DIFF
--- a/src/sorcha/modules/PPMiniDifi.py
+++ b/src/sorcha/modules/PPMiniDifi.py
@@ -212,11 +212,6 @@ def linkObject(obsv, seed, maxdt_minutes, minlen_arcsec, window, nlink, p, night
             discoveryChances = len(discNights)
             discoverySubmissionDate = discNights[discIdx]
 
-            # find the first observation on the discovery date
-            i, j = np.searchsorted(night, [discoverySubmissionDate, discoverySubmissionDate + 1])
-            k = i + np.argmin(mjd[i:j])
-            discoveryObservationId = diaSourceId[k]
-
             # find the first observation in the discovery window.
             # we'll (somewhat arbitrarily) define this as the "asterisk" observation.
             # in reality, we'll run precovery on linkages so the asterisk observation


### PR DESCRIPTION
Fixes a problem identified on Slack where linking would fail with "ValueError: attempt to get argmin of an empty sequence."

Describe your changes.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
