### PR TITLE
Changes to fading_function_on

### DIFF
--- a/src/sorcha/data/demo/sorcha_config_demo.ini
+++ b/src/sorcha/data/demo/sorcha_config_demo.ini
@@ -107,9 +107,8 @@ footprint_edge_threshold = 2.
 
 [FADINGFUNCTION]
 
-# Detection efficiency fading function on or off. Uses the fading function as outlined in
+# Uses the fading function as outlined in
 # Chesley and Vereš (2017) to remove observations.
-fading_function_on = True
 
 # Width parameter for fading function. Should be greater than zero and less than 0.5.
 # Suggested value is 0.1 after Chesley and Vereš (2017).

--- a/src/sorcha/data/survey_setups/Rubin_circular_approximation.ini
+++ b/src/sorcha/data/survey_setups/Rubin_circular_approximation.ini
@@ -98,9 +98,8 @@ circle_radius = 1.75
 
 [FADINGFUNCTION]
 
-# Detection efficiency fading function on or off. Uses the fading function as outlined in
+# Uses the fading function as outlined in
 # Chesley and Vereš (2017) to remove observations.
-fading_function_on = True
 
 # Width parameter for fading function. Should be greater than zero and less than 0.5.
 # Suggested value is 0.1 after Chesley and Vereš (2017).

--- a/src/sorcha/data/survey_setups/Rubin_full_footprint.ini
+++ b/src/sorcha/data/survey_setups/Rubin_full_footprint.ini
@@ -98,9 +98,8 @@ footprint_edge_threshold = 2.
 
 [FADINGFUNCTION]
 
-# Detection efficiency fading function on or off. Uses the fading function as outlined in
+# Uses the fading function as outlined in
 # Chesley and Vereš (2017) to remove observations.
-fading_function_on = True
 
 # Width parameter for fading function. Should be greater than zero and less than 0.5.
 # Suggested value is 0.1 after Chesley and Vereš (2017).

--- a/src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
+++ b/src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
@@ -89,7 +89,7 @@ footprint_edge_threshold = 2.
 
 [FADINGFUNCTION]
 
-# Detection efficiency fading function on or off. Uses the fading function as outlined in
+#  Uses the fading function as outlined in
 # Chesley and Vereš (2017) to remove observations.
 fading_function_on = False
 

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -392,7 +392,7 @@ class fadingfunctionConfigs:
     """Data class for holding FADINGFUNCTION section configuration file keys and validating them"""
 
     fading_function_on: bool = None
-    """Detection efficiency fading function on or off."""
+    """Detection efficiency fading function on or off. Default True"""
 
     fading_function_width: float = None
     """Width parameter for fading function. Should be greater than zero and less than 0.5."""
@@ -417,10 +417,20 @@ class fadingfunctionConfigs:
         None
         """
 
-        # make sure all the mandatory keys have been populated.
-        check_key_exists(self.fading_function_on, "fading_function_on")
-        self.fading_function_on = cast_as_bool(self.fading_function_on, "fading_function_on")
-
+        if (
+            self.fading_function_on is None
+            and self.fading_function_peak_efficiency is None
+            and self.fading_function_width is None
+        ):
+            logging.error(
+                "ERROR: Both fading_function_peak_efficiency and fading_function_width are needed to be supplied for fading function"
+            )
+            sys.exit(
+                "ERROR: Both fading_function_peak_efficiency and fading_function_width are needed to be supplied for fading function"
+            )
+        self.fading_function_on = cast_as_bool_or_set_default(
+            self.fading_function_on, "fading_function_on", True
+        )
         if self.fading_function_on == True:
 
             # when fading_function_on = true, fading_function_width and fading_function_peak_efficiency now mandatory

--- a/tests/sorcha/test_sorchaConfigs.py
+++ b/tests/sorcha/test_sorchaConfigs.py
@@ -610,27 +610,9 @@ def test_fadingfunctionConfig_on_float(key_name):
     )
 
 
-def test_fadingfunctionConfig_bool():
-    """
-    Tests that wrong inputs for fadingfunctionConfig bool attributes is caught correctly
-    """
-
-    fadingfunction_configs = correct_fadingfunction.copy()
-    test_configs = fadingfunctionConfigs(**fadingfunction_configs)
-    assert test_configs.__dict__ == fadingfunction_configs
-
-    fadingfunction_configs["fading_function_on"] = "ten"
-    with pytest.raises(SystemExit) as error_text:
-        test_configs = fadingfunctionConfigs(**fadingfunction_configs)
-
-    assert (
-        error_text.value.code
-        == "ERROR: expected a bool for config parameter fading_function_on. Check value in config file."
-    )
-
 
 @pytest.mark.parametrize(
-    "key_name", ["fading_function_on", "fading_function_width", "fading_function_peak_efficiency"]
+    "key_name", ["fading_function_width", "fading_function_peak_efficiency"]
 )
 def test_fadingfunction_mandatory(key_name):
     """
@@ -692,7 +674,19 @@ def test_fadingfunction_outofbounds(key_name):
             == "ERROR: fading_function_peak_efficiency out of bounds. Must be between 0 and 1."
         )
 
-
+def test_fadingfunction_allnone():
+    """
+    This loops through the not required keys and makes sure the code fails correctly when all attributes are none
+    """
+    fadingfunction_configs = correct_fadingfunction.copy()
+    fadingfunction_configs["fading_function_on"] = None
+    fadingfunction_configs["fading_function_width"] = None
+    fadingfunction_configs["fading_function_peak_efficiency"] = None
+    with pytest.raises(SystemExit) as error_text:
+        test_configs = fadingfunctionConfigs(**fadingfunction_configs)
+    assert (
+        error_text.value.code == "ERROR: Both fading_function_peak_efficiency and fading_function_width are needed to be supplied for fading function"
+    )
 ##################################################################################################################################
 
 # linkingfilter tests


### PR DESCRIPTION

Fixes #1092 .

fading_function_on is now True by default. User has to manually set  fading_function_on = False to turn off fading function.


## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
