### PR TITLE
Run sorcha without forcing reading config file or forced writing results to disk

### DIFF
--- a/src/sorcha/modules/PPStats.py
+++ b/src/sorcha/modules/PPStats.py
@@ -1,7 +1,7 @@
 import os
 
 
-def stats(observations, statsfilename, outpath, sconfigs):
+def stats(observations, statsfilename, outpath, sconfigs, return_only=False):
     """
     Write a summary statistics file including whether each object was linked
     or not within miniDifi, their number of observations, min/max phase angles,
@@ -22,9 +22,12 @@ def stats(observations, statsfilename, outpath, sconfigs):
     sconfigs: dataclass
         Dataclass of configuration file arguments.
 
+    return_only: bool
+        Ignore writing result to disk and return DataFrame
+
     Returns
     -------
-    None.
+    None or pandas.DataFrame
 
     """
 
@@ -54,8 +57,10 @@ def stats(observations, statsfilename, outpath, sconfigs):
     else:
         joined_stats = num_obs.join([mag, phase_deg])
 
+    if return_only:
+        return joined_stats
+
     joined_stats.to_csv(
         path_or_buf=statsfilepath, mode="a", header=not os.path.exists(statsfilepath), index=True
     )
-
     return

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -4,6 +4,7 @@ import sys
 import time
 import numpy as np
 import argparse
+import pandas as pd
 import os
 import logging
 
@@ -80,7 +81,7 @@ def mem(df):
     return usage
 
 
-def runLSSTSimulation(args, sconfigs):
+def runLSSTSimulation(args, sconfigs, return_only=False):
     """
     Runs the post processing survey simulator functions that apply a series of
     filters to bias a model Solar System small body population to what the
@@ -94,9 +95,12 @@ def runLSSTSimulation(args, sconfigs):
     sconfigs: dataclass
         Dataclass of configuration file arguments.
 
+    return_only : bool
+        Skip writing to disk and return observations and stats (if requested)
+
     Returns
     -----------
-    None.
+    None or observations DataFrame and stats DataFrame
 
     """
     pplogger = logging.getLogger(__name__)
@@ -172,6 +176,11 @@ def runLSSTSimulation(args, sconfigs):
     if sconfigs.fov.camera_model == "footprint":
         verboselog("Creating sensor footprint object for filtering")
         footprint = Footprint(sconfigs.fov.footprint_path)
+
+    # Lists to hold results to be concated and returned
+    if return_only:
+        result_observations = []
+        result_stats = []
 
     while endChunk < lenf:
         verboselog("Starting main Sorcha processing loop round {}".format(loopCounter))
@@ -358,9 +367,15 @@ def runLSSTSimulation(args, sconfigs):
         if len(observations.index) > 0:
             pplogger.info("Post processing completed for this chunk")
             pplogger.info("Outputting results for this chunk")
-            PPWriteOutput(args, sconfigs, observations, verbose=args.loglevel)
-            if args.stats is not None:
-                stats(observations, args.stats, args.outpath, sconfigs)
+
+            if return_only:
+                result_observations.append(observations)
+                if args.stats is not None:
+                    result_stats.append(stats(observations, args.stats, args.outpath, sconfigs, return_only=True))
+            else:
+                PPWriteOutput(args, sconfigs, observations, verbose=args.loglevel)
+                if args.stats is not None:
+                    stats(observations, args.stats, args.outpath, sconfigs)
         else:
             verboselog("No observations left in chunk. No output will be written for this chunk.")
 
@@ -375,3 +390,10 @@ def runLSSTSimulation(args, sconfigs):
         PPIndexSQLDatabase(os.path.join(args.outpath, args.outfilestem + ".db"))
 
     pplogger.info("Sorcha process is completed.")
+
+    if return_only:
+        result_observations = pd.concat(result_observations)
+        if args.stats is not None:
+            result_stats = pd.concat(result_stats)
+            return result_observations, result_stats
+        return result_observations

