### PR TITLE
Sorcha cite command line function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ sorcha-init = "sorcha_cmdline.init:main"
 sorcha-demo = "sorcha_cmdline.demo:main"
 sorcha-outputs = "sorcha_cmdline.outputs:main"
 sorcha-bootstrap = "sorcha_cmdline.bootstrap:main"
+sorcha-cite = "sorcha_cmdline.cite:main"
 
 [project.urls]
 "Documentation" = "https://sorcha.readthedocs.io/en/latest/"

--- a/src/sorcha_cmdline/cite.py
+++ b/src/sorcha_cmdline/cite.py
@@ -1,0 +1,68 @@
+#
+# The `sorcha cite` subcommand implementation
+#
+import argparse
+from sorcha_cmdline.sorchaargumentparser import SorchaArgumentParser
+import os
+
+
+def main():
+    parser = SorchaArgumentParser(
+        prog="sorcha cite",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Providing the bibtex, AAS Journals software latex command, and acknowledgement statements for Sorcha and the associated packages that power it in a file called sorcha_citation.txt.",
+    )
+
+    optional = parser.add_argument_group("Optional arguments")
+    optional.add_argument(
+        "-cf",
+        "--cite-file-path",
+        help="File path to store citation file sorcha_citation.txt.",
+        type=str,
+        dest="cf",
+        required=False,
+        default=os.getcwd(),
+    )
+
+    optional.add_argument(
+        "-p",
+        "--print",
+        help="Prints citation to terminal.",
+        dest="p",
+        action="store_true",
+        required=False,
+    )
+
+    args = parser.parse_args()
+
+    return execute(args)
+
+
+def execute(args):
+    import sys
+    import io
+    from sorcha.utilities.citation_text import cite_sorcha
+
+    if args.p:  # prints citation to terminal
+        cite_sorcha()
+
+    if not os.path.isdir(args.cf):
+        sys.exit(f"ERROR: file path {args.cf} does not exist or isn't a directory")
+
+    output_file_path = os.path.join(args.cf, "sorcha_citation.txt")
+
+    # Makes sdtdout output the print statements into a temporary file
+    output_capture = io.StringIO()
+    sys.stdout = output_capture
+
+    cite_sorcha()
+
+    # writes the outputs in the temporary file to a text file
+    with open(output_file_path, "w") as output_file:
+        output_file.write(output_capture.getvalue())
+
+    # Resets stdout back to normal
+    sys.stdout = sys.__stdout__
+    output_capture.close()
+
+    print(f"Citations have been written into {os.path.abspath(output_file_path)}")

--- a/src/sorcha_cmdline/main.py
+++ b/src/sorcha_cmdline/main.py
@@ -37,6 +37,7 @@ def main():
         "   outputs   Manipulate/package sorcha outputs\n"
         "   demo      Set up a demo simulation\n"
         "   bootstrap Download datafiles required to run sorcha\n"
+        "   cite      Outputs the citation to a file\n"
         "\n"
         "To get more information, run the verb with --help. For example:\n\n"
         "   sorcha run --help\n"


### PR DESCRIPTION


Fixes #1091.

Created a Sorcha cite command line function with two optional arguments. An argument to print the citation to the terminal and an argument to decide the file path

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
