### PR TITLE
cleaned up minidifi, added docstrings, updated PPLinkingFilter unit test to adapt to updated minidifi

### DIFF
--- a/benchmarks/bench_cProfile.py
+++ b/benchmarks/bench_cProfile.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":  # pragma: no cover
     # get path to Sorcha top-level folder
     path_to_file = os.path.abspath(__file__)
     path_to_sorcha = str(Path(path_to_file).parents[1])
-    
+
     print(path_to_sorcha)
 
     cmd_args_dict = {
@@ -34,7 +34,7 @@ if __name__ == "__main__":  # pragma: no cover
         "outfilestem": os.path.join(path_to_sorcha, f"out_{args.object_type}"),
         "verbose": False,
         "surveyname": "rubin_sim",
-        "stats": None
+        "stats": None,
     }
 
     args_obj = sorchaArguments(cmd_args_dict)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,5 +44,5 @@ autoapi_dirs = ["../src"]
 autoapi_ignore = ["*/__main__.py", "*/_version.py"]
 autoapi_add_toc_tree_entry = False
 autoapi_member_order = "bysource"
-smartquotes = False 
+smartquotes = False
 html_theme = "sphinx_rtd_theme"

--- a/src/sorcha/modules/PPMiniDifi.py
+++ b/src/sorcha/modules/PPMiniDifi.py
@@ -47,7 +47,7 @@ def haversine_np(lon1, lat1, lon2, lat2):
 @njit(cache=True)
 def hasTracklet(mjd, ra, dec, maxdt_minutes, minlen_arcsec):
     """
-    Given a set of observations in one night, calculate it has 
+    Given a set of observations in one night, calculate it has
     at least onedetectable tracklet.
 
     Parameters
@@ -97,8 +97,8 @@ def hasTracklet(mjd, ra, dec, maxdt_minutes, minlen_arcsec):
 
 @njit(cache=True)
 def trackletsInNights(night, mjd, ra, dec, maxdt_minutes, minlen_arcsec):
-    '''
-    Calculate, for a given set of observations sorted by observation time, 
+    """
+    Calculate, for a given set of observations sorted by observation time,
     whether or not it has at least one discoverable tracklet in each night.
 
     Parameters
@@ -129,7 +129,7 @@ def trackletsInNights(night, mjd, ra, dec, maxdt_minutes, minlen_arcsec):
     hasTrk : boolean or array of booleans
         Array denoting if each night has a discoverable tracklet
 
-    '''
+    """
 
     nights = np.unique(night)
     hasTrk = np.zeros(len(nights), dtype="bool")
@@ -147,7 +147,7 @@ def trackletsInNights(night, mjd, ra, dec, maxdt_minutes, minlen_arcsec):
 
 @njit(cache=True)
 def discoveryOpportunities(nights, nightHasTracklets, window, nlink, p, rng):
-    '''
+    """
     Find all nights where a trailing window of <window> nights (including the
     current night) has at least <nlink> tracklets to constitute a discovery.
 
@@ -161,7 +161,7 @@ def discoveryOpportunities(nights, nightHasTracklets, window, nlink, p, rng):
 
     window : float
         Number of tracklets required with <= this window to complete a detection
-    
+
     nlink : float
         Number of tracklets required to form detection
 
@@ -179,7 +179,7 @@ def discoveryOpportunities(nights, nightHasTracklets, window, nlink, p, rng):
     disc : list of floats
         List of MJD dates where the object is discoverable
 
-    '''
+    """
 
     if nlink > 1:
         # algorithm: create an array of length [0 ... num_nights],
@@ -233,7 +233,7 @@ def discoveryOpportunities(nights, nightHasTracklets, window, nlink, p, rng):
 
 
 def linkObject(obsv, seed, maxdt_minutes, minlen_arcsec, window, nlink, p, night_start_utc_days):
-    '''
+    """
     For a set of observations of a single object, calculate if there are any tracklets,
     if there are enough tracklets to form a discovery window, and then report back all of
     those successful discoveries.
@@ -281,11 +281,11 @@ def linkObject(obsv, seed, maxdt_minutes, minlen_arcsec, window, nlink, p, night
 
     discoverySubmissionDate : float
         The night at which the discovery is first submitted
-    
+
     discoveryChances : float
         The number of chances for discovery of the object
 
-    '''
+    """
     discoveryObservationId = 0xFFFF_FFFF_FFFF_FFFF
     discoverySubmissionDate = np.nan
     discoveryChances = 0
@@ -344,10 +344,10 @@ def linkObservations(
     dec="decl",
     **config,
 ):
-    '''
+    """
     Ingesting a set of observations for one or more objects, determine if each object
     would be discovered by the SSP pipeline based on tracklet forming and linking.