--- a/src/sorcha/sorcha.py
+++ b/src/sorcha/sorcha.py
@@ -371,7 +371,9 @@ def runLSSTSimulation(args, sconfigs, return_only=False):
             if return_only:
                 result_observations.append(observations)
                 if args.stats is not None:
-                    result_stats.append(stats(observations, args.stats, args.outpath, sconfigs, return_only=True))
+                    result_stats.append(
+                        stats(observations, args.stats, args.outpath, sconfigs, return_only=True)
+                    )
             else:
                 PPWriteOutput(args, sconfigs, observations, verbose=args.loglevel)
                 if args.stats is not None:

--- a/src/sorcha/utilities/generate_meta_kernel.py
+++ b/src/sorcha/utilities/generate_meta_kernel.py
@@ -1,7 +1,6 @@
 import os
 import pooch
 
-
 """
     An example output from running `build_meta_kernel_file` might look like
     the following:

--- a/src/sorcha/utilities/sorchaArguments.py
+++ b/src/sorcha/utilities/sorchaArguments.py
@@ -95,8 +95,9 @@ class sorchaArguments:
         if self.input_ephemeris_file and not path.isfile(self.input_ephemeris_file):
             raise ValueError("File does not exist at path supplied for -er/--ephem_read argument.")
 
-        if not path.isfile(self.configfile):
-            raise ValueError("File does not exist at path supplied for -c/--config argument.")
+        if self.configfile is not None:
+            if not path.isfile(self.configfile):
+                raise ValueError("File does not exist at path supplied for -c/--config argument.")
 
         if not path.isfile(self.pointing_database):
             raise ValueError("File does not exist at path supplied for -pd/--pointing_database argument.")

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -1040,8 +1040,8 @@ class basesorchaConfigs:
 
 
 class sorchaConfigs(basesorchaConfigs):
-    """Set the dataclass to load from a file
-    """
+    """Set the dataclass to load from a file"""
+
     # this __init__ overrides a dataclass's inbuilt __init__ because we want to populate this from a file, not explicitly ourselves
     def __init__(self, config_file_location=None, survey_name=None):
 

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -231,21 +231,25 @@ class saturationConfigs:
 
         if self.bright_limit_on:
             check_key_exists(self._observing_filters, "_observing_filters")
-            try:
-                self.bright_limit = [float(e.strip()) for e in self.bright_limit.split(",")]
-            except ValueError:
-                logging.error("ERROR: could not parse brightness limits. Check formatting and try again.")
-                sys.exit("ERROR: could not parse brightness limits. Check formatting and try again.")
-            if len(self.bright_limit) == 1:
-                # when only one value is given that value is saved as a float instead of in a list
-                self.bright_limit = cast_as_float(self.bright_limit[0], "bright_limit")
-            elif len(self.bright_limit) != 1 and len(self.bright_limit) != len(self._observing_filters):
-                logging.error(
-                    "ERROR: list of saturation limits is not the same length as list of observing filters."
-                )
-                sys.exit(
-                    "ERROR: list of saturation limits is not the same length as list of observing filters."
-                )
+            if isinstance(self.bright_limit, str):
+                try:
+                    self.bright_limit = [float(e.strip()) for e in self.bright_limit.split(",")]
+                except ValueError:
+                    logging.error("ERROR: could not parse brightness limits. Check formatting and try again.")
+                    sys.exit("ERROR: could not parse brightness limits. Check formatting and try again.")
+            elif isinstance(self.bright_limit, float):
+                self.bright_limit = [self.bright_limit] * len(self._observing_filters)
+            if isinstance(self.bright_limit, list):
+                if len(self.bright_limit) == 1:
+                    # when only one value is given that value is saved as a float instead of in a list
+                    self.bright_limit = cast_as_float(self.bright_limit[0], "bright_limit")
+                elif len(self.bright_limit) != 1 and len(self.bright_limit) != len(self._observing_filters):
+                    logging.error(
+                        "ERROR: list of saturation limits is not the same length as list of observing filters."
+                    )
+                    sys.exit(
+                        "ERROR: list of saturation limits is not the same length as list of observing filters."
+                    )
 
 
 @dataclass

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -161,7 +161,8 @@ class filtersConfigs:
         # checks mandatory keys are populated
         check_key_exists(self.observing_filters, "observing_filters")
         check_key_exists(self.survey_name, "survey_name")
-        self.observing_filters = [e.strip() for e in self.observing_filters.split(",")]
+        if isinstance(self.observing_filters, str):
+            self.observing_filters = [e.strip() for e in self.observing_filters.split(",")]
         self._check_for_correct_filters()
 
     def _check_for_correct_filters(self):
@@ -241,8 +242,7 @@ class saturationConfigs:
                 self.bright_limit = [self.bright_limit] * len(self._observing_filters)
             if isinstance(self.bright_limit, list):
                 if len(self.bright_limit) == 1:
-                    # when only one value is given that value is saved as a float instead of in a list
-                    self.bright_limit = cast_as_float(self.bright_limit[0], "bright_limit")
+                    self.bright_limit = [self.bright_limit[0]] * len(self._observing_filters)
                 elif len(self.bright_limit) != 1 and len(self.bright_limit) != len(self._observing_filters):
                     logging.error(
                         "ERROR: list of saturation limits is not the same length as list of observing filters."
@@ -989,7 +989,7 @@ class auxiliaryConfigs:
 
 
 @dataclass
-class sorchaConfigs:
+class basesorchaConfigs:
     """Dataclass which stores configuration file keywords in dataclasses."""
 
     input: inputConfigs = None
@@ -1038,6 +1038,10 @@ class sorchaConfigs:
     survey_name: str = ""
     """The name of the survey."""
 
+
+class sorchaConfigs(basesorchaConfigs):
+    """Set the dataclass to load from a file
+    """
     # this __init__ overrides a dataclass's inbuilt __init__ because we want to populate this from a file, not explicitly ourselves
     def __init__(self, config_file_location=None, survey_name=None):
 
@@ -1109,16 +1113,6 @@ class sorchaConfigs:
             section_key = section.lower()
             setattr(self, section_key, config_instance)
 
-
-class sorchaConfigsNoFile(sorchaConfigs):
-    """Revert to a regular dataclass so not forced to
-    read a configuration file.
-    """
-    def __init__(self, **kwargs):
-        # attach the logger object so we can print things to the Sorcha logs
-        self.pplogger = logging.getLogger(__name__)
-        for key, val in kwargs.items():
-            setattr(self, key, val)
 
 ## below are the utility functions used to help validate the keywords, add more as needed
 

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -1110,6 +1110,16 @@ class sorchaConfigs:
             setattr(self, section_key, config_instance)
 
 
+class sorchaConfigsNoFile(sorchaConfigs):
+    """Revert to a regular dataclass so not forced to
+    read a configuration file.
+    """
+    def __init__(self, **kwargs):
+        # attach the logger object so we can print things to the Sorcha logs
+        self.pplogger = logging.getLogger(__name__)
+        for key, val in kwargs.items():
+            setattr(self, key, val)
+
 ## below are the utility functions used to help validate the keywords, add more as needed
 
 

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -990,7 +990,9 @@ class auxiliaryConfigs:
 
 @dataclass
 class basesorchaConfigs:
-    """Dataclass which stores configuration file keywords in dataclasses."""
+    """Dataclass which stores configuration file keywords in dataclasses,
+    Usefull for using runLSSTSimulation without a dedicated config file. Use
+    sorchaConfigs to read config files."""
 
     input: inputConfigs = None
     """inputConfigs dataclass which stores the keywords from the INPUT section of the config file."""

--- a/src/sorcha/utilities/sorchaConfigs.py
+++ b/src/sorcha/utilities/sorchaConfigs.py
@@ -1338,7 +1338,7 @@ def PrintConfigsToLog(sconfigs, cmd_args):
     """
     pplogger = logging.getLogger(__name__)
 
