### PR TITLE
Clarifying error message in PPReadPointingDatabase()

### DIFF
--- a/src/sorcha/modules/PPReadPointingDatabase.py
+++ b/src/sorcha/modules/PPReadPointingDatabase.py
@@ -32,13 +32,16 @@ def PPReadPointingDatabase(bsdbname, observing_filters, dbquery, surveyname):
 
     try:
         df = pd.read_sql_query(dbquery, con)
-    except Exception:
+    except pd.errors.DatabaseError:
         pplogger.error(
             "ERROR: PPReadPointingDatabase: SQL query on pointing database failed. Check that the query is correct in the config file."
         )
         sys.exit(
             "ERROR: PPReadPointingDatabase: SQL query on pointing database failed. Check that the query is correct in the config file."
         )
+    except Exception as e:  # pragma: no cover
+        pplogger.error(f"ERROR: PPReadPointingDatabase: error reading from pointing database: {e}")
+        sys.exit(f"ERROR: PPReadPointingDatabase: error reading from pointing database: {e}")
 
     df["observationId_"] = df["observationId"]
     df = df.rename(columns={"observationId": "FieldID"})


### PR DESCRIPTION
Fixes #1058.
- Split up exception handling in `PPReadPointingDatabase()`.
- One error message triggers specifically if the SQL query is problematic. This would be the most common cause of failure.
- However, Joe has reported a failure for a different, unknown reason (probably file access issues due to multiple HPC runs). The second except catches all other exceptions and will include the Python error message in the message it prints to the terminal and log.

Describe your changes.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
