### PR TITLE
Making n sub intervals a config class parameter

### DIFF
--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -111,7 +111,7 @@ def create_ephemeris(orbits_df, pointings_df, args, sconfigs):
     picket_interval = sconfigs.simulation.ar_picket
     obsCode = sconfigs.simulation.ar_obs_code
     nside = 2**sconfigs.simulation.ar_healpix_order
-    n_sub_intervals = sconfigs.simulation.n_sub_intervals
+    n_sub_intervals = sconfigs.simulation.ar_n_sub_intervals
 
     ephemeris_csv_filename = None
     if args.output_ephemeris_file and args.outpath:

--- a/src/sorcha/ephemeris/simulation_driver.py
+++ b/src/sorcha/ephemeris/simulation_driver.py
@@ -80,6 +80,8 @@ def create_ephemeris(orbits_df, pointings_df, args, sconfigs):
         nside : integer
             The nside value used for the HEALPIx calculations.  Must be a
             power of 2 (1, 2, 4, ...)  nside=64 is current default.
+        n_sub_intervals: int
+            Number of sub-intervals for the Lagrange interpolation (default: 101)
 
     Returns
     -------
@@ -109,7 +111,7 @@ def create_ephemeris(orbits_df, pointings_df, args, sconfigs):
     picket_interval = sconfigs.simulation.ar_picket
     obsCode = sconfigs.simulation.ar_obs_code
     nside = 2**sconfigs.simulation.ar_healpix_order
-    n_sub_intervals = 101  # configs["n_sub_intervals"]
+    n_sub_intervals = sconfigs.simulation.n_sub_intervals
 
     ephemeris_csv_filename = None
     if args.output_ephemeris_file and args.outpath:

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -77,6 +77,9 @@ class simulationConfigs:
     ar_healpix_order: int = None
     """the order of healpix which we will use for the healpy portions of the code."""
 
+    n_sub_intervals: int = 101
+    """Number of sub-intervals for the Lagrange ephemerides interpolation (default: 101)"""
+
     _ephemerides_type: str = None
     """Simulation used for ephemeris input."""
 
@@ -111,6 +114,7 @@ class simulationConfigs:
             self.ar_fov_buffer = cast_as_float(self.ar_fov_buffer, "ar_fov_buffer")
             self.ar_picket = cast_as_int(self.ar_picket, "ar_picket")
             self.ar_healpix_order = cast_as_int(self.ar_healpix_order, "ar_healpix_order")
+            self.n_sub_intervals = cast_as_int(self.n_sub_intervals, "n_sub_intervals")
         elif self._ephemerides_type == "external":
             # makes sure when these are not needed that they are not populated
             check_key_doesnt_exist(self.ar_ang_fov, "ar_ang_fov", "but ephemerides type is external")

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -77,7 +77,7 @@ class simulationConfigs:
     ar_healpix_order: int = None
     """the order of healpix which we will use for the healpy portions of the code."""
 
-    n_sub_intervals: int = None
+    ar_n_sub_intervals: int = 101
     """Number of sub-intervals for the Lagrange ephemerides interpolation (default: 101)"""
 
     _ephemerides_type: str = None
@@ -114,7 +114,7 @@ class simulationConfigs:
             self.ar_fov_buffer = cast_as_float(self.ar_fov_buffer, "ar_fov_buffer")
             self.ar_picket = cast_as_int(self.ar_picket, "ar_picket")
             self.ar_healpix_order = cast_as_int(self.ar_healpix_order, "ar_healpix_order")
-            self.n_sub_intervals = cast_as_int_or_set_default(self.n_sub_intervals, "n_sub_intervals", 101)
+            self.ar_n_sub_intervals = cast_as_int(self.ar_n_sub_intervals, "ar_n_sub_intervals")
         elif self._ephemerides_type == "external":
             # makes sure when these are not needed that they are not populated
             check_key_doesnt_exist(self.ar_ang_fov, "ar_ang_fov", "but ephemerides type is external")
@@ -1311,39 +1311,6 @@ def cast_as_bool_or_set_default(value, key, default):
         return default
 
 
