### PR TITLE
Wrap `create_assist_ephemeris` function so argparse object is not required.

### DIFF
--- a/src/sorcha/ephemeris/simulation_setup.py
+++ b/src/sorcha/ephemeris/simulation_setup.py
@@ -46,6 +46,7 @@ def create_assist_ephemeris(args, auxconfigs) -> tuple:
     cache_directory = args.ar_data_file_path
     return _create_assist_ephemeris(auxconfigs, cache_directory)
 
+
 def _create_assist_ephemeris(auxconfigs, cache_dir=None) -> tuple:
     """Build the ASSIST ephemeris object
     Parameter

--- a/src/sorcha/ephemeris/simulation_setup.py
+++ b/src/sorcha/ephemeris/simulation_setup.py
@@ -30,11 +30,33 @@ def create_assist_ephemeris(args, auxconfigs) -> tuple:
     """Build the ASSIST ephemeris object
     Parameter
     ---------
+    args: dictionary
+        Dictionary of command-line arguments.
     auxconfigs: dataclass
         Dataclass of auxiliary configuration file arguments.
     Returns
     ---------
-    Ephem : ASSIST ephemeris obejct
+    Ephem : ASSIST ephemeris object
+        The ASSIST ephemeris object
+    gm_sun : float
+        value for the GM_SUN value
+    gm_total : float
+        value for gm_total
+    """
+    cache_directory = args.ar_data_file_path
+    return _create_assist_ephemeris(auxconfigs, cache_directory)
+
+def _create_assist_ephemeris(auxconfigs, cache_dir=None) -> tuple:
+    """Build the ASSIST ephemeris object
+    Parameter
+    ---------
+    auxconfigs: dataclass
+        Dataclass of auxiliary configuration file arguments.
+    cache_dir: string
+        The base directory to place all downloaded files. Default = None
+    Returns
+    ---------
+    Ephem : ASSIST ephemeris object
         The ASSIST ephemeris object
     gm_sun : float
         value for the GM_SUN value
@@ -43,7 +65,7 @@ def create_assist_ephemeris(args, auxconfigs) -> tuple:
     """
     pplogger = logging.getLogger(__name__)
 
-    retriever = make_retriever(auxconfigs, args.ar_data_file_path)
+    retriever = make_retriever(auxconfigs, cache_dir)
     planets_file_path = retriever.fetch(auxconfigs.jpl_planets)
     small_bodies_file_path = retriever.fetch(auxconfigs.jpl_small_bodies)
     ephem = Ephem(planets_path=planets_file_path, asteroids_path=small_bodies_file_path)


### PR DESCRIPTION
Fixes #1137 .
Created a protected (underscored) function that expects a cache_directory as either None or a string. The logic in the existing function was moved to the underscored function, and the existing `create_assist_ephemeris` function now is just a thin wrapper over `_create_assist_ephemeris` that simply passes `args.ar_data_file_path` to the `_create_assist_ephemeris` function.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