-    
+
     Parameters
     -----------
     obsv : numpy array
@@ -397,7 +397,7 @@ def linkObservations(
             discoveryChances : float
                 The number of chances for discovery of the object
 
-    '''
+    """
 
     # create the "group by" splits for individual objects
     # See https://stackoverflow.com/a/43094244 for inspiration for this code

--- a/tests/sorcha/test_PPLinkingFilter.py
+++ b/tests/sorcha/test_PPLinkingFilter.py
@@ -114,7 +114,7 @@ def test_PPLinkingFilter_discoveryChances():
         window=min_tracklet_window,
         nlink=min_tracklets,
         p=detection_efficiency,
-        night_start_utc_days=17.0/24.0
+        night_start_utc_days=17.0 / 24.0,
     )
     assert len(obj) == 1
 
@@ -161,7 +161,7 @@ def test_PPLinkingFilter_nlink1():
         window=min_tracklet_window,
         nlink=min_tracklets,
         p=detection_efficiency,
-        night_start_utc_days=17.0/24.0
+        night_start_utc_days=17.0 / 24.0,
     )
     assert len(obj) == 1
 
@@ -319,8 +319,8 @@ def test_PPLinkingFilter():
 
     return
 
-    # check that the correct linking window has been applied 
-    inputdf = pd.read_csv(get_test_filepath('./test_input_minidifi_observations.csv'))
+    # check that the correct linking window has been applied
+    inputdf = pd.read_csv(get_test_filepath("./test_input_minidifi_observations.csv"))
 
     detection_efficiency = 0.95
     np.random.seed(42)
@@ -339,6 +339,7 @@ def test_PPLinkingFilter():
         assert False
     else:
         assert len(linked_observations) != 0
+
 
 def test_PPLinkingFilter_nodrop():
     from sorcha.modules.PPLinkingFilter import PPLinkingFilter

--- a/tests/sorcha/test_PPLinkingFilter.py
+++ b/tests/sorcha/test_PPLinkingFilter.py
@@ -114,6 +114,7 @@ def test_PPLinkingFilter_discoveryChances():
         window=min_tracklet_window,
         nlink=min_tracklets,
         p=detection_efficiency,
+        night_start_utc_days=17.0/24.0
     )
     assert len(obj) == 1
 
@@ -160,6 +161,7 @@ def test_PPLinkingFilter_nlink1():
         window=min_tracklet_window,
         nlink=min_tracklets,
         p=detection_efficiency,
+        night_start_utc_days=17.0/24.0
     )
     assert len(obj) == 1
 

--- a/tests/sorcha/test_demo_end2end.py
+++ b/tests/sorcha/test_demo_end2end.py
@@ -76,9 +76,7 @@ def test_demo_verification():
         for i in v:
             v[i].sort("fieldMJD_TAI")
             t[i].sort("observationStartMJD_TAI")
-            for j, k in zip(
-                ["RA_deg", "Dec_deg", "trailedSourceMag"], ["RA_INTERP", "DEC_INTERP", "mag"]
-            ):
+            for j, k in zip(["RA_deg", "Dec_deg", "trailedSourceMag"], ["RA_INTERP", "DEC_INTERP", "mag"]):
                 m = np.abs(np.mean(v[i][j] - t[i][k]))
                 if k == "mag":
                     assert np.isclose(np.max(m), 0, atol=1e-3)  # 1 mmag - should be much better than that


### PR DESCRIPTION
Fixes #1046

miniDifi has also had remaining bug testing code swept up and removed (🧹 sorry Mario).

In doing so, I removed a segment that updated the default linking config variables locally within PPMiniDifi as per a call on 23rd Oct. This is not needed here as it is read in from the configs variable within PPLinkingFilter -> PPMiniDifi anyways and all results remain the same. This does however affect two unit tests within test_PPLinkingFilter that depended on this config being read in locally. It can and has been fixed by adding the night_start_utc_days as extra arguments to test_PPLinkingFilter_nlink1 and test_PPLinkingFilter_discoveryChances and the unit tests work again.

Also doc strings have now been added to all functions within miniDifi. May want to double check I have described everything accurately just in case.