### PR TITLE
Improve error messaging in CSVReader

### DIFF
--- a/src/sorcha/readers/CSVReader.py
+++ b/src/sorcha/readers/CSVReader.py
@@ -275,7 +275,7 @@ class CSVDataReader(ObjectDataReader):
             # Check if there is a more understandable error we can raise.
             self._validate_csv(self.header_row)
 
-            # If we do not detect the a problem with _validate_csv, reraise the error.
+            # If we do not detect a problem with _validate_csv, reraise the error.
             raise current_exc
         return res_df
 

--- a/tests/readers/test_CSVReader.py
+++ b/tests/readers/test_CSVReader.py
@@ -1,8 +1,10 @@
 import numpy as np
+import os
 import pandas as pd
 import pytest
 from numpy.testing import assert_equal
 from pandas.testing import assert_frame_equal
+import tempfile
 
 from sorcha.readers.CSVReader import CSVDataReader
 from sorcha.utilities.dataUtilitiesForTests import get_test_filepath
@@ -392,3 +394,25 @@ def test_CSVDataReader_delims():
     with pytest.raises(SystemExit) as e2:
         _ = CSVDataReader(get_test_filepath("testcolour.txt"), "")
     assert e2.type == SystemExit
+
+
+def test_CSVDataReader_blank_lines():
+    """Test that we fail if the input file has blank lines."""
+    with tempfile.TemporaryDirectory() as dir_name:
+        file_name = os.path.join(dir_name, "test.csv")
+        with open(file_name, 'w') as output:
+            output.write("ObjID,b,c\n")
+            output.write("0,1,2\n")
+            output.write("1,2,3\n")
+
+        # The checks pass.
+        reader = CSVDataReader(file_name, sep="csv", full_checks=False)
+        with open(file_name, 'a') as output:
+             output.write("\n")  # add a blank line
+        
+        # The code now fails by default.
+        with pytest.raises(SystemExit):
+            _ = CSVDataReader(file_name, sep="csv")
+        
+        # Checking can be turned off.
+        reader = CSVDataReader(file_name, sep="csv", full_checks=False)

--- a/tests/readers/test_CSVReader.py
+++ b/tests/readers/test_CSVReader.py
@@ -399,20 +399,26 @@ def test_CSVDataReader_delims():
 def test_CSVDataReader_blank_lines():
     """Test that we fail if the input file has blank lines."""
     with tempfile.TemporaryDirectory() as dir_name:
-        file_name = os.path.join(dir_name, "test.csv")
+        file_name = os.path.join(dir_name, "test.ecsv")
         with open(file_name, 'w') as output:
+            output.write("# My comment\n")
             output.write("ObjID,b,c\n")
             output.write("0,1,2\n")
-            output.write("1,2,3\n")
+            output.write("1,1,2\n")
+            output.write("2,1,2\n")
 
         # The checks pass.
-        reader = CSVDataReader(file_name, sep="csv", full_checks=False)
+        reader = CSVDataReader(file_name, sep="csv", cache_table=False)
+        data = reader.read_objects([1, 2])
+        assert len(data) == 2
+
         with open(file_name, 'a') as output:
-             output.write("\n")  # add a blank line
+            output.write("3,1,2\n")
+            output.write("\n")  # add another blank line
+            output.write("\n")  # add another blank line
+            output.write("\n")  # add another blank line
         
         # The code now fails by default.
-        with pytest.raises(SystemExit):
-            _ = CSVDataReader(file_name, sep="csv")
-        
-        # Checking can be turned off.
-        reader = CSVDataReader(file_name, sep="csv", full_checks=False)
+        reader2 = CSVDataReader(file_name, sep="csv", cache_table=False)
+        data2 = reader2.read_objects([1, 2])
+        assert len(data2) == 2

--- a/tests/readers/test_CSVReader.py
+++ b/tests/readers/test_CSVReader.py
@@ -400,7 +400,7 @@ def test_CSVDataReader_blank_lines():
     """Test that we fail if the input file has blank lines."""
     with tempfile.TemporaryDirectory() as dir_name:
         file_name = os.path.join(dir_name, "test.ecsv")
