### PR TITLE
Filepaths greater than 80 characters fix

### DIFF
--- a/src/sorcha/utilities/generate_meta_kernel.py
+++ b/src/sorcha/utilities/generate_meta_kernel.py
@@ -26,8 +26,20 @@ import pooch
 
 
 def _split_kernel_path_str(abspath: str, split=79):
-    # If directory string is longer than 79 chars, split it up in the meta kernel
-    # 79 is the default because the character limit in SPICE is 80 before the string needs split
+    """If abspath string is longer than 79 chars, split it up in the meta kernel by inserting "+' '".
+    79 is the default because the character limit in SPICE is 80 before the string needs split.
+
+    Parameters
+    ----------
+    abspath: str
+        The filepath string that needs split.
+    Split : int
+        The maximum size each part of the filepath can be before it needs split.
+    Returns
+    ---------
+    abspath : str
+    The filepath string split into chunks of required size.
+    """
 
     n_iter = int(len(str(abspath)) / split)  # Number of splits required
     for n in range(n_iter, 0, -1):  # Goes backwards to not change the character count of the string before it

--- a/tests/ephemeris/test_ephemeris_generation.py
+++ b/tests/ephemeris/test_ephemeris_generation.py
@@ -143,7 +143,7 @@ def test_ephemeris_end2end(single_synthetic_pointing, tmp_path):
         args,
         configs,
     )
-    
+
     assert len(observations) == 15
 
     # ensure no ephemeris file is written

--- a/tests/ephemeris/test_kernel_str_length.py
+++ b/tests/ephemeris/test_kernel_str_length.py
@@ -19,8 +19,6 @@ def test_kernel_str_length():
             59,
         ],
     )
-    print(test_strings[0])
     for test_data in test_strings:
-        print(test_data[0])
         output = _split_kernel_path_str(test_data[0], split=test_data[2])
         assert output == test_data[1]


### PR DESCRIPTION
Fixes #1166 

Introduced the function _split_kernel_path_str which will split the filepath into chunks of 80 characters, as well as a unit test for this function in tests/ephemeris/test_kernel_str_length.py

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
