### PR TITLE
Doc ar_n_sub_intervals typo

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -143,7 +143,7 @@ Modifying the Ephemeris Generator Interpolation
 A user can update the number of sub-intervals for the Lagrange ephemerides interpolation used within ``Sorcha``'s internal ephemeris generator. By default this value is set to **101**, but the user can update it to a different value. 101 works for most orbits, but it may be worth exploring using a different value if you're modeling Earth impactors and very close Near-Earth Objects (NEOs). To change the number of sub-intervals, **n_sub_intervals** variable is  added to the ([SIMULATION]) section::
 
     [SIMULATION]
-    n_sub_intervals = 122
+    ar_n_sub_intervals = 122
 
 Specifying Alernative Versions of the Auxiliary Files Used in the Ephemeris Generator 
 -----------------------------------------------------------------------------------------

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -140,7 +140,7 @@ To implement the faint object culling filter, include the following in the :ref:
 Modifying the Ephemeris Generator Interpolation
 --------------------------------------------------
 
-A user can update the number of sub-intervals for the Lagrange ephemerides interpolation used within ``Sorcha``'s internal ephemeris generator. By default this value is set to **101**, but the user can update it to a different value. 101 works for most orbits, but it may be worth exploring using a different value if you're modeling Earth impactors and very close Near-Earth Objects (NEOs). To change the number of sub-intervals, **n_sub_intervals** variable is  added to the ([SIMULATION]) section::
+A user can update the number of sub-intervals for the Lagrange ephemerides interpolation used within ``Sorcha``'s internal ephemeris generator. By default this value is set to **101**, but the user can update it to a different value. 101 works for most orbits, but it may be worth exploring using a different value if you're modeling Earth impactors and very close Near-Earth Objects (NEOs). To change the number of sub-intervals, **ar_n_sub_intervals** variable is  added to the ([SIMULATION]) section::
 
     [SIMULATION]
     ar_n_sub_intervals = 122


### PR DESCRIPTION

Fixed typo in docs where n_sub_intervals must be ar_n_sub_intervalsin for the config file.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
