### PR TITLE
Creating global variable to set use_integrate

### DIFF
--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -113,6 +113,11 @@ def create_ephemeris(orbits_df, pointings_df, args, configs):
     nside = 2 ** configs["ar_healpix_order"]
     n_sub_intervals = 101  # configs["n_sub_intervals"]
 
+    if configs["ar_use_integrate"]:
+        #set global variable to use integrate method instead of integrate_or_interpolate
+        global USE_INTEGRATE
+        USE_INTEGRATE = True
+
     ephemeris_csv_filename = None
     if args.output_ephemeris_file and args.outpath:
         ephemeris_csv_filename = os.path.join(args.outpath, args.output_ephemeris_file)

--- a/src/sorcha/ephemeris/simulation_geometry.py
+++ b/src/sorcha/ephemeris/simulation_geometry.py
@@ -60,8 +60,17 @@ def integrate_light_time(sim, ex, t, r_obs, lt0=0, iter=3, speed_of_light=SPEED_
         Object velocity at t-lt
     """
     lt = lt0
+    global USE_INTEGRATE
+    try:
+        USE_INTEGRATE
+    except NameError:
+        USE_INTEGRATE = False
+
     for i in range(iter):
-        ex.integrate_or_interpolate(t - lt)
+        if USE_INTEGRATE:
+            sim.integrate(t - lt)
+        else:
+            ex.integrate_or_interpolate(t - lt)
         target = np.array(sim.particles[0].xyz)
         vtarget = np.array(sim.particles[0].vxyz)
         rho = target - r_obs

--- a/src/sorcha/modules/PPConfigParser.py
+++ b/src/sorcha/modules/PPConfigParser.py
@@ -748,6 +748,16 @@ def PPConfigFileParser(configfile, survey_name):
         )
 
     try:
+        config_dict["ar_use_integrate"] = config.getboolean("EXPERT", "ar_use_integrate", fallback=False)
+    except ValueError:
+        pplogger.error(
+            "ERROR: could not parse value for ar_use_integrate as a boolean. Check formatting and try again."
+        )
+        sys.exit(
+            "ERROR: could not parse value for ar_use_integrate as a boolean. Check formatting and try again."
+        )
+
+    try:
         config_dict["trailing_losses_on"] = config.getboolean("EXPERT", "trailing_losses_on", fallback=True)
     except ValueError:
         pplogger.error(
@@ -856,6 +866,11 @@ def PPPrintConfigsToLog(configs, cmd_args):
         "The apparent brightness is calculated using the following phase function model: "
         + configs["phase_function"]
     )
+
+    if configs["ar_use_integrate"]:
+        pplogger.info("ASSIST+REBOUND integration is ON. Integrate or interpolate will NOT be used.")
+    else:
+        pplogger.info("ASSIST+REBOUND integration is OFF. Integrate or interpolate will be used.")
 
     if configs["trailing_losses_on"]:
         pplogger.info("Computation of trailing losses is switched ON.")

--- a/tests/data/test_PPPrintConfigsToLog.txt
+++ b/tests/data/test_PPPrintConfigsToLog.txt
@@ -14,6 +14,7 @@ sorcha.modules.PPConfigParser INFO     The main filter in which H is defined is 
 sorcha.modules.PPConfigParser INFO     The filters included in the post-processing results are r g i z 
 sorcha.modules.PPConfigParser INFO     Thus, the colour indices included in the simulation are g-r i-r z-r 
 sorcha.modules.PPConfigParser INFO     The apparent brightness is calculated using the following phase function model: HG 
+sorcha.modules.PPConfigParser INFO     ASSIST+REBOUND integration is OFF. Integrate or interpolate will be used. 
 sorcha.modules.PPConfigParser INFO     Computation of trailing losses is switched ON. 
 sorcha.modules.PPConfigParser INFO     Randomization of position and magnitude around uncertainties is switched ON. 
 sorcha.modules.PPConfigParser INFO     Vignetting is switched ON. 

--- a/tests/ephemeris/test_ephemeris_generation.py
+++ b/tests/ephemeris/test_ephemeris_generation.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 import os
 import re
+from numpy.testing import assert_almost_equal
 
 from sorcha.utilities.dataUtilitiesForTests import get_test_filepath, get_demo_filepath
 from sorcha.modules.PPConfigParser import PPConfigFileParser
@@ -150,6 +151,23 @@ def test_ephemeris_end2end(single_synthetic_pointing, tmp_path):
 
     for file in files:
         assert not re.match(r".+\.csv", file)
+
+    configs["ar_use_integrate"] = True
+
+    observations_integrate = create_ephemeris(
+        single_synthetic_pointing,
+        filterpointing,
+        args,
+        configs,
+    )
+
+    assert len(observations_integrate) == 10
+
+    assert_almost_equal(
+        observations_integrate["fieldMJD_TAI"].values, observations["fieldMJD_TAI"].values, decimal=6
+    )
+    assert_almost_equal(observations_integrate["RA_deg"].values, observations["RA_deg"].values, decimal=6)
+    assert_almost_equal(observations_integrate["Dec_deg"].values, observations["Dec_deg"].values, decimal=6)
 
 
 def test_ephemeris_writeread_csv(single_synthetic_ephemeris, tmp_path):

--- a/tests/sorcha/test_PPConfigParser.py
+++ b/tests/sorcha/test_PPConfigParser.py
@@ -77,6 +77,7 @@ def test_PPConfigFileParser(setup_and_teardown_for_PPConfigFileParser):
         "lc_model": None,
         "randomization_on": True,
         "vignetting_on": True,
+        "ar_use_integrate": False,
     }
 
     assert configs == test_configs
@@ -300,6 +301,7 @@ def test_PPPrintConfigsToLog(tmp_path):
         "lc_model": None,
         "randomization_on": True,
         "vignetting_on": True,
+        "ar_use_integrate": False,
     }
 
     PPPrintConfigsToLog(configs, args)


### PR DESCRIPTION
Fixes # .

Creates a config parameter to allow use of the rebound integrate method instead of assist's integrate_or_interpolate. create_epheremeris sets a global variable from the config which is checked in integrate_light_time. This seemed less messy than drilling the option down to the lower functions, but happy to do it that way as well if that's preferable. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
