### PR TITLE
Pin sbpy>=0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pandas>=2.0",
     "astropy",
     "matplotlib",
-    "sbpy",
+    "sbpy>=0.6.0",
     "tables",
     "spiceypy",
     "healpy",


### PR DESCRIPTION
Pins sbpy>= 0.6.0 release which adds support for Astropy 7.2. 
Otherwise import [here](https://github.com/NASA-Planetary-Science/sbpy/blob/cfb258b8f9e748eff84b9b5b95a328a8e8edbc22/sbpy/units/__init__.py#L15) fails as the `generate_units_summary` functionality was moved from `astropy.units.utils` to `astropy.units.docgen`

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [N.A.] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [N.A.] Have you used black on the files you have updated to confirm python programming style guide enforcement?