-        with open(file_name, 'w') as output:
+        with open(file_name, "w") as output:
             output.write("# My comment\n")
             output.write("ObjID,b,c\n")
             output.write("0,1,2\n")
@@ -409,16 +409,15 @@ def test_CSVDataReader_blank_lines():
 
         # The checks pass.
         reader = CSVDataReader(file_name, sep="csv", cache_table=False)
-        data = reader.read_objects([1, 2])
+        data = reader.read_objects(["1", "2"])
         assert len(data) == 2
 
-        with open(file_name, 'a') as output:
+        with open(file_name, "a") as output:
             output.write("3,1,2\n")
             output.write("\n")  # add another blank line
             output.write("\n")  # add another blank line
-            output.write("\n")  # add another blank line
-        
+
         # The code now fails by default.
         reader2 = CSVDataReader(file_name, sep="csv", cache_table=False)
-        data2 = reader2.read_objects([1, 2])
-        assert len(data2) == 2
+        with pytest.raises(SystemExit):
+            _ = reader2.read_objects(["1", "2"])

--- a/tests/readers/test_OrbitAuxReader.py
+++ b/tests/readers/test_OrbitAuxReader.py
@@ -343,11 +343,10 @@ def test_orbit_sanity_check_com():
     with pytest.raises(SystemExit) as err:
         _ = OrbitAuxReader(get_test_filepath("orbit_test_files/orbit_sanity_check_com_q<0.csv"),"csv")
         _.read_rows()
-    assert err.value.code == "ERROR: Invalid cometary elements detected for one or more objects (check log for information)"
+    assert err.value.code.startswith("ERROR: CSVReader: found a blank line")
 
     #for comentary  e<0
     with pytest.raises(SystemExit) as err:
         _ = OrbitAuxReader(get_test_filepath("orbit_test_files/orbit_sanity_check_com_e<0.csv"),"csv")
         _.read_rows()
-    assert err.value.code == "ERROR: Invalid cometary elements detected for one or more objects (check log for information)"
-
+    assert err.value.code.startswith("ERROR: CSVReader: found a blank line")

--- a/tests/readers/test_OrbitAuxReader.py
+++ b/tests/readers/test_OrbitAuxReader.py
@@ -343,10 +343,10 @@ def test_orbit_sanity_check_com():
     with pytest.raises(SystemExit) as err:
         _ = OrbitAuxReader(get_test_filepath("orbit_test_files/orbit_sanity_check_com_q<0.csv"),"csv")
         _.read_rows()
-    assert err.value.code.startswith("ERROR: CSVReader: found a blank line")
+    assert err.value.code == "ERROR: Invalid cometary elements detected for one or more objects (check log for information)"
 
     #for comentary  e<0
     with pytest.raises(SystemExit) as err:
         _ = OrbitAuxReader(get_test_filepath("orbit_test_files/orbit_sanity_check_com_e<0.csv"),"csv")
         _.read_rows()
-    assert err.value.code.startswith("ERROR: CSVReader: found a blank line")
+    assert err.value.code == "ERROR: Invalid cometary elements detected for one or more objects (check log for information)"

--- a/tests/readers/test_OrbitAuxReader.py
+++ b/tests/readers/test_OrbitAuxReader.py
@@ -307,6 +307,7 @@ def test_orbit_reader_wrong_delim():
     with pytest.raises(SystemExit) as err:
         _ = OrbitAuxReader(get_test_filepath("testorb.des"), "csv")
 
+
 def test_orbit_sanity_check_kep():
     """If an orbit parameter is undefined, raise an exception"""
 
@@ -333,7 +334,6 @@ def test_orbit_sanity_check_kep():
         _ = OrbitAuxReader(get_test_filepath("orbit_test_files/orbit_sanity_check_kep_e<1_a<0.des"),"whitespace")
         _.read_rows()
     assert err.value.code == "ERROR: Invalid Keplerian elements detected for one or more objects (check log for information)"
-
 
 
 def test_orbit_sanity_check_com():


### PR DESCRIPTION
Fixes #1023

When CSVReader encounters a file with terminating blank lines and uses the read objects method, it throws a confusing error. This approach wraps the read in a try block and check if the error is just due to blank lines.

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [X] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [X] Have you used black on the files you have updated to confirm python programming style guide enforcement?
