### PR TITLE
Replacing code block which counts input objects

### DIFF
--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -158,16 +158,13 @@ def runLSSTSimulation(args, configs):
     reader.check_aux_object_ids()
 
     # In case of a large input file, the data is read in chunks. The
-    # "sizeSerialChunk" parameter in the config file assigns the chunk.
+    # "size_serial_chunk" parameter in the config file assigns the chunk size.
     startChunk = 0
     endChunk = 0
     loopCounter = 0
 
-    ii = -1
-    with open(args.orbinfile) as f:
-        for ii, l in enumerate(f):
-            pass
-    lenf = ii
+    # Get number of objects in total.
+    lenf = len(reader.aux_data_readers[0].obj_id_table)
 
     footprint = None
     if configs["camera_model"] == "footprint":


### PR DESCRIPTION
Fixes #1050.
- Removed code block in sorcha.py which obtained the number of input objects by reading the number of lines in the orbits input file.
- Replaced it with a simple `len()` call on the already-generated `obj_id_table` attribute on the reader class: this is quicker and more accurate, as it accounts for long headers.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
