### PR TITLE
Fading function on behave like linkingfilter

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -69,7 +69,7 @@ Applying :ref:`trailing losses<trailing>` is on by default, but it can be turned
 Turning off Detection Efficiency/Applying the Fading Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :ref:`survey detection efficiency<fading>` is disabled when the fading function section of the config file is not included or left empty ( When fadind_function_width and fadind_function_peak_efficency have not been given ).
+The :ref:`survey detection efficiency<fading>` is disabled if the fading function section of the config file is not included or left empty (When fadind_function_width and fadind_function_peak_efficency have not been given).
 
 Turning Off the Camera Footprint Filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -69,7 +69,7 @@ Applying :ref:`trailing losses<trailing>` is on by default, but it can be turned
 Turning off Detection Efficiency/Applying the Fading Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :ref:`survey detection efficiency<fading>` is disabled if the fading function section of the config file is not included or left empty (When fadind_function_width and fadind_function_peak_efficency have not been given).
+The :ref:`survey detection efficiency<fading>` is disabled if the fading function section of the config file is removed or not included (When fadind_function_width and fadind_function_peak_efficency have not been given).
 
 Turning Off the Camera Footprint Filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -69,10 +69,7 @@ Applying :ref:`trailing losses<trailing>` is on by default, but it can be turned
 Turning off Detection Efficiency/Applying the Fading Function
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Applying the :ref:`survey detection efficiency<fading>` is on by default, but it can be turned off by including the option in the :ref:`configs`::
-
-    [FADINGFUNCTION]
-    fading_function_on = False
+The :ref:`survey detection efficiency<fading>` is disabled when the fading function section of the config file is not included or left empty ( When fadind_function_width and fadind_function_peak_efficency have not been given ).
 
 Turning Off the Camera Footprint Filter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
+++ b/src/sorcha/data/survey_setups/Rubin_known_object_prediction.ini
@@ -87,13 +87,6 @@ camera_model = footprint
 footprint_edge_threshold = 2.
 
 
-[FADINGFUNCTION]
-
-#  Uses the fading function as outlined in
-# Chesley and Vereš (2017) to remove observations.
-fading_function_on = False
-
-
 [OUTPUT]
 
 # Output format of the output file[s]

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -417,25 +417,10 @@ class fadingfunctionConfigs:
         None
         """
 
-        if (
-            self.fading_function_on is None
-            and self.fading_function_peak_efficiency is None
-            and self.fading_function_width is None
-        ):
-            logging.error(
-                "ERROR: Both fading_function_peak_efficiency and fading_function_width are needed to be supplied for fading function"
-            )
-            sys.exit(
-                "ERROR: Both fading_function_peak_efficiency and fading_function_width are needed to be supplied for fading function"
-            )
-        self.fading_function_on = cast_as_bool_or_set_default(
-            self.fading_function_on, "fading_function_on", True
-        )
-        if self.fading_function_on == True:
-
+        if self.fading_function_width is not None and self.fading_function_peak_efficiency is not None:
+            self.fading_function_on = True
             # when fading_function_on = true, fading_function_width and fading_function_peak_efficiency now mandatory
-            check_key_exists(self.fading_function_width, "fading_function_width")
-            check_key_exists(self.fading_function_peak_efficiency, "fading_function_peak_efficiency")
+
             self.fading_function_width = cast_as_float(self.fading_function_width, "fading_function_width")
             self.fading_function_peak_efficiency = cast_as_float(
                 self.fading_function_peak_efficiency, "fading_function_peak_efficiency"
@@ -457,15 +442,15 @@ class fadingfunctionConfigs:
                 )
                 sys.exit("ERROR: fading_function_peak_efficiency out of bounds. Must be between 0 and 1.")
 
-        elif self.fading_function_on == False:
-            # making sure these aren't populated when self.fading_function_on = False
-            check_key_doesnt_exist(
-                self.fading_function_width, "fading_function_width", "but fading_function_on is False."
+        elif self.fading_function_width is None and self.fading_function_peak_efficiency is None:
+            self.fading_function_on = False
+
+        else:
+            logging.error(
+                "ERROR: Both fading_function_peak_efficiency and fading_function_width are needed to be supplied for fading function"
             )
-            check_key_doesnt_exist(
-                self.fading_function_peak_efficiency,
-                "fading_function_peak_efficiency",
-                "but fading_function_on is False.",
+            sys.exit(
+                "ERROR: Both fading_function_peak_efficiency and fading_function_width are needed to be supplied for fading function"
             )
 
 

--- a/tests/sorcha/test_sorchaConfigs.py
+++ b/tests/sorcha/test_sorchaConfigs.py
@@ -611,46 +611,6 @@ def test_fadingfunctionConfig_on_float(key_name):
 
 
 
-@pytest.mark.parametrize(
-    "key_name", ["fading_function_width", "fading_function_peak_efficiency"]
-)
-def test_fadingfunction_mandatory(key_name):
-    """
-    this loops through the mandatory keys and keys that shouldn't exist and makes sure the code fails correctly when each is missing
-    """
-
-    fadingfunction_configs = correct_fadingfunction.copy()
-
-    del fadingfunction_configs[key_name]
-
-    with pytest.raises(SystemExit) as error_text:
-        test_configs = fadingfunctionConfigs(**fadingfunction_configs)
-
-    assert (
-        error_text.value.code
-        == f"ERROR: No value found for required key {key_name} in config file. Please check the file and try again."
-    )
-
-
-@pytest.mark.parametrize("key_name", ["fading_function_width", "fading_function_peak_efficiency"])
-def test_fadingfunction_notrequired(key_name):
-    """
-    This loops through the not required keys and makes sure the code fails correctly when they're truthy
-    """
-
-    # tests that "fading_function_width" and "fading_function_peak_efficiency" are not called when "fading_function_on" is false
-    fadingfunction_configs = correct_fadingfunction.copy()
-    fadingfunction_configs["fading_function_on"] = "False"
-    fadingfunction_configs["fading_function_width"] = None
-    fadingfunction_configs["fading_function_peak_efficiency"] = None
-    fadingfunction_configs[key_name] = 0.5
-    with pytest.raises(SystemExit) as error_text:
-        test_configs = fadingfunctionConfigs(**fadingfunction_configs)
-    assert (
-        error_text.value.code == f"ERROR: {key_name} supplied in config file but fading_function_on is False."
-    )
-
-
 @pytest.mark.parametrize("key_name", ["fading_function_width", "fading_function_peak_efficiency"])
 def test_fadingfunction_outofbounds(key_name):
     """
@@ -680,7 +640,7 @@ def test_fadingfunction_allnone():
     """
     fadingfunction_configs = correct_fadingfunction.copy()
     fadingfunction_configs["fading_function_on"] = None
-    fadingfunction_configs["fading_function_width"] = None
+    fadingfunction_configs["fading_function_width"] = 5.0
     fadingfunction_configs["fading_function_peak_efficiency"] = None
     with pytest.raises(SystemExit) as error_text:
         test_configs = fadingfunctionConfigs(**fadingfunction_configs)


### PR DESCRIPTION

Fixes #1101

The user will no longer need to set fading_function_on to True or False. Instead, when the fading function section is not included then fading_function_on will be false. 
## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
