### PR TITLE
Fixed bug for spice TYPEMISMATCH 80 column issue

### DIFF
--- a/src/sorcha/utilities/generate_meta_kernel.py
+++ b/src/sorcha/utilities/generate_meta_kernel.py
@@ -24,7 +24,7 @@ import pooch
 """
 
 
-def _split_kernel_path_str(abspath: str, split=79):
+def _split_kernel_path_str(abspath: str, split=77):
     """If abspath string is longer than 79 chars, split it up in the meta kernel by inserting "+' '".
     79 is the default because the character limit in SPICE is 80 before the string needs split.
 
@@ -42,7 +42,7 @@ def _split_kernel_path_str(abspath: str, split=79):
 
     n_iter = int(len(str(abspath)) / split)  # Number of splits required
     for n in range(n_iter, 0, -1):  # Goes backwards to not change the character count of the string before it
-        abspath = abspath[: split * n] + "+' '" + abspath[split * n :]
+        abspath = abspath[: split * n] + "+',\n'" + abspath[split * n :]
     return abspath
 
 

--- a/src/sorcha/utilities/generate_meta_kernel.py
+++ b/src/sorcha/utilities/generate_meta_kernel.py
@@ -25,7 +25,7 @@ import pooch
 
 
 def _split_kernel_path_str(abspath: str, split=77):
-    """If abspath string is longer than 79 chars, split it up in the meta kernel by inserting "+',\n'".
+    """If abspath string is longer than 77 chars, split it up in the meta kernel by inserting "+',\n'".
     77 is the default because the character limit in SPICE is 80 before the string needs split.
 
     Parameters

--- a/src/sorcha/utilities/generate_meta_kernel.py
+++ b/src/sorcha/utilities/generate_meta_kernel.py
@@ -25,8 +25,8 @@ import pooch
 
 
 def _split_kernel_path_str(abspath: str, split=77):
-    """If abspath string is longer than 79 chars, split it up in the meta kernel by inserting "+' '".
-    79 is the default because the character limit in SPICE is 80 before the string needs split.
+    """If abspath string is longer than 79 chars, split it up in the meta kernel by inserting "+',\n'".
+    77 is the default because the character limit in SPICE is 80 before the string needs split.
 
     Parameters
     ----------

--- a/tests/ephemeris/test_kernel_str_length.py
+++ b/tests/ephemeris/test_kernel_str_length.py
@@ -1,6 +1,7 @@
 # This file tests if the function _split_kernel_path_str() returns the right string
+import os
+import spiceypy
 from sorcha.utilities.generate_meta_kernel import _split_kernel_path_str
-
 
 def test_kernel_str_length():
 
@@ -22,3 +23,31 @@ def test_kernel_str_length():
     for test_data in test_strings:
         output = _split_kernel_path_str(test_data[0], split=test_data[2])
         assert output == test_data[1]
+
+
+
+def test_meta_kernel_loads_under_long_path(tmp_path):
+    # A cache path long enough to trip the SPICE 80-char string limit.
+    deep = tmp_path
+    while len(str(deep)) < 160:
+        deep = deep / "12345678"
+    deep.mkdir(parents=True, exist_ok=True)
+
+    # A tiny kernel we can check actually loaded.
+    (deep / "tiny.tls").write_text("\\begindata\nDELTET/DELTA_T_A = 99.5\n\\begintext\n")
+
+    mk = deep / "meta_kernel.txt"
+    mk.write_text(
+        "\\begindata\n\n"
+        f"PATH_VALUES = ('{_split_kernel_path_str(str(deep))}')\n\n"
+        "PATH_SYMBOLS = ('A')\n\n"
+        "KERNELS_TO_LOAD = ( '$A/tiny.tls' )\n\n"
+        "\\begintext\n"
+    )
+
+    spiceypy.kclear()
+    try:
+        spiceypy.furnsh(str(mk))  # would raise TYPEMISMATCH before the fix
+        assert spiceypy.gdpool("DELTET/DELTA_T_A", 0, 1)[0] == 99.5
+    finally:
+        spiceypy.kclear()

--- a/tests/ephemeris/test_kernel_str_length.py
+++ b/tests/ephemeris/test_kernel_str_length.py
@@ -6,16 +6,16 @@ def test_kernel_str_length():
 
     # Each list in the tuple is a test containing the input, expected output and split value for the function, respectively
     test_strings = (
-        ["this is a test string", "this is a test +' 'string", 15],
+        ["this is a test string", "this is a test +',\n'string", 15],
         [
             "this is another test string which is slightly larger",
-            "this is another+' ' test string wh+' 'ich is slightly+' ' larger",
+            "this is another+',\n' test string wh+',\n'ich is slightly+',\n' larger",
             15,
         ],
         ["small string", "small string", 79],
         [
             "split will be the length of this string to see what happens",
-            "split will be the length of this string to see what happens+' '",
+            "split will be the length of this string to see what happens+',\n'",
             59,
         ],
     )


### PR DESCRIPTION
Lowered spilit number to account for extra added characters

added comma and newline for each 77 char chunk of file_path. 

Comma is needed for ever chunk of abspath string 
newline due to a separate per line character limit 

Fixes #1211   .

Describe your changes.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does Sorcha run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
