### PR TITLE
Fixing utility script help strings/flags

### DIFF
--- a/src/sorcha/utilities/createResultsSQLDatabase.py
+++ b/src/sorcha/utilities/createResultsSQLDatabase.py
@@ -2,8 +2,8 @@
 # (physical parameters, orbits, cometary info, etc) into one SQL database with
 # tables SSPP_results, physical_parameters, orbits, cometary_parameters (if used)
 
-# The code assumes that your physical/cometary parameters and orbits files are
-# in the same folder and begin with 'params', 'comet' and 'orbits' respectively.
+# The code assumes that your physical/complex physical parameters and orbits files are
+# in the same folder and begin with 'params', 'complex' and 'orbits' respectively.
 # It also assumes that they are whitespace-separated. Feel free to adapt for your
 # own use-case :)
 
@@ -96,7 +96,7 @@ def create_inputs_table(cnx_out, input_path, table_type):
         Filepath of directory containing input files.
 
     table_type : string
-        Type of file. Should be "orbits"/"params"/"comet".
+        Type of file. Should be "orbits"/"params"/"complex".
 
     Returns
     -----------
@@ -139,20 +139,20 @@ def create_results_database(args):
 
     """
 
-    cnx_out = sqlite3.connect(args.filename)
+    cnx_out = sqlite3.connect(args.output)
 
     if args.stem:
         stemname = args.stem
     else:
         stemname = ""
 
-    create_results_table(cnx_out, args.filename, args.outputs, stemname)
+    create_results_table(cnx_out, args.inputs, args.results, stemname)
 
     create_inputs_table(cnx_out, args.inputs, "params")
     create_inputs_table(cnx_out, args.inputs, "orbits")
 
-    if args.comet:
-        create_inputs_table(cnx_out, "comet")
+    if args.complex:
+        create_inputs_table(cnx_out, args.inputs, "complex")
 
 
 def get_column_names(filename, table_name="sorcha_results"):

--- a/src/sorcha_cmdline/outputs.py
+++ b/src/sorcha_cmdline/outputs.py
@@ -19,12 +19,12 @@ def cmd_outputs_create_sqlite(args):  # pragma: no cover
     from sorcha.modules.PPConfigParser import PPFindDirectoryOrExit
     import os
 
-    args.filename = os.path.abspath(args.filename)
+    args.output = os.path.abspath(args.output)
     args.inputs = os.path.abspath(args.inputs)
-    args.outputs = os.path.abspath(args.outputs)
+    args.results = os.path.abspath(args.results)
 
     _ = PPFindDirectoryOrExit(args.inputs, "-i, --inputs")
-    _ = PPFindDirectoryOrExit(args.outputs, "-o, --outputs")
+    _ = PPFindDirectoryOrExit(args.results, "-r, --results")
 
     return create_results_database(args)
 
@@ -69,7 +69,7 @@ def cmd_outputs_check_logs(args):  # pragma: no cover
 
 def main():
     # Create the top-level parser
-    parser = argparse.ArgumentParser(prog="sorcha-config", description="Sorcha outputs manipulation utility")
+    parser = argparse.ArgumentParser(prog="sorcha-outputs", description="Sorcha outputs manipulation utility")
     subparsers = parser.add_subparsers(
         title="commands", description="Available commands", help="Command to execute", dest="command"
     )
@@ -81,38 +81,38 @@ def main():
     outputs_create_sqlite_parser.set_defaults(func=cmd_outputs_create_sqlite)
 
     outputs_create_sqlite_parser.add_argument(
-        "-f",
-        "--filename",
+        "-o",
+        "--output",
         type=str,
         required=True,
-        help="Filepath and name where you want to save the database.",
+        help="Filepath and name where you want to save the created SQLite database.",
     )
     outputs_create_sqlite_parser.add_argument(
         "-i",
         "--inputs",
         type=str,
         required=True,
-        help="Path location of input text files (orbits, colours and config files).",
+        help="Path location of Sorcha input text files (orbits, physical parameters and config files).",
     )
     outputs_create_sqlite_parser.add_argument(
-        "-o",
-        "--outputs",
+        "-r",
+        "--results",
         type=str,
         required=True,
-        help="Path location of Sorcha output files/folders. Code will search subdirectories recursively.",
+        help="Path location of Sorcha results files/folders. Code will search subdirectories recursively.",
     )
     outputs_create_sqlite_parser.add_argument(
         "-s",
         "--stem",
         type=str,
-        help="Stem filename of outputs. Used to find output filenames. Use if you want to specify.",
+        help="Stem filename of Sorcha results files. Used to find Sorcha output filenames. Use if you want to specify.",
     )
     outputs_create_sqlite_parser.add_argument(
         "-c",
-        "--comet",
+        "--complex",
         default=False,
         action="store_true",
-        help="Toggle whether to look for cometary activity files. Default False.",
+        help="Toggle whether to look for complex physical parameters files. Default False.",
     )
 
     # Add the `check-logs` subcommand

--- a/tests/sorcha/test_createResultsSQLDatabase.py
+++ b/tests/sorcha/test_createResultsSQLDatabase.py
@@ -11,11 +11,11 @@ class args:
     def __init__(self, tmp_path):
         temp_path = get_test_filepath("sql_results")
 
-        args.filename = os.path.join(tmp_path, "test_res_database.db")
+        args.output = os.path.join(tmp_path, "test_res_database.db")
         args.inputs = temp_path
-        args.outputs = temp_path
+        args.results = temp_path
         args.stem = "sqlresults"
-        args.comet = False
+        args.complex = False
 
 
 def test_get_column_names():


### PR DESCRIPTION
Fixes #1020.
- Fixed the help prompt for sorcha-outputs so it reads `sorcha-outputs` instead of `sorcha-config`

Fixes #1021.
- Changed the command line flags for `sorcha outputs create-sqlite` to hopefully be a bit more intuitive
- Realised that the `sorcha outputs create-sqlite` functionality still referred to the obsolete "comet" input file, so changed all instances to "complex" for the complex physical parameters file
- Found and fixed a bug
- Updated the unit test

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
