### PR TITLE
Correct the spelling of Steve Chesley's name

### DIFF
--- a/src/sorcha/data/demo/sorcha_config_demo.ini
+++ b/src/sorcha/data/demo/sorcha_config_demo.ini
@@ -108,14 +108,14 @@ footprint_edge_threshold = 2.
 [FADINGFUNCTION]
 
 # Detection efficiency fading function on or off. Uses the fading function as outlined in
-# Chelsey and Vereš (2017) to remove observations.
+# Chesley and Vereš (2017) to remove observations.
 fading_function_on = True
 
 # Width parameter for fading function. Should be greater than zero and less than 0.5.
-# Suggested value is 0.1 after Chelsey and Vereš (2017).
+# Suggested value is 0.1 after Chesley and Vereš (2017).
 fading_function_width = 0.1
 
-# Peak efficiency for the fading function, called the 'fill factor' in Chelsey and Veres (2017).
+# Peak efficiency for the fading function, called the 'fill factor' in Chesley and Veres (2017).
 # Suggested value is 1. Do not change this unless you are sure of what you are doing.
 fading_function_peak_efficiency = 1.
 

--- a/src/sorcha/data/survey_setups/Rubin_circular_approximation.ini
+++ b/src/sorcha/data/survey_setups/Rubin_circular_approximation.ini
@@ -99,14 +99,14 @@ circle_radius = 1.75
 [FADINGFUNCTION]
 
 # Detection efficiency fading function on or off. Uses the fading function as outlined in
-# Chelsey and Vereš (2017) to remove observations.
+# Chesley and Vereš (2017) to remove observations.
 fading_function_on = True
 
 # Width parameter for fading function. Should be greater than zero and less than 0.5.
-# Suggested value is 0.1 after Chelsey and Vereš (2017).
+# Suggested value is 0.1 after Chesley and Vereš (2017).
 fading_function_width = 0.1
 
-# Peak efficiency for the fading function, called the 'fill factor' in Chelsey and Veres (2017).
+# Peak efficiency for the fading function, called the 'fill factor' in Chesley and Veres (2017).
 # Suggested value is 1. Do not change this unless you are sure of what you are doing.
 fading_function_peak_efficiency = 1.
 

--- a/src/sorcha/data/survey_setups/Rubin_full_footprint.ini
+++ b/src/sorcha/data/survey_setups/Rubin_full_footprint.ini
@@ -99,14 +99,14 @@ footprint_edge_threshold = 2.
 [FADINGFUNCTION]
 
 # Detection efficiency fading function on or off. Uses the fading function as outlined in
-# Chelsey and Vereš (2017) to remove observations.
+# Chesley and Vereš (2017) to remove observations.
 fading_function_on = True
 
 # Width parameter for fading function. Should be greater than zero and less than 0.5.
-# Suggested value is 0.1 after Chelsey and Vereš (2017).
+# Suggested value is 0.1 after Chesley and Vereš (2017).
 fading_function_width = 0.1
 
-# Peak efficiency for the fading function, called the 'fill factor' in Chelsey and Veres (2017).
+# Peak efficiency for the fading function, called the 'fill factor' in Chesley and Veres (2017).
 # Suggested value is 1. Do not change this unless you are sure of what you are doing.
 fading_function_peak_efficiency = 1.
 

--- a/src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
+++ b/src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
@@ -90,7 +90,7 @@ footprint_edge_threshold = 2.
 [FADINGFUNCTION]
 
 # Detection efficiency fading function on or off. Uses the fading function as outlined in
-# Chelsey and Vereš (2017) to remove observations.
+# Chesley and Vereš (2017) to remove observations.
 fading_function_on = False
 
 

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -393,7 +393,7 @@ class fadingfunctionConfigs:
     """Width parameter for fading function. Should be greater than zero and less than 0.5."""
 
     fading_function_peak_efficiency: float = None
-    """Peak efficiency for the fading function, called the 'fill factor' in Chelsey and Veres (2017)."""
+    """Peak efficiency for the fading function, called the 'fill factor' in Chesley and Veres (2017)."""
 
     def __post_init__(self):
         """Automagically validates the fading function configs after initialisation."""


### PR DESCRIPTION
The name 'Chesley' appears in the comments but it should be 'Chesley' 

No code changes, just comments.