### PR TITLE
Minimal cmdline update

### DIFF
--- a/src/sorcha/utilities/sorcha_demo_command.py
+++ b/src/sorcha/utilities/sorcha_demo_command.py
@@ -14,7 +14,7 @@ def get_demo_command():
         working sorcha demo command
     """
 
-    return "sorcha run -c sorcha_config_demo.ini -p sspp_testset_colours.txt -ob sspp_testset_orbits.des -pd baseline_v2.0_1yr.db -o ./ -t testrun_e2e -st testrun_stats"
+    return "sorcha run -c sorcha_config_demo.ini -p sspp_testset_colours.txt --orbits sspp_testset_orbits.des --pointing-db baseline_v2.0_1yr.db -o ./ -t testrun_e2e --stats testrun_stats"
 
 
 def print_demo_command(printall=True):

--- a/src/sorcha_cmdline/main.py
+++ b/src/sorcha_cmdline/main.py
@@ -46,17 +46,20 @@ def main():
     parser = argparse.ArgumentParser(
         description=description, epilog=epilog_text, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+
     parser.add_argument(
         "--version",
         help="Print version information",
         dest="version",
         action="store_true",
     )
+
     parser.add_argument("verb", nargs="?", choices=available_verbs, help="Verb to execute")
     parser.add_argument("args", nargs=argparse.REMAINDER, help="Arguments for the verb")
 
     args = parser.parse_args()
 
+    # intercept global options (just version, for now)
     if args.version:
         import sorcha
 

--- a/src/sorcha_cmdline/run.py
+++ b/src/sorcha_cmdline/run.py
@@ -26,9 +26,9 @@ def main():
         required=True,
     )
     required.add_argument(
-        "-ob",
-        "--orbit",
-        help="Orbit file name",
+        "--ob",
+        "--orbits",
+        help="Orbit catalog file name",
         type=str,
         dest="ob",
         required=True,
@@ -42,8 +42,8 @@ def main():
         required=True,
     )
     required.add_argument(
-        "-pd",
-        "--pointing_database",
+        "--pd",
+        "--pointing-db",
         help="Survey pointing information",
         type=str,
         dest="pd",
@@ -52,8 +52,8 @@ def main():
 
     optional = parser.add_argument_group("Optional arguments")
     optional.add_argument(
-        "-er",
-        "--ephem_read",
+        "--er",
+        "--ephem-read",
         help="Previously generated ephemeris simulation file name, required if ephemerides_type in config file is 'external'.",
         type=str,
         dest="er",
@@ -61,8 +61,8 @@ def main():
         default=None,
     )
     optional.add_argument(
-        "-ew",
-        "--ephem_write",
+        "--ew",
+        "--ephem-write",
         help="Output file name for newly generated ephemeris simulation, required if ephemerides_type in config file is not 'external'.",
         type=str,
         dest="ew",
@@ -70,16 +70,16 @@ def main():
         default=None,
     )
     optional.add_argument(
-        "-ar",
-        "--ar_data_path",
+        "--ar",
+        "--ar-data-path",
         help="Directory path where Assist+Rebound data files where stored when running bootstrap_sorcha_data_files from the command line.",
         type=str,
         dest="ar",
         required=False,
     )
     optional.add_argument(
-        "-cp",
-        "--complex_physical_parameters",
+        "--cp",
+        "--complex-physical-parameters",
         help="Complex physical parameters file name",
         type=str,
         dest="cp",
@@ -108,7 +108,7 @@ def main():
     )
 
     optional.add_argument(
-        "-st",
+        "--st",
         "--stats",
         help="Output summary statistics table to this stem filename.",
         type=str,

--- a/src/sorcha_cmdline/run.py
+++ b/src/sorcha_cmdline/run.py
@@ -35,8 +35,8 @@ def main():
     )
     required.add_argument(
         "-p",
-        "--params",
-        help="Physical parameters file name",
+        "--physical-parameters",
+        help="Catalog of object physical parameters",
         type=str,
         dest="p",
         required=True,
@@ -80,7 +80,7 @@ def main():
     optional.add_argument(
         "--cp",
         "--complex-physical-parameters",
-        help="Complex physical parameters file name",
+        help="Catalog of object complex physical parameters",
         type=str,
         dest="cp",
     )
@@ -101,7 +101,7 @@ def main():
     optional.add_argument(
         "-v",
         "--verbose",
-        help="Verbosity. Default currently true; include to turn off verbosity.",
+        help="Print additional information to log while running",
         dest="v",
         default=True,
         action="store_false",


### PR DESCRIPTION
Fixes #978

This PR minimally changes the names of the command line options of`sorcha run`, to have them follow typical UNIX conventions better:

  * Have short options with multiple letters start with -- rather than - (e.g., -ob has been renamed to --ob)

  * Have multi-word options use - rather than _ as a word separator (e.g., --ephem-write instead of --ephem_write)

  * Rename options as requested [here](https://github.com/dirac-institute/sorcha/issues/978#issuecomment-2368297768).

Also changed the name of `--orbit` to `--orbits`.

Also added a `sorcha --version` option.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
