### PR TITLE
Fix convert_to_geocentric for zero-valued parallax constants

### DIFF
--- a/src/sorcha/ephemeris/simulation_parsing.py
+++ b/src/sorcha/ephemeris/simulation_parsing.py
@@ -338,10 +338,15 @@ class Observatory:
                 Geocentric position (x,y,z)
         """
         returned_tuple = (None, None, None)
+        # Test for the *presence* of the parallax constants rather than their
+        # truthiness: a constant that is legitimately 0.0 -- the geocenter
+        # (code 500: Longitude=cos=sin=0), Greenwich (code 000: Longitude=0),
+        # or an equatorial station such as Quito (code 782: sin=0) -- is falsy
+        # and would otherwise be mistaken for a missing position.
         if (
-            obs_location.get("Longitude", False)
-            and obs_location.get("cos", False)
-            and obs_location.get("sin", False)
+            obs_location.get("Longitude") is not None
+            and obs_location.get("cos") is not None
+            and obs_location.get("sin") is not None
         ):
             longitude = obs_location["Longitude"] * np.pi / 180.0
             x = obs_location["cos"] * np.cos(longitude)

--- a/tests/ephemeris/test_simulation_parsing.py
+++ b/tests/ephemeris/test_simulation_parsing.py
@@ -31,6 +31,30 @@ def test_observatory_for_moving_observatories():
     assert obs["250"] == (None, None, None)
 
 
+def test_convert_to_geocentric_zero_parallax_constants():
+    """A parallax constant that is legitimately 0.0 must not be mistaken for a
+    missing position (e.g. geocenter 500, Greenwich 000, equatorial station 782)."""
+    auxconfigs = auxiliaryConfigs()
+    observatory = sp.Observatory(
+        auxconfigs=auxconfigs, args=None, oc_file=get_test_filepath("ObsCodes_test.json")
+    )
+
+    # Geocenter: every constant is 0.0 -> a finite (0, 0, 0) offset, not (None, None, None).
+    assert observatory.convert_to_geocentric({"Longitude": 0.0, "cos": 0.0, "sin": 0.0}) == (0.0, 0.0, 0.0)
+
+    # Greenwich: Longitude == 0.0, but cos/sin are nonzero -> finite position.
+    x, y, z = observatory.convert_to_geocentric({"Longitude": 0.0, "cos": 0.62411, "sin": 0.77873})
+    assert np.allclose((x, y, z), (0.62411, 0.0, 0.77873))
+
+    # Equatorial station: sin == 0.0 -> finite position with z == 0.
+    x, y, z = observatory.convert_to_geocentric({"Longitude": 281.65, "cos": 0.999, "sin": 0.0})
+    assert z == 0.0
+    assert not np.isnan([x, y, z]).any()
+
+    # A genuinely position-less observatory (no parallax keys) still returns None.
+    assert observatory.convert_to_geocentric({"Name": "Roving Observer"}) == (None, None, None)
+
+
 def test_observatory_before_1962():
     auxconfigs = auxiliaryConfigs()
     observatory = sp.Observatory(


### PR DESCRIPTION
## Summary

`Observatory.convert_to_geocentric` mistakes a parallax constant that is legitimately `0.0` for a missing position, so several real observatory codes are wrongly reported as having no fixed location.

The check gates on **truthiness**:

```python
if (obs_location.get("Longitude", False)
    and obs_location.get("cos", False)
    and obs_location.get("sin", False)):
```

A constant equal to `0.0` is falsy, so these codes fall through to `(None, None, None)`:

| code | name | zero constant |
|------|------|---------------|
| 500 / 244 / 248 | Geocentric / Occultation / Hipparcos | Longitude = cos = sin = 0 |
| 000 | Greenwich | Longitude = 0 |
| 782 | Quito (equatorial) | sin = 0 |

Downstream consumers then route these to a moving-observatory path that expects per-observation positions and fail on plain MPC input. The common geocentric code **500** is the most impactful.

## Fix

Test for the **presence** of the constants (`is not None`) rather than their truthiness.

- Codes with no parallax keys at all (roving observer, space telescopes) still return `(None, None, None)`.
- The geocenter resolves to a `(0, 0, 0)` offset from Earth's center, which is correct.

## Verification

New test `test_convert_to_geocentric_zero_parallax_constants` covers the geocenter, Greenwich, an equatorial station, and a position-less observatory. It passes with the fix and fails against the previous truthiness check.

Reported downstream in Smithsonian/layup#286.