-    pplogger.info("The config file used is located at " + cmd_args.configfile)
+    pplogger.info("The config file used is located at " + str(cmd_args.configfile))
     pplogger.info("The physical parameters file used is located at " + cmd_args.paramsinput)
     pplogger.info("The orbits file used is located at " + cmd_args.orbinfile)
     if cmd_args.input_ephemeris_file:

--- a/tests/data/test_PrintConfigsToLog.txt
+++ b/tests/data/test_PrintConfigsToLog.txt
@@ -190,7 +190,7 @@ sorcha.utilities.sorchaConfigs INFO     Vignetting is switched ON.
 sorcha.utilities.sorchaConfigs INFO     Footprint is modelled after the actual camera footprint. 
 sorcha.utilities.sorchaConfigs INFO     Loading default LSST footprint LSST_detector_corners_100123.csv 
 sorcha.utilities.sorchaConfigs INFO     The footprint edge threshold is 2.0 arcseconds 
-sorcha.utilities.sorchaConfigs INFO     The upper saturation limit(s) is/are: 16.0 
+sorcha.utilities.sorchaConfigs INFO     The upper saturation limit(s) is/are: [16.0, 16.0, 16.0, 16.0] 
 sorcha.utilities.sorchaConfigs INFO     SNR limit is turned OFF. 
 sorcha.utilities.sorchaConfigs INFO     Default SNR cut is ON. All observations with SNR < 2.0 will be removed. 
 sorcha.utilities.sorchaConfigs INFO     Magnitude limit is turned OFF. 

