### PR TITLE
Fixing config parser for bright limit

### DIFF
--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -442,21 +442,24 @@ def PPConfigFileParser(configfile, survey_name):
         config, "SATURATION", "bright_limit", "none"
     )
 
-    try:
-        bright_list = [float(e.strip()) for e in bright_limits.split(",")]
-    except ValueError:
-        pplogger.error("ERROR: could not parse brightness limits. Check formatting and try again.")
-        sys.exit("ERROR: could not parse brightness limits. Check formatting and try again.")
+    if config_dict["bright_limit_on"]:
+        try:
+            bright_list = [float(e.strip()) for e in bright_limits.split(",")]
+        except ValueError:
+            pplogger.error("ERROR: could not parse brightness limits. Check formatting and try again.")
+            sys.exit("ERROR: could not parse brightness limits. Check formatting and try again.")
 
-    if len(bright_list) == 1:
-        config_dict["bright_limit"] = bright_list[0]
-    else:
-        if len(bright_list) != len(config_dict["observing_filters"]):
-            pplogger.error(
-                "ERROR: list of saturation limits is not the same length as list of observing filters."
-            )
-            sys.exit("ERROR: list of saturation limits is not the same length as list of observing filters.")
-        config_dict["bright_limit"] = bright_list
+        if len(bright_list) == 1:
+            config_dict["bright_limit"] = bright_list[0]
+        else:
+            if len(bright_list) != len(config_dict["observing_filters"]):
+                pplogger.error(
+                    "ERROR: list of saturation limits is not the same length as list of observing filters."
+                )
+                sys.exit(
+                    "ERROR: list of saturation limits is not the same length as list of observing filters."
+                )
+            config_dict["bright_limit"] = bright_list
 
     # PHASECURVES
 


### PR DESCRIPTION
Fixes #1022.

Desired behaviour:
- if the bright limit keyword is not in the config file (e.g. if you are using Rubin_known_object_prediction.ini) the bright limit cut should be skipped

Actual behaviour:
- code broke completely because I forgot to wrap some stuff in an if-statement in PPConfigParser

Fix:
-  put the if-statement in

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
