### PR TITLE
Changes to Sorcha logging, utility script

### DIFF
--- a/src/sorcha/modules/PPGetLogger.py
+++ b/src/sorcha/modules/PPGetLogger.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 def PPGetLogger(
     log_location,
+    log_stem,
     log_format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s ",
     log_name="",
     log_file_info="sorcha.log",
@@ -18,6 +19,9 @@ def PPGetLogger(
     log_location : string
         Filepath to directory in which to save logs.
 
+    log_stem : string
+        String output stem used to prefix all Sorcha outputs.
+
     log_format : string, optional
         Format for log filename.
         Default = "%(asctime)s %(name)-12s %(levelname)-8s %(message)s "
@@ -26,10 +30,10 @@ def PPGetLogger(
         Name of log. Default = ""
 
     log_file_info : string, optional
-        Name with which to save info log. Default = "sorcha.log"
+        Suffix and extension with which to save info log. Default = "sorcha.log"
 
     log_file_error : string, optional
-        Name with which to save error log. Default = "sorcha.err"
+        Suffix and extension with which to save error log. Default = "sorcha.err"
 
     Returns
     ----------
@@ -49,8 +53,8 @@ def PPGetLogger(
     dstr = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     cpid = os.getpid()
 
-    log_file_info = os.path.join(log_location, dstr + "-p" + str(cpid) + "-" + log_file_info)
-    log_file_error = os.path.join(log_location, dstr + "-p" + str(cpid) + "-" + log_file_error)
+    log_file_info = os.path.join(log_location, "-".join([log_stem, dstr, "p" + str(cpid), log_file_info]))
+    log_file_error = os.path.join(log_location, "-".join([log_stem, dstr, "p" + str(cpid), log_file_error]))
 
     file_handler_info = logging.FileHandler(log_file_info, mode="w")
     file_handler_info.setFormatter(log_formatter)

--- a/src/sorcha/utilities/check_output_logs.py
+++ b/src/sorcha/utilities/check_output_logs.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pandas as pd
 
 
@@ -64,7 +65,7 @@ def check_all_logs(log_files):
     return good_log, last_lines
 
 
-def check_output_logs(filepath, output):
+def check_output_logs(filepath, output=False):
     """Searches directories recursively for Sorcha log files, classifies them as
     belonging to successful or unsuccessful Sorcha runs, and provides this information
     to the user. This is helpful in cases where several runs of Sorcha are being
@@ -76,7 +77,7 @@ def check_output_logs(filepath, output):
     filepath : str
         Filepath of top-level directory within which to search for Sorcha log files.
     output : str or bool
-        Either the filepath/name in which to save output, or False to print output to terminal.
+        Either the filepath/name in which to save output, or False to print output to terminal. Default=False.
 
     """
 
@@ -85,8 +86,9 @@ def check_output_logs(filepath, output):
     if len(log_files) > 0:
         print(str(len(log_files)) + " Sorcha log files have been found. Investigating....\n")
     if len(log_files) == 0:
-        print("No Sorcha log files could be found in directories/subdirectories of supplied filepath.")
-        return
+        sys.exit(
+            "ERROR: no Sorcha log files could be found in directories/subdirectories of supplied filepath."
+        )
 
     good_log, last_lines = check_all_logs(log_files)
 

--- a/src/sorcha/utilities/check_output_logs.py
+++ b/src/sorcha/utilities/check_output_logs.py
@@ -1,0 +1,65 @@
+import os
+import pandas as pd
+
+
+def find_all_log_files(filepath):
+    log_files = []
+
+    for dirpath, dirnames, filenames in os.walk(filepath):
+        for filename in [f for f in filenames if f.endswith(".log")]:
+            log_files.append(os.path.join(dirpath, filename))
+
+    return log_files
+
+
+def check_all_logs(log_files):
+    good_log = []
+    last_lines = []
+
+    for log_file in log_files:
+        with open(log_file, "r") as f:
+            lines = f.read().splitlines()
+            last_line = lines[-1]
+
+            if last_line[-29:] == "Sorcha process is completed. ":
+                good_log.append(True)
+                last_lines.append(" ")
+            else:
+                good_log.append(False)
+                last_lines.append(last_line)
+
+    return good_log, last_lines
+
+
+def check_output_logs(filepath, output):
+    log_files = find_all_log_files(filepath)
+
+    if len(log_files) > 0:
+        print(str(len(log_files)) + " Sorcha log files have been found. Investigating....\n")
+    if len(log_files) == 0:
+        print("No Sorcha log files could be found in directories/subdirectories of supplied filepath.")
+        return
+
+    good_log, last_lines = check_all_logs(log_files)
+
+    log_results = pd.DataFrame(
+        {"log_filename": log_files, "run_successful": good_log, "log_lastline": last_lines}
+    )
+    failed_runs = log_results[~log_results["run_successful"]]
+
+    if len(failed_runs) > 0:
+        print(str(len(failed_runs)) + " unsuccessful Sorcha run(s) found.\n")
+
+        if output:
+            print("Saving results to: " + output)
+            log_results.to_csv(os.path.join(output))
+        else:
+            for i, row in failed_runs.iterrows():
+                print("Failed run log filename:\n\t" + row["log_filename"])
+                print("Failed run last line of log:\n\t" + row["log_lastline"])
+                print("\n\n")
+
+    else:
+        print("All Sorcha runs appear to have completed successfully. :)")
+
+    return

--- a/src/sorcha/utilities/check_output_logs.py
+++ b/src/sorcha/utilities/check_output_logs.py
@@ -3,16 +3,49 @@ import pandas as pd
 
 
 def find_all_log_files(filepath):
+    """Looks for all Sorcha log files in the given filepath and subdirectories
+    recursively. Specifically searches for files ending *sorcha.log.
+
+    Parameters
+    -----------
+    filepath : str
+        Filepath of top-level directory within which to search for Sorcha log files.
+
+    Returns
+    -----------
+    log_files : list
+        A list of the discovered log files (absolute paths)
+
+    """
     log_files = []
 
     for dirpath, dirnames, filenames in os.walk(filepath):
-        for filename in [f for f in filenames if f.endswith(".log")]:
+        for filename in [f for f in filenames if f.endswith("sorcha.log")]:
             log_files.append(os.path.join(dirpath, filename))
 
     return log_files
 
 
 def check_all_logs(log_files):
+    """Checks the last line of all the log files supplied and checks to see
+    if the Sorcha run completed successfully, saving the last line of the log
+    in question if it did not.
+
+    Parameters
+    -----------
+    log_files : list
+        A list of filepaths pointing to Sorcha log files.
+
+    Returns
+    -----------
+    good_log : list of Booleans
+        A list of whether each log file was deemed to be successful or not
+
+    last_lines : list of str
+        A list of the last lines of unsuccessful Sorcha runs.
+
+    """
+
     good_log = []
     last_lines = []
 
@@ -32,6 +65,21 @@ def check_all_logs(log_files):
 
 
 def check_output_logs(filepath, output):
+    """Searches directories recursively for Sorcha log files, classifies them as
+    belonging to successful or unsuccessful Sorcha runs, and provides this information
+    to the user. This is helpful in cases where several runs of Sorcha are being
+    performed simultaneously (i.e. on a supercomputer). Can output either a .csv
+    file or straight to the terminal.
+
+    Parameters
+    -----------
+    filepath : str
+        Filepath of top-level directory within which to search for Sorcha log files.
+    output : str or bool
+        Either the filepath/name in which to save output, or False to print output to terminal.
+
+    """
+
     log_files = find_all_log_files(filepath)
 
     if len(log_files) > 0:
@@ -57,9 +105,11 @@ def check_output_logs(filepath, output):
             for i, row in failed_runs.iterrows():
                 print("Failed run log filename:\n\t" + row["log_filename"])
                 print("Failed run last line of log:\n\t" + row["log_lastline"])
-                print("\n\n")
+                print("\n")
 
     else:
         print("All Sorcha runs appear to have completed successfully. :)")
+        if output:
+            print("No output will be saved.")
 
     return

--- a/src/sorcha_cmdline/outputs.py
+++ b/src/sorcha_cmdline/outputs.py
@@ -30,6 +30,37 @@ def cmd_outputs_create_sqlite(args):  # pragma: no cover
 
 
 #
+# sorcha outputs check-logs
+#
+
+
+def cmd_outputs_check_logs(args):  # pragma: no cover
+    from sorcha.utilities.check_output_logs import check_output_logs
+    from sorcha.modules.PPConfigParser import PPFindDirectoryOrExit
+    import os
+
+    args.filepath = os.path.abspath(args.filepath)
+    _ = PPFindDirectoryOrExit(args.filepath, "-f, --filepath")
+
+    if args.outpath:
+        args.outpath = os.path.abspath(args.outpath)
+        _ = PPFindDirectoryOrExit(os.path.dirname(args.outpath), "-o, --outpath")
+
+        if os.path.exists(args.outpath):
+            print(
+                "File already found at {}. Delete existing file or re-run with new output path.".format(
+                    args.outpath
+                )
+            )
+            return
+
+        if args.outpath[-4:] != ".csv":
+            args.outpath = args.outpath + ".csv"
+
+    return check_output_logs(args.filepath, args.outpath)
+
+
+#
 # sorcha outputs
 #
 
@@ -66,7 +97,7 @@ def main():
         "--outputs",
         type=str,
         required=True,
-        help="Path location of SSPP output files/folders. Code will search subdirectories recursively.",
+        help="Path location of Sorcha output files/folders. Code will search subdirectories recursively.",
     )
     outputs_create_sqlite_parser.add_argument(
         "-s",
@@ -80,6 +111,28 @@ def main():
         default=False,
         action="store_true",
         help="Toggle whether to look for cometary activity files. Default False.",
+    )
+
+    # Add the `check-logs` subcommand
+    outputs_create_checklog_parser = subparsers.add_parser(
+        "check-logs",
+        help="Check all Sorcha log files within a directory and subdirectories for successful/unsuccessful runs.",
+    )
+    outputs_create_checklog_parser.set_defaults(func=cmd_outputs_check_logs)
+
+    outputs_create_checklog_parser.add_argument(
+        "-f",
+        "--filepath",
+        type=str,
+        required=True,
+        help="Top level directory in which to search for Sorcha log files. Code will search subdirectories recursively.",
+    )
+    outputs_create_checklog_parser.add_argument(
+        "-o",
+        "--outpath",
+        type=str,
+        default=False,
+        help="Output filepath and name to save output .csv, if desired. If not supplied, output will be printed to the terminal.",
     )
 
     # Parse the command-line arguments

--- a/src/sorcha_cmdline/outputs.py
+++ b/src/sorcha_cmdline/outputs.py
@@ -46,13 +46,15 @@ def cmd_outputs_check_logs(args):  # pragma: no cover
         args.outpath = os.path.abspath(args.outpath)
         _ = PPFindDirectoryOrExit(os.path.dirname(args.outpath), "-o, --outpath")
 
-        if os.path.exists(args.outpath):
+        if os.path.exists(args.outpath) and not args.force:
             print(
-                "File already found at {}. Delete existing file or re-run with new output path.".format(
+                "File already found at {}. Re-run with --force argument to overwrite existing output.".format(
                     args.outpath
                 )
             )
             return
+        elif os.path.exists(args.outpath) and args.force:
+            os.remove(args.outpath)
 
         if args.outpath[-4:] != ".csv":
             args.outpath = args.outpath + ".csv"
@@ -133,6 +135,12 @@ def main():
         type=str,
         default=False,
         help="Output filepath and name to save output .csv, if desired. If not supplied, output will be printed to the terminal.",
+    )
+    outputs_create_checklog_parser.add_argument(
+        "--force",
+        default=False,
+        action="store_true",
+        help="Force overwrite existing output file. Default is False.",
     )
 
     # Parse the command-line arguments

--- a/src/sorcha_cmdline/run.py
+++ b/src/sorcha_cmdline/run.py
@@ -143,7 +143,7 @@ def execute(args):
 
     # Extract the output file path now in order to set up logging.
     outpath = PPFindFileOrExit(args.o, "-o, --outfile")
-    pplogger = PPGetLogger(outpath)
+    pplogger = PPGetLogger(outpath, args.t)
     pplogger.info("Sorcha Start (Main)")
     pplogger.info(f"Command line: {' '.join(sys.argv)}")
 

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -177,15 +177,30 @@ Used by:
 - test_ephemeris_generation.py  
 - test_pixdict.py
 
+**PPReadOrbitFile_bad_format.csv**  
+Example orbits file with bad formatting.  
+Used by:  
+- test_OrbitAuxReader.py
+
 **PPReadOrbitFile_bad.txt**  
 Example orbits file with bad column headers.  
 Used by:  
 - test_OrbitAuxReader.py
 
-**PPReadOrbitFile_bad_format.csv**  
-Example orbits file with bad formatting.  
+**run_1/testrun_1-sorcha.log**  
+Sorcha log file for a successful run.  
 Used by:  
-- test_OrbitAuxReader.py
+- test_check_output_logs.py
+
+**run_2/testrun_2-sorcha.log**  
+Sorcha log file for an unsuccessful run.  
+Used by:  
+- test_check_output_logs.py
+
+**sorcha_logs_expected.csv**  
+Test output for check_output_logs utility.  
+Used by:  
+- test_check_output_logs.py
 
 **sql_results/orbits_test1.txt**  
 Example orbits files with standardised names.  

--- a/tests/data/sorcha_logs_expected.csv
+++ b/tests/data/sorcha_logs_expected.csv
@@ -1,0 +1,3 @@
+Unnamed: 0,log_filename,run_successful,log_lastline
+0,/Users/stephaniemerritt/Projects/sorcha/tests/data/run_2/testrun_2-sorcha.log,False,"2024-09-03 15:13:38,536 sorcha.modules.PPCommandLineParser ERROR    ERROR: existing file found at output location ./testrun_stats.csv. Set -f flag to overwrite this file. "
+1,/Users/stephaniemerritt/Projects/sorcha/tests/data/run_1/testrun_1-sorcha.log,True, 

--- a/tests/ephemeris/test_ephemeris_generation.py
+++ b/tests/ephemeris/test_ephemeris_generation.py
@@ -120,7 +120,7 @@ def test_ephemeris_end2end(single_synthetic_pointing, tmp_path):
         "stats": None,
     }
 
-    pplogger = PPGetLogger(cmd_args_dict["outpath"])
+    pplogger = PPGetLogger(cmd_args_dict["outpath"], "test_log")
     args = sorchaArguments(cmd_args_dict)
 
     configs = PPConfigFileParser(

--- a/tests/sorcha/test_PPConfigParser.py
+++ b/tests/sorcha/test_PPConfigParser.py
@@ -237,7 +237,7 @@ def test_PPPrintConfigsToLog(tmp_path):
 
     test_path = os.path.dirname(get_test_filepath("test_input_fullobs.csv"))
 
-    pplogger = PPGetLogger(tmp_path, log_format="%(name)-12s %(levelname)-8s %(message)s ")
+    pplogger = PPGetLogger(tmp_path, "test_log", log_format="%(name)-12s %(levelname)-8s %(message)s ")
 
     cmd_args = {
         "paramsinput": "testcolour.txt",

--- a/tests/sorcha/test_PPGetLogger.py
+++ b/tests/sorcha/test_PPGetLogger.py
@@ -8,7 +8,7 @@ def test_PPGetLogger():
     from sorcha.modules.PPGetLogger import PPGetLogger
 
     with tempfile.TemporaryDirectory() as dir_name:
-        pplogger = PPGetLogger(dir_name)
+        pplogger = PPGetLogger(dir_name, "test_log")
 
         # Check that the files get created.
         errlog = glob.glob(os.path.join(dir_name, "*-sorcha.err"))

--- a/tests/sorcha/test_check_output_logs.py
+++ b/tests/sorcha/test_check_output_logs.py
@@ -1,0 +1,51 @@
+import os
+import pytest
+import pandas as pd
+from sorcha.utilities.dataUtilitiesForTests import get_test_filepath
+
+
+def test_find_and_check_all_log_files():
+    from sorcha.utilities.check_output_logs import find_all_log_files
+    from sorcha.utilities.check_output_logs import check_all_logs
+
+    filepath = os.path.dirname(get_test_filepath("oiftestoutput.txt"))
+
+    test_log = find_all_log_files(filepath)
+    assert len(test_log) == 2
+
+    good_log, last_lines = check_all_logs(test_log)
+
+    assert good_log == [False, True]
+    assert last_lines[1] == " "
+    assert len(last_lines[0]) == 171
+
+
+def test_check_output_logs(tmp_path):
+    from sorcha.utilities.check_output_logs import check_output_logs
+
+    filepath = os.path.dirname(get_test_filepath("oiftestoutput.txt"))
+
+    output = os.path.join(tmp_path, "sorcha_logs.csv")
+    check_output_logs(filepath, output)
+
+    # check output matches
+    written_output = pd.read_csv(output)
+    expected_output = pd.read_csv(get_test_filepath("sorcha_logs_expected.csv"))
+    pd.testing.assert_frame_equal(written_output, expected_output)
+
+    # check no output on successful run
+    single_filepath = os.path.join(os.path.dirname(get_test_filepath("oiftestoutput.txt")), "run_1")
+    successful_output = os.path.join(tmp_path, "successful_sorcha_logs.csv")
+    successful_run = check_output_logs(single_filepath, successful_output)
+
+    assert os.path.exists(successful_output) == False
+
+    # check error message when no files are found
+    with pytest.raises(SystemExit) as e:
+        failed_run = check_output_logs("dummy/path/")
+
+    assert e.type == SystemExit
+    assert (
+        e.value.code
+        == "ERROR: no Sorcha log files could be found in directories/subdirectories of supplied filepath."
+    )


### PR DESCRIPTION
Fixes #1003.
- All log files now share an output prefix with the Sorcha output file they are associated with, to aid location of bad runs.
- Wrote a utility script that will recursively search for all Sorcha log files in a given directory/subdirectories and check to see whether the Sorcha runs were successfully completed. Usage given below.
- Unit tests.

Usage for the new utility script is as follows. I put it in the outputs section of the command line utilities, as that made the most sense.

```
>> sorcha outputs check-logs <top level directory filepath> <optional output filepath>
```

The output file is a .csv consisting of the log filename, a True/False flag as to whether the run was successfully completed, and if not, the last line of the log file.

If you don't supply an output filename, it'll just output everything to the terminal. If all runs were successful, **no output file is created**, as I didn't see the point really. A happy message is printed to the terminal instead.

All unit tests pass on my machine.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