--- a/tests/sorcha/test_sorchaConfigs.py
+++ b/tests/sorcha/test_sorchaConfigs.py
@@ -404,6 +404,15 @@ def test_saturationConfigs():
         error_text.value.code == "ERROR: could not parse brightness limits. Check formatting and try again."
     )
 
+    # Make sure it can take a simple float
+    bright_limit = 2.
+    manual_saturation_config = saturationConfigs(bright_limit=bright_limit, _observing_filters=["g"])
+    assert manual_saturation_config.bright_limit == bright_limit
+
+    # Cast float to a list if multiple filters
+    manual_saturation_config = saturationConfigs(bright_limit=bright_limit, _observing_filters=["g", "r"])
+    assert len(manual_saturation_config.bright_limit) == 2
+
 
 @pytest.mark.parametrize("key_name", ["_observing_filters"])
 def test_saturationConfigs_mandatory(key_name):

--- a/tests/sorcha/test_sorchaConfigs.py
+++ b/tests/sorcha/test_sorchaConfigs.py
@@ -147,20 +147,22 @@ def test_sorchaConfigs():
     test_configs_file = sorchaConfigs(config_file_location, "rubin_sim")
 
     # test we can make a config without needing to read a file
-    test_configs_nofile = basesorchaConfigs(survey_name="rubin_sim",
-                                            input=inputConfigs(**correct_inputs),
-                                            simulation=simulationConfigs(**correct_simulation),
-                                            filters=filtersConfigs(**correct_filters),
-                                            saturation=saturationConfigs(**correct_saturation),
-                                            phasecurves=phasecurvesConfigs(**correct_phasecurve),
-                                            fov=fovConfigs(**correct_fov),
-                                            fadingfunction=fadingfunctionConfigs(**correct_fadingfunction),
-                                            linkingfilter=linkingfilterConfigs(**correct_linkingfilter),
-                                            output=outputConfigs(**correct_output),
-                                            lightcurve=lightcurveConfigs(**correct_lc_model),
-                                            activity=activityConfigs(**correct_activity),
-                                            expert=expertConfigs(**correct_expert),
-                                            auxiliary=auxiliaryConfigs())
+    test_configs_nofile = basesorchaConfigs(
+        survey_name="rubin_sim",
+        input=inputConfigs(**correct_inputs),
+        simulation=simulationConfigs(**correct_simulation),
+        filters=filtersConfigs(**correct_filters),
+        saturation=saturationConfigs(**correct_saturation),
+        phasecurves=phasecurvesConfigs(**correct_phasecurve),
+        fov=fovConfigs(**correct_fov),
+        fadingfunction=fadingfunctionConfigs(**correct_fadingfunction),
+        linkingfilter=linkingfilterConfigs(**correct_linkingfilter),
+        output=outputConfigs(**correct_output),
+        lightcurve=lightcurveConfigs(**correct_lc_model),
+        activity=activityConfigs(**correct_activity),
+        expert=expertConfigs(**correct_expert),
+        auxiliary=auxiliaryConfigs(),
+    )
     # check each section to make sure you get what you expect
     for test_configs in [test_configs_file, test_configs_nofile]:
         assert correct_inputs == test_configs.input.__dict__
