### PR TITLE
Sorting discovered log files

### DIFF
--- a/src/sorcha/utilities/check_output_logs.py
+++ b/src/sorcha/utilities/check_output_logs.py
@@ -24,7 +24,7 @@ def find_all_log_files(filepath):
         for filename in [f for f in filenames if f.endswith("sorcha.log")]:
             log_files.append(os.path.join(dirpath, filename))
 
-    return log_files
+    return sorted(log_files)
 
 
 def check_all_logs(log_files):

--- a/tests/data/sorcha_logs_expected.csv
+++ b/tests/data/sorcha_logs_expected.csv
@@ -1,3 +1,3 @@
 log_filename,run_successful,log_lastline
-/Users/stephaniemerritt/Projects/sorcha/tests/data/run_2/testrun_2-sorcha.log,False,"2024-09-03 15:13:38,536 sorcha.modules.PPCommandLineParser ERROR    ERROR: existing file found at output location ./testrun_stats.csv. Set -f flag to overwrite this file. "
 /Users/stephaniemerritt/Projects/sorcha/tests/data/run_1/testrun_1-sorcha.log,True, 
+/Users/stephaniemerritt/Projects/sorcha/tests/data/run_2/testrun_2-sorcha.log,False,"2024-09-03 15:13:38,536 sorcha.modules.PPCommandLineParser ERROR    ERROR: existing file found at output location ./testrun_stats.csv. Set -f flag to overwrite this file. "

--- a/tests/sorcha/test_check_output_logs.py
+++ b/tests/sorcha/test_check_output_logs.py
@@ -16,9 +16,9 @@ def test_find_and_check_all_log_files():
 
     good_log, last_lines = check_all_logs(test_log)
 
-    assert good_log == [False, True]
-    assert last_lines[1] == " "
-    assert len(last_lines[0]) == 171
+    assert good_log == [True, False]
+    assert last_lines[0] == " "
+    assert len(last_lines[1]) == 171
 
 
 def test_check_output_logs(tmp_path):


### PR DESCRIPTION
Fixes #1030.
- The `find_all_log_files()` function in /utilities/check_output_logs.py now returns a sorted list, so the results will always be in the same order.
- Regenerated unit test data file.
- Small adjustment to unit test.

Did you know that `os.walk()` will return filenames in a different order depending on the filesystem? I didn't. I do now.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
