### PR TITLE
A fix for pre-1962-Jan-20 observations

### DIFF
--- a/src/sorcha/ephemeris/simulation_geometry.py
+++ b/src/sorcha/ephemeris/simulation_geometry.py
@@ -196,8 +196,8 @@ def barycentricObservatoryRates(et, obsCode, observatories, Rearth=RADIUS_EARTH_
     vel = posvel[3:6]
     # Get the matrix that rotates from the Earth's equatorial body fixed frame to the J2000 equatorial frame.
     # We don't need to compute this repeatedly
-    et_1962 = spice.str2et('1962-Jan-20')    
-    if et>=et_1962:
+    et_1962 = spice.str2et("1962-Jan-20")
+    if et >= et_1962:
         m = spice.pxform("ITRF93", "J2000", et)
         mp = spice.pxform("ITRF93", "J2000", et + delta_et)
         mm = spice.pxform("ITRF93", "J2000", et - delta_et)
@@ -205,9 +205,9 @@ def barycentricObservatoryRates(et, obsCode, observatories, Rearth=RADIUS_EARTH_
         m = spice.pxform("IAU_EARTH", "J2000", et)
         mp = spice.pxform("IAU_EARTH", "J2000", et + delta_et)
         mm = spice.pxform("IAU_EARTH", "J2000", et - delta_et)
-    #m = spice.pxform("ITRF93", "J2000", et)
-    #mp = spice.pxform("ITRF93", "J2000", et + delta_et)
-    #mm = spice.pxform("ITRF93", "J2000", et - delta_et)
+    # m = spice.pxform("ITRF93", "J2000", et)
+    # mp = spice.pxform("ITRF93", "J2000", et + delta_et)
+    # mm = spice.pxform("ITRF93", "J2000", et - delta_et)
     # Get the MPC's unit vector from the geocenter to
     # the observatory
     obsVec = observatories.ObservatoryXYZ[obsCode]

--- a/src/sorcha/ephemeris/simulation_geometry.py
+++ b/src/sorcha/ephemeris/simulation_geometry.py
@@ -195,9 +195,19 @@ def barycentricObservatoryRates(et, obsCode, observatories, Rearth=RADIUS_EARTH_
     pos = posvel[0:3]
     vel = posvel[3:6]
     # Get the matrix that rotates from the Earth's equatorial body fixed frame to the J2000 equatorial frame.
-    m = spice.pxform("ITRF93", "J2000", et)
-    mp = spice.pxform("ITRF93", "J2000", et + delta_et)
-    mm = spice.pxform("ITRF93", "J2000", et - delta_et)
+    # We don't need to compute this repeatedly
+    et_1962 = spice.str2et('1962-Jan-20')    
+    if et>=et_1962:
+        m = spice.pxform("ITRF93", "J2000", et)
+        mp = spice.pxform("ITRF93", "J2000", et + delta_et)
+        mm = spice.pxform("ITRF93", "J2000", et - delta_et)
+    else:
+        m = spice.pxform("IAU_EARTH", "J2000", et)
+        mp = spice.pxform("IAU_EARTH", "J2000", et + delta_et)
+        mm = spice.pxform("IAU_EARTH", "J2000", et - delta_et)
+    #m = spice.pxform("ITRF93", "J2000", et)
+    #mp = spice.pxform("ITRF93", "J2000", et + delta_et)
+    #mm = spice.pxform("ITRF93", "J2000", et - delta_et)
     # Get the MPC's unit vector from the geocenter to
     # the observatory
     obsVec = observatories.ObservatoryXYZ[obsCode]

--- a/src/sorcha/ephemeris/simulation_geometry.py
+++ b/src/sorcha/ephemeris/simulation_geometry.py
@@ -205,9 +205,6 @@ def barycentricObservatoryRates(et, obsCode, observatories, Rearth=RADIUS_EARTH_
         m = spice.pxform("IAU_EARTH", "J2000", et)
         mp = spice.pxform("IAU_EARTH", "J2000", et + delta_et)
         mm = spice.pxform("IAU_EARTH", "J2000", et - delta_et)
-    # m = spice.pxform("ITRF93", "J2000", et)
-    # mp = spice.pxform("ITRF93", "J2000", et + delta_et)
-    # mm = spice.pxform("ITRF93", "J2000", et - delta_et)
     # Get the MPC's unit vector from the geocenter to
     # the observatory
     obsVec = observatories.ObservatoryXYZ[obsCode]

--- a/tests/ephemeris/test_simulation_parsing.py
+++ b/tests/ephemeris/test_simulation_parsing.py
@@ -38,15 +38,14 @@ def test_observatory_before_1962():
         auxconfigs=auxconfigs, args=None, oc_file=get_test_filepath("ObsCodes_test.json")
     )
 
-    obs = observatory.ObservatoryXYZ
-
-    et = sp.spice.str2et("1961-Jan-20 00:00")
+    et = -1229083166.3680687  # thanks to Rahil Makadia
 
     pos, _ = sg.barycentricObservatoryRates(et, "Z20", observatory)
 
-    x, y, z = -7.426461821563405e07, 1.177545544454091e08, 5.105719899396534e07
-    print("X COORD ", pos[0] - x)
-    print("Y COORD ", pos[1] - y)
-    print("Z COORD ", pos[2] - z)
+    x, y, z = -7.426461821563405e07, 1.177545544454091e08, 5.105719899396534e07  # taken from JPL
 
-    # print(pos, x,y,z)
+    # note these should not match precisely because pre-1962 we're using an approximation
+    # but this is good enough
+    assert np.isclose(pos[0], x, 5)
+    assert np.isclose(pos[1], y, 5)
+    assert np.isclose(pos[2], z, 5)

--- a/tests/ephemeris/test_simulation_parsing.py
+++ b/tests/ephemeris/test_simulation_parsing.py
@@ -32,7 +32,6 @@ def test_observatory_for_moving_observatories():
 
 
 def test_observatory_before_1962():
-    # THIS UNIT TEST IS INCOMPLETE!
     auxconfigs = auxiliaryConfigs()
     observatory = sp.Observatory(
         auxconfigs=auxconfigs, args=None, oc_file=get_test_filepath("ObsCodes_test.json")

--- a/tests/ephemeris/test_simulation_parsing.py
+++ b/tests/ephemeris/test_simulation_parsing.py
@@ -2,6 +2,8 @@ import numpy as np
 import sorcha.ephemeris.simulation_parsing as sp
 from sorcha.utilities.dataUtilitiesForTests import get_test_filepath
 from sorcha.utilities.sorchaConfigs import auxiliaryConfigs
+import sorcha.ephemeris.simulation_geometry as sg
+import sorcha.ephemeris.simulation_setup as ss
 
 
 def test_observatory_compared_to_original():
@@ -27,3 +29,24 @@ def test_observatory_for_moving_observatories():
     obs = observatory.ObservatoryXYZ
 
     assert obs["250"] == (None, None, None)
+
+
+def test_observatory_before_1962():
+    # THIS UNIT TEST IS INCOMPLETE!
+    auxconfigs = auxiliaryConfigs()
+    observatory = sp.Observatory(
+        auxconfigs=auxconfigs, args=None, oc_file=get_test_filepath("ObsCodes_test.json")
+    )
+
+    obs = observatory.ObservatoryXYZ
+
+    et = sp.spice.str2et("1961-Jan-20 00:00")
+
+    pos, _ = sg.barycentricObservatoryRates(et, "Z20", observatory)
+
+    x, y, z = -7.426461821563405e07, 1.177545544454091e08, 5.105719899396534e07
+    print("X COORD ", pos[0] - x)
+    print("Y COORD ", pos[1] - y)
+    print("Z COORD ", pos[2] - z)
+
+    # print(pos, x,y,z)


### PR DESCRIPTION
Fixes #1145 

This adds code to use IAU_EARTH rather than ITRF for observations before 1962-Jan-20.  Thank you, Rahil!

## Review Checklist for Source Code Changes

- [ ] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does Sorcha run successfully on a test set of input files/databases?
- [ ] Have you used black on the files you have updated to confirm python programming style guide enforcement?