-def cast_as_int_or_set_default(value, key, default):
-
-    # replaces PPGetBoolOrExit: checks to make sure the value can be cast as a bool.
-    """
-    Checks to see if value can be cast as an int and if not set (equals None) gives default int.
-
-    Parameters
-    -----------
-    value : object attribute
-        value of the config file attribute
-
-    key : string
-        The key being checked.
-
-    default : int
-        default int if value is None
-
-    Returns
-    ----------
-    value as an int
-    """
-
-    if value is not None:
-        try:
-            int(value)
-        except ValueError:
-            logging.error(f"ERROR: expected an int for config parameter {key}. Check value in config file.")
-            sys.exit(f"ERROR: expected an int for config parameter {key}. Check value in config file.")
-        return value
-    elif value is None:
-        return default
-
-
 def PrintConfigsToLog(sconfigs, cmd_args):
     """
     Prints all the values from the config file and command line to the log.
@@ -1549,6 +1516,7 @@ def PrintConfigsToLog(sconfigs, cmd_args):
         pplogger.info("...the picket interval is: " + str(sconfigs.simulation.ar_picket))
         pplogger.info("...the observatory code is: " + str(sconfigs.simulation.ar_obs_code))
         pplogger.info("...the healpix order is: " + str(sconfigs.simulation.ar_healpix_order))
+        pplogger.info("...the number of sub-intervals is: " + str(sconfigs.simulation.ar_n_sub_intervals))
     else:
         pplogger.info("ASSIST+REBOUND Simulation is turned OFF.")
 

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -77,7 +77,7 @@ class simulationConfigs:
     ar_healpix_order: int = None
     """the order of healpix which we will use for the healpy portions of the code."""
 
-    n_sub_intervals: int = 101
+    n_sub_intervals: int = None
     """Number of sub-intervals for the Lagrange ephemerides interpolation (default: 101)"""
 
     _ephemerides_type: str = None
@@ -114,7 +114,7 @@ class simulationConfigs:
             self.ar_fov_buffer = cast_as_float(self.ar_fov_buffer, "ar_fov_buffer")
             self.ar_picket = cast_as_int(self.ar_picket, "ar_picket")
             self.ar_healpix_order = cast_as_int(self.ar_healpix_order, "ar_healpix_order")
-            self.n_sub_intervals = cast_as_int(self.n_sub_intervals, "n_sub_intervals")
+            self.n_sub_intervals = cast_as_int_or_set_default(self.n_sub_intervals, "n_sub_intervals", 101)
         elif self._ephemerides_type == "external":
             # makes sure when these are not needed that they are not populated
             check_key_doesnt_exist(self.ar_ang_fov, "ar_ang_fov", "but ephemerides type is external")
@@ -1307,6 +1307,39 @@ def cast_as_bool_or_set_default(value, key, default):
         else:
             logging.error(f"ERROR: expected a bool for config parameter {key}. Check value in config file.")
             sys.exit(f"ERROR: expected a bool for config parameter {key}. Check value in config file.")
+    elif value is None:
+        return default
+
+
+def cast_as_int_or_set_default(value, key, default):
+
+    # replaces PPGetBoolOrExit: checks to make sure the value can be cast as a bool.
+    """
+    Checks to see if value can be cast as an int and if not set (equals None) gives default int.
+
+    Parameters
+    -----------
+    value : object attribute
+        value of the config file attribute
+
+    key : string
+        The key being checked.
+
+    default : int
+        default int if value is None
+
+    Returns
+    ----------
+    value as an int
+    """
+
+    if value is not None:
+        try:
+            int(value)
+        except ValueError:
+            logging.error(f"ERROR: expected an int for config parameter {key}. Check value in config file.")
+            sys.exit(f"ERROR: expected an int for config parameter {key}. Check value in config file.")
+        return value
     elif value is None:
         return default
 

--- a/tests/data/test_PrintConfigsToLog.txt
+++ b/tests/data/test_PrintConfigsToLog.txt
@@ -224,6 +224,7 @@ sorcha.utilities.sorchaConfigs INFO     ...the buffer around the FOV is: 0.2
 sorcha.utilities.sorchaConfigs INFO     ...the picket interval is: 1 
 sorcha.utilities.sorchaConfigs INFO     ...the observatory code is: X05 
 sorcha.utilities.sorchaConfigs INFO     ...the healpix order is: 6 
+sorcha.utilities.sorchaConfigs INFO     ...the number of sub-intervals is: 101 
 sorcha.utilities.sorchaConfigs INFO     No lightcurve model is being applied. 
 sorcha.utilities.sorchaConfigs INFO     Output files will be saved in path: ./ with filestem testout 
 sorcha.utilities.sorchaConfigs INFO     Output files will be saved as format: csv 

--- a/tests/sorcha/test_sorchaConfigs.py
+++ b/tests/sorcha/test_sorchaConfigs.py
@@ -35,7 +35,7 @@ correct_simulation = {
     "ar_picket": 1,
     "ar_obs_code": "X05",
     "ar_healpix_order": 6,
-    "n_sub_intervals": 101
+    "ar_n_sub_intervals": 101
 }
 
 correct_filters_read = {"observing_filters": "r,g,i,z,u,y", "survey_name": "rubin_sim"}
@@ -262,7 +262,7 @@ def test_simulationConfigs_float(key_name):
     )
 
 
-@pytest.mark.parametrize("key_name", ["ar_picket", "ar_healpix_order","n_sub_intervals"])
+@pytest.mark.parametrize("key_name", ["ar_picket", "ar_healpix_order","ar_n_sub_intervals"])
 def test_simulationConfigs_int(key_name):
     """
     Tests that wrong inputs for simulationConfigs int attributes is caught correctly

--- a/tests/sorcha/test_sorchaConfigs.py
+++ b/tests/sorcha/test_sorchaConfigs.py
@@ -35,6 +35,7 @@ correct_simulation = {
     "ar_picket": 1,
     "ar_obs_code": "X05",
     "ar_healpix_order": 6,
+    "n_sub_intervals": 101
 }
 
 correct_filters_read = {"observing_filters": "r,g,i,z,u,y", "survey_name": "rubin_sim"}
@@ -261,7 +262,7 @@ def test_simulationConfigs_float(key_name):
     )
 
 
-@pytest.mark.parametrize("key_name", ["ar_picket", "ar_healpix_order"])
+@pytest.mark.parametrize("key_name", ["ar_picket", "ar_healpix_order","n_sub_intervals"])
 def test_simulationConfigs_int(key_name):
     """
     Tests that wrong inputs for simulationConfigs int attributes is caught correctly


### PR DESCRIPTION
Fixes #1079.

Changed n_sub_intervals in simulation_driver.py to be a config class parameter in simulationConfigs

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