@@ -423,7 +425,7 @@ def test_saturationConfigs():
     )
 
     # Make sure it can take a simple float
-    bright_limit = 2.
+    bright_limit = 2.0
     manual_saturation_config = saturationConfigs(bright_limit=bright_limit, _observing_filters=["g"])
     assert manual_saturation_config.bright_limit[0] == bright_limit
 

--- a/tests/sorcha/test_sorchaConfigs.py
+++ b/tests/sorcha/test_sorchaConfigs.py
@@ -5,6 +5,7 @@ from sorcha.lightcurves.lightcurve_registration import LC_METHODS
 from sorcha.activity.activity_registration import CA_METHODS
 from sorcha.utilities.sorchaConfigs import (
     sorchaConfigs,
+    basesorchaConfigs,
     inputConfigs,
     simulationConfigs,
     filtersConfigs,
@@ -48,7 +49,7 @@ correct_filters = {
 
 correct_saturation = {
     "bright_limit_on": True,
-    "bright_limit": 16.0,
+    "bright_limit": [16.0, 16.0, 16.0, 16.0, 16.0, 16.0],
     "_observing_filters": ["r", "g", "i", "z", "u", "y"],
 }
 correct_saturation_read = {"bright_limit": "16.0", "_observing_filters": ["r", "g", "i", "z", "u", "y"]}
@@ -143,22 +144,39 @@ def test_sorchaConfigs():
     # general test to make sure, overall, everything works. checks just one file: sorcha_config_demo.ini
 
     config_file_location = get_demo_filepath("sorcha_config_demo.ini")
-    test_configs = sorchaConfigs(config_file_location, "rubin_sim")
+    test_configs_file = sorchaConfigs(config_file_location, "rubin_sim")
+
+    # test we can make a config without needing to read a file
+    test_configs_nofile = basesorchaConfigs(survey_name="rubin_sim",
+                                            input=inputConfigs(**correct_inputs),
+                                            simulation=simulationConfigs(**correct_simulation),
+                                            filters=filtersConfigs(**correct_filters),
+                                            saturation=saturationConfigs(**correct_saturation),
+                                            phasecurves=phasecurvesConfigs(**correct_phasecurve),
+                                            fov=fovConfigs(**correct_fov),
+                                            fadingfunction=fadingfunctionConfigs(**correct_fadingfunction),
+                                            linkingfilter=linkingfilterConfigs(**correct_linkingfilter),
+                                            output=outputConfigs(**correct_output),
+                                            lightcurve=lightcurveConfigs(**correct_lc_model),
+                                            activity=activityConfigs(**correct_activity),
+                                            expert=expertConfigs(**correct_expert),
+                                            auxiliary=auxiliaryConfigs())
     # check each section to make sure you get what you expect
-    assert correct_inputs == test_configs.input.__dict__
-    assert correct_simulation == test_configs.simulation.__dict__
-    assert correct_filters == test_configs.filters.__dict__
-    assert correct_saturation == test_configs.saturation.__dict__
-    assert correct_phasecurve == test_configs.phasecurves.__dict__
-    assert correct_fov == test_configs.fov.__dict__
-    assert correct_fadingfunction == test_configs.fadingfunction.__dict__
-    assert correct_linkingfilter == test_configs.linkingfilter.__dict__
-    assert correct_output == test_configs.output.__dict__
-    assert correct_lc_model == test_configs.lightcurve.__dict__
-    assert correct_activity == test_configs.activity.__dict__
-    assert correct_expert == test_configs.expert.__dict__
-    assert correct_auxciliary_URLs == test_configs.auxiliary.__dict__["urls"]
-    assert correct_auxciliary_filenames == test_configs.auxiliary.__dict__["data_file_list"]
+    for test_configs in [test_configs_file, test_configs_nofile]:
+        assert correct_inputs == test_configs.input.__dict__
+        assert correct_simulation == test_configs.simulation.__dict__
+        assert correct_filters == test_configs.filters.__dict__
+        assert correct_saturation == test_configs.saturation.__dict__
+        assert correct_phasecurve == test_configs.phasecurves.__dict__
+        assert correct_fov == test_configs.fov.__dict__
+        assert correct_fadingfunction == test_configs.fadingfunction.__dict__
+        assert correct_linkingfilter == test_configs.linkingfilter.__dict__
+        assert correct_output == test_configs.output.__dict__
+        assert correct_lc_model == test_configs.lightcurve.__dict__
+        assert correct_activity == test_configs.activity.__dict__
+        assert correct_expert == test_configs.expert.__dict__
+        assert correct_auxciliary_URLs == test_configs.auxiliary.__dict__["urls"]
+        assert correct_auxciliary_filenames == test_configs.auxiliary.__dict__["data_file_list"]
 
 
 ##################################################################################################################################
@@ -407,7 +425,7 @@ def test_saturationConfigs():
     # Make sure it can take a simple float
     bright_limit = 2.
     manual_saturation_config = saturationConfigs(bright_limit=bright_limit, _observing_filters=["g"])
-    assert manual_saturation_config.bright_limit == bright_limit
+    assert manual_saturation_config.bright_limit[0] == bright_limit
 
     # Cast float to a list if there are multiple filters
     manual_saturation_config = saturationConfigs(bright_limit=bright_limit, _observing_filters=["g", "r"])

--- a/tests/sorcha/test_sorchaConfigs.py
+++ b/tests/sorcha/test_sorchaConfigs.py
@@ -409,7 +409,7 @@ def test_saturationConfigs():
     manual_saturation_config = saturationConfigs(bright_limit=bright_limit, _observing_filters=["g"])
     assert manual_saturation_config.bright_limit == bright_limit
 
-    # Cast float to a list if multiple filters
+    # Cast float to a list if there are multiple filters
     manual_saturation_config = saturationConfigs(bright_limit=bright_limit, _observing_filters=["g", "r"])
     assert len(manual_saturation_config.bright_limit) == 2
 


### PR DESCRIPTION
For cases where one has several pointing histories and several solar system body populations, it would be useful to loop over those within python and call `runLSSTSimulation` directly without using the command line and configuration file(s).

* Update so `sorchaConfigs` is now a subclass of `basesorchaConfigs`, so if one wants to make a config without reading a file it is possible to with `basesorchaConfigs`, and `sorchaConfigs` behaves as before. 
* Add `return_only` kwargs to `runLSSTSimulation` and `PPStats.stats` so users are not forced to write output to disk in case they just want the DataFrames returned
* Minor fixes in some other config classes so they work with both reading config files and manual instatiation.


## Review Checklist for Source Code Changes

- [ x] Does pip install still work?
- [ x] Have you written a unit test for any new functions?
- [ x] Do all the units tests run successfully?
- [ x] Does Sorcha run successfully on a test set of input files/databases?
- [ x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
