### PR TITLE
Fixing bugs with add-on classes

### DIFF
--- a/src/sorcha/activity/base_activity.py
+++ b/src/sorcha/activity/base_activity.py
@@ -32,7 +32,7 @@ class AbstractCometaryActivity(ABC):
         df : Pandas dataframe
             The ``observations`` dataframe provided by ``Sorcha``.
         """
-        raise (NotImplementedError, "Must be implemented by the subclass")
+        raise NotImplementedError("Must be implemented by the subclass")
 
     def _validate_column_names(self, df: pd.DataFrame) -> None:
         """Private method that checks that the provided pandas dataframe contains
@@ -47,7 +47,7 @@ class AbstractCometaryActivity(ABC):
             if colname not in df.columns:
                 err_msg = f"Input dataframe is missing column %{colname}"
                 self._log_error_message(error_msg=err_msg)
-                raise (ValueError, err_msg)
+                raise ValueError(err_msg)
 
     def _log_exception(self, exception: Exception) -> None:
         """Log an error message from an exception to the error log file
@@ -73,4 +73,4 @@ class AbstractCometaryActivity(ABC):
     @abstractmethod
     def name_id() -> str:
         """This method will return the unique name of the LightCurve Model"""
-        raise (NotImplementedError, "Must be implemented as a static method by the subclass")
+        raise NotImplementedError("Must be implemented as a static method by the subclass")

--- a/src/sorcha/lightcurves/base_lightcurve.py
+++ b/src/sorcha/lightcurves/base_lightcurve.py
@@ -32,7 +32,7 @@ class AbstractLightCurve(ABC):
         df : Pandas dataframe
             The ``observations`` dataframe provided by ``Sorcha``.
         """
-        raise (NotImplementedError, "Must be implemented by the subclass")
+        raise NotImplementedError("Must be implemented by the subclass")
 
     def _validate_column_names(self, df: pd.DataFrame) -> None:
         """Private method that checks that the provided pandas dataframe contains
@@ -47,7 +47,7 @@ class AbstractLightCurve(ABC):
             if colname not in df.columns:
                 err_msg = f"Input dataframe is missing column %{colname}"
                 self._log_error_message(error_msg=err_msg)
-                raise (ValueError, err_msg)
+                raise ValueError(err_msg)
 
     def _log_exception(self, exception: Exception) -> None:
         """Log an error message from an exception to the error log file
@@ -73,4 +73,4 @@ class AbstractLightCurve(ABC):
     @abstractmethod
     def name_id() -> str:
         """This method will return the unique name of the LightCurve Model"""
-        raise (NotImplementedError, "Must be implemented as a static method by the subclass")
+        raise NotImplementedError("Must be implemented as a static method by the subclass")

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -100,9 +100,6 @@ def runLSSTSimulation(args, configs):
     pplogger = logging.getLogger(__name__)
     pplogger.info("Post-processing begun.")
 
-    update_lc_subclasses()
-    update_activity_subclasses()
-
     try:
         args.validate_arguments()
     except Exception as err:

--- a/src/sorcha_cmdline/run.py
+++ b/src/sorcha_cmdline/run.py
@@ -138,6 +138,8 @@ def execute(args):
         PPConfigFileParser,
         runLSSTSimulation,
         sorchaArguments,
+        update_activity_subclasses,
+        update_lc_subclasses,
     )
     import sys, os
 
@@ -146,6 +148,10 @@ def execute(args):
     pplogger = PPGetLogger(outpath, args.t)
     pplogger.info("Sorcha Start (Main)")
     pplogger.info(f"Command line: {' '.join(sys.argv)}")
+
+    # update add-on subclasses before we parse the config file!
+    update_lc_subclasses()
+    update_activity_subclasses()
 
     # Extract and validate the remaining arguments.
     cmd_args = PPCommandLineParser(args)


### PR DESCRIPTION
Fixes #1056.
- Moved the lines of code which update the activity and lightcurve subclasses to run.py so this happens before we call PPConfigParser().
- Found that the raised exceptions in the base activity and lightcurve abstract classes weren't implemented correctly (wrong syntax) so I fixed that too.
- Tested it along with a fix to [this issue](https://github.com/dirac-institute/sorcha-addons/issues/31) and it all runs correctly now.

Describe your changes.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
