### PR TITLE
Big speedup for ObjID checking

### DIFF
--- a/src/sorcha/readers/CombinedDataReader.py
+++ b/src/sorcha/readers/CombinedDataReader.py
@@ -19,6 +19,7 @@ rows for the current objects.
 import logging
 import pandas as pd
 import sys
+import numpy as np
 
 
 class CombinedDataReader:
@@ -81,9 +82,22 @@ class CombinedDataReader:
                 primary_ids = self.aux_data_readers[i].obj_id_table
                 continue
 
-            if not all(
-                item in primary_ids.values for item in self.aux_data_readers[i].obj_id_table.values
-            ) or (len(primary_ids) != len(self.aux_data_readers[i].obj_id_table)):
+            raise_error = False
+            if len(primary_ids) != len(self.aux_data_readers[i].obj_id_table):
+                pplogger.error(
+                    "ERROR: mismatched ObjIDs in auxiliary input files. IDs in {} do not match {}.".format(
+                        self.aux_data_readers[0].filename, self.aux_data_readers[i].filename
+                    )
+                )
+                sys.exit(
+                    "ERROR: mismatched ObjIDs in auxiliary input files. IDs in {} do not match {}.".format(
+                        self.aux_data_readers[0].filename, self.aux_data_readers[i].filename
+                    )
+                )
+            elif not all(
+                np.sort(primary_ids["ObjID"].values)
+                == np.sort(self.aux_data_readers[i].obj_id_table["ObjID"].values)
+            ):
                 pplogger.error(
                     "ERROR: mismatched ObjIDs in auxiliary input files. IDs in {} do not match {}.".format(
                         self.aux_data_readers[0].filename, self.aux_data_readers[i].filename

--- a/src/sorcha/readers/CombinedDataReader.py
+++ b/src/sorcha/readers/CombinedDataReader.py
@@ -19,7 +19,7 @@ rows for the current objects.
 import logging
 import pandas as pd
 import sys
-import numpy as np
+import collections
 
 
 class CombinedDataReader:
@@ -94,9 +94,8 @@ class CombinedDataReader:
                         self.aux_data_readers[0].filename, self.aux_data_readers[i].filename
                     )
                 )
-            elif not all(
-                np.sort(primary_ids["ObjID"].values)
-                == np.sort(self.aux_data_readers[i].obj_id_table["ObjID"].values)
+            elif collections.Counter(primary_ids["ObjID"].values) != collections.Counter(
+                self.aux_data_readers[i].obj_id_table["ObjID"].values
             ):
                 pplogger.error(
                     "ERROR: mismatched ObjIDs in auxiliary input files. IDs in {} do not match {}.".format(


### PR DESCRIPTION
Fixes #1040.
- Changed the way the ObjID columns in auxiliary input files are checked against each other in `CombinedDataReader.check_aux_object_ids()`. 
- Tweaked error handling a bit so it worked properly again.

Initially I implemented this in the silliest way possible, by checking each individual element in one ObjID list to make sure it exists in the other list. This is O(n^2) complexity -- runtime scales quadratically with the size of the data -- and I should have known better. I plead temporary insanity.

It's now using collections.Counter() to compare one list's count of unique elements to the other. This is O(n) so runtime scales linearly with data size. 

On an input file of 250,000 rows it takes **150ms**. 

(Not twelve minutes.)

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
