### PR TITLE
moved parameter check for saturation filter into if statement.

### DIFF
--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -225,11 +225,12 @@ class saturationConfigs:
         ----------
         None
         """
-        check_key_exists(self._observing_filters, "_observing_filters")
+
         if self.bright_limit is not None:
             self.bright_limit_on = True
 
         if self.bright_limit_on:
+            check_key_exists(self._observing_filters, "_observing_filters")
             try:
                 self.bright_limit = [float(e.strip()) for e in self.bright_limit.split(",")]
             except ValueError:


### PR DESCRIPTION
Fixes #1158  .

In saturationConfigs, the parameter  _observing_filter is now only checked when being used. 

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
